### PR TITLE
fix: move version to metadata.version in SKILL.md frontmatter

### DIFF
--- a/.github/workflows/repo-sentinel.yml
+++ b/.github/workflows/repo-sentinel.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   file-checks:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ Each skill lives in its own directory under `skills/` and must contain a `SKILL.
 ```yaml
 ---
 name: my-skill-name
-version: 1.0.0
 description: What this skill does in plain language.
+metadata:
+  version: 1.0.0
 ---
 ```
 
@@ -22,7 +23,7 @@ Optional subdirectories:
 
 ## Versioning
 
-Skills use [semantic versioning](https://semver.org/) via the `version` field in SKILL.md frontmatter.
+Skills use [semantic versioning](https://semver.org/) via the `metadata.version` field in SKILL.md frontmatter.
 
 | Change Type | Bump | Example |
 |-------------|------|---------|
@@ -125,7 +126,7 @@ uv run scripts/package_skill.py skills/my-skill-name
 
 Before opening a PR, confirm:
 
-- [ ] `SKILL.md` has valid YAML frontmatter with `name`, `version`, and `description`
+- [ ] `SKILL.md` has valid YAML frontmatter with `name`, `description`, and `metadata.version`
 - [ ] Version bumped according to semver (MAJOR/MINOR/PATCH)
 - [ ] Manifest regenerated: `uv run scripts/generate_manifest.py`
 - [ ] Skill name is kebab-case, under 64 characters

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -26,6 +26,14 @@ def parse_frontmatter(content: str) -> dict[str, str]:
     return yaml.safe_load(match.group(1))
 
 
+def extract_version(meta: dict[str, str]) -> str:
+    """Extract version from metadata.version (preferred) or top-level version (legacy)."""
+    metadata = meta.get("metadata")
+    if isinstance(metadata, dict) and metadata.get("version"):
+        return str(metadata["version"])
+    return str(meta.get("version", ""))
+
+
 def collect_skills() -> list[dict[str, str]]:
     """Walk skills/*/SKILL.md and build manifest entries."""
     entries: list[dict[str, str]] = []
@@ -39,7 +47,7 @@ def collect_skills() -> list[dict[str, str]]:
         meta = parse_frontmatter(content)
 
         name = meta.get("name", "")
-        version = meta.get("version", "")
+        version = extract_version(meta)
         description = meta.get("description", "")
 
         if not name:

--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -76,6 +76,14 @@ def parse_frontmatter(content: str) -> dict[str, str]:
     return yaml.safe_load(match.group(1))
 
 
+def extract_version(meta: dict[str, str]) -> str:
+    """Extract version from metadata.version (preferred) or top-level version (legacy)."""
+    metadata = meta.get("metadata")
+    if isinstance(metadata, dict) and metadata.get("version"):
+        return str(metadata["version"])
+    return str(meta.get("version", "0.0.0"))
+
+
 def discover_skills() -> list[SkillInfo]:
     """Discover available skills from manifest or SKILL.md files."""
     if MANIFEST_PATH.exists():
@@ -119,7 +127,7 @@ def _discover_from_skill_files() -> list[SkillInfo]:
 
         skills.append(SkillInfo(
             name=name,
-            version=meta.get("version", "0.0.0"),
+            version=extract_version(meta),
             description=meta.get("description", "").strip(),
             source_path=skill_dir,
         ))
@@ -139,7 +147,7 @@ def get_installed_version(install_dir: Path, skill_name: str) -> str | None:
     except ValueError:
         return "0.0.0"
 
-    return meta.get("version", "0.0.0")
+    return extract_version(meta)
 
 
 def build_install_plans(

--- a/scripts/install_skills.py
+++ b/scripts/install_skills.py
@@ -36,6 +36,7 @@ console = Console()
 class InstallAction(Enum):
     INSTALL = "install"
     UPGRADE = "upgrade"
+    REINSTALL = "reinstall"
     SKIP = "skip"
 
 
@@ -153,8 +154,10 @@ def get_installed_version(install_dir: Path, skill_name: str) -> str | None:
 def build_install_plans(
     skills: list[SkillInfo],
     install_dir: Path,
+    *,
+    reinstall: bool = False,
 ) -> list[InstallPlan]:
-    """Determine install/upgrade/skip action for each skill."""
+    """Determine install/upgrade/reinstall/skip action for each skill."""
     plans: list[InstallPlan] = []
 
     for skill in skills:
@@ -172,6 +175,8 @@ def build_install_plans(
             action = InstallAction.INSTALL
         elif is_newer(skill.version, installed_version):
             action = InstallAction.UPGRADE
+        elif reinstall:
+            action = InstallAction.REINSTALL
         else:
             action = InstallAction.SKIP
 
@@ -197,6 +202,7 @@ def display_plans(plans: list[InstallPlan]) -> None:
     action_styles = {
         InstallAction.INSTALL: "[green]install[/green]",
         InstallAction.UPGRADE: "[yellow]upgrade[/yellow]",
+        InstallAction.REINSTALL: "[blue]reinstall[/blue]",
         InstallAction.SKIP: "[dim]skip[/dim]",
     }
 
@@ -278,6 +284,13 @@ def copy_skill(source: Path, target: Path) -> int:
     return count
 
 
+_ACTION_LABELS: dict[InstallAction, str] = {
+    InstallAction.INSTALL: "Installed",
+    InstallAction.UPGRADE: "Upgraded",
+    InstallAction.REINSTALL: "Reinstalled",
+}
+
+
 def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
     """Execute selected installation plans."""
     to_install = [plans[i] for i in selected if plans[i].action != InstallAction.SKIP]
@@ -293,9 +306,9 @@ def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
             progress.update(task, description=f"Installing {plan.skill.name}...")
             file_count = copy_skill(plan.skill.source_path, plan.target_path)
             progress.advance(task)
-            action_word = "Upgraded" if plan.action == InstallAction.UPGRADE else "Installed"
+            label = _ACTION_LABELS.get(plan.action, "Installed")
             console.print(
-                f"  {action_word} [cyan]{plan.skill.name}[/cyan] "
+                f"  {label} [cyan]{plan.skill.name}[/cyan] "
                 f"v{plan.skill.version} ({file_count} files)"
             )
 
@@ -307,12 +320,12 @@ def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
     summary.add_column("Version")
 
     for plan in to_install:
-        action_word = "upgraded" if plan.action == InstallAction.UPGRADE else "installed"
+        label = _ACTION_LABELS.get(plan.action, "installed").lower()
         if plan.action == InstallAction.UPGRADE:
             ver = f"{plan.installed_version} → {plan.skill.version}"
         else:
             ver = plan.skill.version
-        summary.add_row(plan.skill.name, action_word, ver)
+        summary.add_row(plan.skill.name, label, ver)
 
     console.print(summary)
     console.print(
@@ -326,6 +339,16 @@ def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
 
 def main() -> int:
     """Main entry point for the TUI installer."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Install praxis-skills to ~/.claude/skills/")
+    parser.add_argument(
+        "--reinstall",
+        action="store_true",
+        help="Allow reinstalling skills that are already at the same version",
+    )
+    args = parser.parse_args()
+
     console.print(Panel("praxis-skills installer", border_style="blue"))
 
     # Discover
@@ -338,7 +361,7 @@ def main() -> int:
     install_dir.mkdir(parents=True, exist_ok=True)
 
     # Build plans
-    plans = build_install_plans(skills, install_dir)
+    plans = build_install_plans(skills, install_dir, reinstall=args.reinstall)
     if not plans:
         console.print("[dim]No installable skills found.[/dim]")
         return 0
@@ -349,7 +372,7 @@ def main() -> int:
     # Count actionable
     actionable = [i for i, p in enumerate(plans) if p.action != InstallAction.SKIP]
     if not actionable:
-        console.print("[dim]All skills are up to date.[/dim]")
+        console.print("[dim]All skills are up to date. Use --reinstall to force reinstallation.[/dim]")
         return 0
 
     # Select
@@ -381,7 +404,7 @@ def main() -> int:
 
     # Confirm
     names = ", ".join(plans[i].skill.name for i in selected_actionable)
-    console.print(f"\nWill install/upgrade: [cyan]{names}[/cyan]")
+    console.print(f"\nWill install/upgrade/reinstall: [cyan]{names}[/cyan]")
     confirm = Prompt.ask("Proceed?", choices=["y", "n"], default="y")
     if confirm != "y":
         console.print("[dim]Cancelled.[/dim]")

--- a/scripts/package_skill.py
+++ b/scripts/package_skill.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import yaml
 
+from typing import Any
+
 
 EXCLUDE_NAMES: set[str] = {
     "__pycache__",
@@ -21,7 +23,7 @@ EXCLUDE_NAMES: set[str] = {
 EXCLUDE_SUFFIXES: set[str] = {".pyc"}
 
 
-def parse_frontmatter(content: str) -> dict[str, str]:
+def parse_frontmatter(content: str) -> dict[str, Any]:
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
     if not match:
         raise ValueError("No valid YAML frontmatter found in SKILL.md")
@@ -33,7 +35,17 @@ def validate_version(version: str) -> None:
         raise ValueError(f"Invalid version '{version}' — must be semver (e.g. 1.0.0)")
 
 
-def validate_frontmatter(skill_dir: Path) -> dict[str, str]:
+def extract_version(meta: dict[str, Any]) -> str | None:
+    """Extract version from metadata.version (preferred) or top-level version (legacy)."""
+    metadata = meta.get("metadata")
+    if isinstance(metadata, dict) and metadata.get("version"):
+        return str(metadata["version"])
+    if meta.get("version"):
+        return str(meta["version"])
+    return None
+
+
+def validate_frontmatter(skill_dir: Path) -> dict[str, Any]:
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
         raise FileNotFoundError(f"SKILL.md not found in {skill_dir}")
@@ -41,11 +53,20 @@ def validate_frontmatter(skill_dir: Path) -> dict[str, str]:
     content = skill_md.read_text(encoding="utf-8")
     meta = parse_frontmatter(content)
 
-    missing = [field for field in ("name", "version", "description") if not meta.get(field)]
+    version = extract_version(meta)
+    missing: list[str] = []
+    if not meta.get("name"):
+        missing.append("name")
+    if not version:
+        missing.append("metadata.version")
+    if not meta.get("description"):
+        missing.append("description")
     if missing:
         raise ValueError(f"SKILL.md missing required fields: {', '.join(missing)}")
 
-    validate_version(meta["version"])
+    assert version is not None
+    validate_version(version)
+    meta["_resolved_version"] = version
 
     return meta
 
@@ -78,7 +99,7 @@ def collect_files(skill_dir: Path) -> tuple[list[Path], list[Path]]:
 def package_skill(skill_dir: Path, output_dir: Path) -> Path:
     meta = validate_frontmatter(skill_dir)
     skill_name: str = meta["name"]
-    skill_version: str = meta["version"]
+    skill_version: str = meta["_resolved_version"]
     archive_name = f"{skill_name}-{skill_version}.skill"
     output_path = output_dir / archive_name
 

--- a/skills/agent-builder/SKILL.md
+++ b/skills/agent-builder/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: agent-builder
-version: 1.0.0
 description: Build AI agents and automate Claude Code programmatically using the Claude Agent SDK and headless CLI mode. Use this skill when you need to build an agent, create a Claude agent, make a bot, work with the agent SDK, run Claude in headless mode, write programmatic agent code, automate with Claude, create an MCP server builder, or query Claude programmatically. Covers the Python SDK, the claude -p headless interface, custom tool creation with SDK MCP servers, hooks for deterministic control, session management, and CLI flag reference. Authentication uses existing ~/.claude/ config — no API keys required.
+metadata:
+  version: 1.0.0
 ---
 
 # Agent Builder - Claude SDK & CLI Expert

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: architecture-diagram
-version: 1.0.0
 description: Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons, CSS Grid nested container layout, SVG path connection overlays, and color-coded connection legends. Use when the user asks to create architecture diagrams, infrastructure diagrams, system topology diagrams, network diagrams, cloud architecture visuals, deployment diagrams, integration flow diagrams, or any request involving visual representation of system components, their containment hierarchy, and interconnections. Triggers on terms like "architecture diagram", "infra diagram", "system diagram", "topology", "deployment diagram", "network diagram", "integration architecture", or when the user provides a system description and asks for a visual/diagram.
+metadata:
+  version: 1.0.0
 ---
 
 # Architecture Diagram Generator

--- a/skills/architecture-reviewer/SKILL.md
+++ b/skills/architecture-reviewer/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: architecture-reviewer
-version: 1.0.0
 description: >
   Architecture reviews across 7 dimensions: structural integrity, scalability, enterprise
   readiness (SOC2/HIPAA/GDPR/PCI-DSS), performance, security, operational excellence, and
@@ -11,6 +10,8 @@ description: >
   "audit system", "evaluate codebase", "find design flaws", "assess scalability", "check
   security", "enterprise readiness", "architecture assessment", "technical due diligence",
   or when user provides a system design document or codebase and asks for feedback or improvements.
+metadata:
+  version: 1.0.0
 ---
 
 # Architecture Reviewer

--- a/skills/concept-to-image/SKILL.md
+++ b/skills/concept-to-image/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: concept-to-image
-version: 1.0.0
 description: >
   Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG image.
   Use this skill whenever the user wants to create a visual representation of an idea and needs an image file output
@@ -11,6 +10,8 @@ description: >
   Trigger phrases include: "create an image of", "make a visual", "design a graphic", "export as PNG",
   "save as SVG", "concept to image", "turn this into an image", "screenshot this HTML",
   "generate an infographic", or any request combining a concept description with image output.
+metadata:
+  version: 1.0.0
 ---
 
 # Concept to Image

--- a/skills/doc-condenser/SKILL.md
+++ b/skills/doc-condenser/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: doc-condenser
-version: 1.0.0
 description: Transform verbose technical documentation into concise, scannable specs. Use this skill when you need to condense, summarize, or reformat technical docs, specs, or READMEs — including when a document is too verbose, when you want a technical summary, or when working with lengthy specification documents. Triggers on phrases like "make this concise", "too verbose", "condense this", "technical summary", "strip the fluff", or "reformat this spec". See assets/template.md for the standard output structure.
+metadata:
+  version: 1.0.0
 ---
 
 # Document Condenser

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: github
-version: 1.0.0
 description: >
   GitHub CLI operations via `gh` for issues, pull requests, CI/Actions, releases, repos, search,
   gists, and the REST/GraphQL API. Structured output with `--json` and `--jq` for parsing.
@@ -13,6 +12,8 @@ description: >
   "why did CI fail", "check CI status", "merge a PR", "manage releases",
   "query the GitHub API", "search repositories", "triage workflows",
   "automate GitHub operations". Also triggers when the user pastes a GitHub URL.
+metadata:
+  version: 1.0.0
 ---
 
 # GitHub

--- a/skills/gpu-optimizer/SKILL.md
+++ b/skills/gpu-optimizer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gpu-optimizer
-version: 1.0.0
 description: Expert GPU optimization for modern consumer GPUs (8-24GB VRAM). Use this skill when you need to optimize GPU training, speed up CUDA code, reduce OOM errors, tune XGBoost for GPU, migrate NumPy to CuPy, make a model faster, manage GPU memory, optimize VRAM usage, or benchmark PyTorch. Covers mixed precision, gradient checkpointing, XGBoost GPU acceleration, CuPy/cuDF migration, vectorization, torch.compile, and diagnostics. NVIDIA GPUs only. PyTorch, XGBoost, and RAPIDS frameworks.
+metadata:
+  version: 1.0.0
 ---
 
 # GPU Optimizer

--- a/skills/html-presentation/SKILL.md
+++ b/skills/html-presentation/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: html-presentation
-version: 1.0.0
 description: Convert any document, outline, or content into a polished, self-contained HTML slide presentation. Use this skill whenever the user wants to create a presentation, slide deck, pitch deck, or talk from a document, markdown file, outline, notes, or any textual content and wants the output as an HTML file (not PPTX). Also trigger when the user asks for an "HTML presentation", "web-based slides", "reveal.js deck", "browser presentation", or wants to convert a document into slides they can present from a browser. Supports two navigation modes - horizontal (left/right, Reveal.js-powered) and vertical scroll (top-to-bottom, keyboard/scroll navigation). Includes multiple visual themes (dark editorial, light minimal, corporate, hacker terminal). Consider asking the user for clarification on theme, navigation direction, and content structure if not already specified.
+metadata:
+  version: 1.0.0
 ---
 
 # HTML Presentation Skill

--- a/skills/linkedin-post-style/SKILL.md
+++ b/skills/linkedin-post-style/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: linkedin-post-style
-version: 1.0.0
 description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and precise. Use this skill whenever the user asks to write, draft, rewrite, or edit a LinkedIn post, social media post, tech commentary, or any public-facing short-form writing about technology, AI, software engineering, or developer tools. Also trigger when the user says "write this in my style", "post about this", "rewrite this for LinkedIn", "draft a post in my style", or provides raw content/notes and wants it shaped into a post.
+metadata:
+  version: 1.0.0
 ---
 
 # LinkedIn Post Style Guide

--- a/skills/manuscript-provenance/SKILL.md
+++ b/skills/manuscript-provenance/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: manuscript-provenance
-version: 1.0.0
 description: >
   Computational provenance audit verifying that every number, table, figure,
   ordering, and terminology in a manuscript is derived from code and scripts —
@@ -12,6 +11,8 @@ description: >
   "audit my pipeline", "are my numbers from code", "check manuscript against
   scripts", "provenance audit", or any request to verify that manuscript
   content traces back to computational outputs.
+metadata:
+  version: 1.0.0
 ---
 
 # Manuscript Provenance Audit

--- a/skills/manuscript-review/SKILL.md
+++ b/skills/manuscript-review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: manuscript-review
-version: 1.0.0
 description: >
   Systematic pre-publication manuscript audit producing a structured refactoring
   report with section-level diagnostics, citation hygiene analysis, and
@@ -13,6 +12,8 @@ description: >
   consistency, argument coherence, or formatting compliance. Covers partial
   requests like "check my references" or "does the abstract work" — the full
   diagnostic surfaces issues across all facets even when only one was asked about.
+metadata:
+  version: 1.0.0
 ---
 
 # Manuscript Review Skill

--- a/skills/mcp-to-skill/SKILL.md
+++ b/skills/mcp-to-skill/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: mcp-to-skill
-version: 1.0.0
 description: >
   Convert MCP (Model Context Protocol) servers into on-demand skills to dramatically
   reduce active context window usage. MCP tool schemas consume tokens on every turn
@@ -11,6 +10,8 @@ description: >
   MCP, MCP migration. Also trigger when the user has many active MCP servers and wants
   to optimize context usage, asks about reducing token overhead from tool definitions,
   or says my context is too big or running out of context when MCPs are active.
+metadata:
+  version: 1.0.0
 ---
 
 # MCP-to-Skill Converter

--- a/skills/md-to-pdf/SKILL.md
+++ b/skills/md-to-pdf/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: md-to-pdf
-version: 1.0.0
 description: >
   Convert Markdown files to professionally styled PDF documents with full support for Mermaid diagrams,
   LaTeX/KaTeX math equations, tables, syntax-highlighted code blocks, and all standard Markdown features.
@@ -11,6 +10,8 @@ description: >
   "generate a pdf report", "how do I export markdown as PDF", "convert my notes to PDF",
   "can you make a PDF from this markdown".
 license: MIT. See LICENSE.txt for complete terms.
+metadata:
+  version: 1.0.0
 ---
 
 # Markdown to PDF Converter

--- a/skills/repo-sentinel/SKILL.md
+++ b/skills/repo-sentinel/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: repo-sentinel
-version: 1.0.0
 description: >
   Full security audit and enforcement for public repositories across 12 attack surfaces: git
   history, source code, docs, config, .gitignore recon, CI/CD, containers, dependencies, binaries,
@@ -13,6 +12,8 @@ description: >
   secret leaks, credential rotation, .claude/ tracking, repo hygiene, security scanning, or
   is this safe to push, pre-oss, open source readiness, release audit, or open source audit.
   This is the gatekeeper between internal and public.
+metadata:
+  version: 1.0.0
 ---
 
 # Repo Sentinel

--- a/skills/sequential-thinking/SKILL.md
+++ b/skills/sequential-thinking/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: sequential-thinking
-version: 1.0.0
 description: >
   Structured, reflective problem-solving through sequential chain-of-thought reasoning.
   Replaces the Sequential Thinking MCP server (sequentialthinking tool). Use this skill
@@ -11,6 +10,8 @@ description: >
   break down problem, think through this, structured analysis, multi-step problem solving,
   reflective reasoning, thought process, deep analysis, complex reasoning, hypothesis
   verification, branching analysis, revision-based thinking, dynamic problem solving.
+metadata:
+  version: 1.0.0
 ---
 
 # Sequential Thinking

--- a/skills/skill-evaluator/SKILL.md
+++ b/skills/skill-evaluator/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: skill-evaluator
-version: 1.0.0
 description: >
   Evaluate Claude Code skill quality across 6 weighted dimensions: frontmatter quality,
   trigger coverage, structural completeness, content depth, consistency and integrity,
@@ -13,6 +12,8 @@ description: >
   "how good is this skill", or when a user asks for feedback on a SKILL.md file. Use this
   skill when reviewing skills before deployment, comparing skill quality across a repo,
   or diagnosing why a skill fails to activate on relevant queries.
+metadata:
+  version: 1.0.0
 ---
 
 # Skill Evaluator

--- a/skills/static-web-artifacts-builder/SKILL.md
+++ b/skills/static-web-artifacts-builder/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: static-web-artifacts-builder
-version: 1.0.0
 description: >
   Suite of tools for creating elaborate, self-contained static HTML artifacts — infographics,
   interactive diagrams, architecture visuals, data dashboards, and rich visual deliverables.
@@ -11,6 +10,8 @@ description: >
   Triggers on: "create interactive HTML", "build self-contained web component", "generate
   static HTML visualization", "make an interactive diagram", "produce infographic", "render
   as HTML artifact", "build a visual dashboard", "create a diagram I can open in browser".
+metadata:
+  version: 1.0.0
 ---
 
 # Static Web Artifacts Builder

--- a/skills/tavily/SKILL.md
+++ b/skills/tavily/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: tavily
-version: 1.0.0
 description: >
   AI-optimized web search and content extraction via Tavily API. Use this skill when you need
   to search the web for current information, recent events, technical documentation, news, or
@@ -10,6 +9,8 @@ description: >
   "extract page content", "get article text", "scrape URL". Tavily returns clean, AI-ready
   snippets — prefer it over raw web fetch for search queries. Use extract for full page content
   when a specific URL is already known.
+metadata:
+  version: 1.0.0
 ---
 
 # Tavily Search

--- a/tests/test_generate_manifest.py
+++ b/tests/test_generate_manifest.py
@@ -12,10 +12,10 @@ class TestParseFrontmatter:
     """Tests for frontmatter extraction."""
 
     def test_extracts_all_fields(self) -> None:
-        content = "---\nname: my-skill\nversion: 1.2.3\ndescription: Does things.\n---\n# Body"
+        content = "---\nname: my-skill\ndescription: Does things.\nmetadata:\n  version: 1.2.3\n---\n# Body"
         meta = parse_frontmatter(content)
         assert meta["name"] == "my-skill"
-        assert meta["version"] == "1.2.3"
+        assert meta["metadata"]["version"] == "1.2.3"
         assert meta["description"] == "Does things."
 
     def test_raises_on_missing_frontmatter(self) -> None:

--- a/tests/test_install_skills.py
+++ b/tests/test_install_skills.py
@@ -204,6 +204,39 @@ class TestBuildInstallPlans:
         plans = build_install_plans(skills, install_dir)
         assert plans[0].action == InstallAction.SKIP
 
+    def test_reinstall_same_version(self, tmp_path: Path) -> None:
+        """With reinstall=True, same-version skills get REINSTALL action."""
+        install_dir = tmp_path / "install"
+        skill_dir = install_dir / "current-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: current-skill\ndescription: test\nmetadata:\n  version: 1.0.0\n---\n"
+        )
+        skills = [self._make_skill("current-skill", "1.0.0", tmp_path)]
+        plans = build_install_plans(skills, install_dir, reinstall=True)
+        assert plans[0].action == InstallAction.REINSTALL
+        assert plans[0].installed_version == "1.0.0"
+
+    def test_reinstall_does_not_affect_new_installs(self, tmp_path: Path) -> None:
+        """New skills stay as INSTALL even with reinstall=True."""
+        install_dir = tmp_path / "install"
+        install_dir.mkdir()
+        skills = [self._make_skill("brand-new", "1.0.0", tmp_path)]
+        plans = build_install_plans(skills, install_dir, reinstall=True)
+        assert plans[0].action == InstallAction.INSTALL
+
+    def test_reinstall_does_not_affect_upgrades(self, tmp_path: Path) -> None:
+        """Upgradeable skills stay as UPGRADE even with reinstall=True."""
+        install_dir = tmp_path / "install"
+        skill_dir = install_dir / "old-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: old-skill\ndescription: test\nmetadata:\n  version: 0.9.0\n---\n"
+        )
+        skills = [self._make_skill("old-skill", "1.0.0", tmp_path)]
+        plans = build_install_plans(skills, install_dir, reinstall=True)
+        assert plans[0].action == InstallAction.UPGRADE
+
     def test_skip_symlink(self, tmp_path: Path) -> None:
         """Symlinked skills are skipped entirely."""
         install_dir = tmp_path / "install"

--- a/tests/test_install_skills.py
+++ b/tests/test_install_skills.py
@@ -10,6 +10,7 @@ from scripts.install_skills import (
     SkillInfo,
     build_install_plans,
     copy_skill,
+    extract_version,
     get_installed_version,
     is_newer,
     parse_selection,
@@ -52,6 +53,22 @@ class TestIsNewer:
 
     def test_older_version(self) -> None:
         assert is_newer("1.0.0", "2.0.0") is False
+
+
+class TestExtractVersion:
+    """Tests for version extraction from frontmatter."""
+
+    def test_metadata_version(self) -> None:
+        assert extract_version({"metadata": {"version": "2.0.0"}}) == "2.0.0"
+
+    def test_legacy_top_level(self) -> None:
+        assert extract_version({"version": "1.0.0"}) == "1.0.0"
+
+    def test_metadata_takes_precedence(self) -> None:
+        assert extract_version({"version": "1.0.0", "metadata": {"version": "2.0.0"}}) == "2.0.0"
+
+    def test_no_version_returns_fallback(self) -> None:
+        assert extract_version({}) == "0.0.0"
 
 
 class TestParseSelection:
@@ -117,6 +134,15 @@ class TestGetInstalledVersion:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
+            "---\nname: test-skill\ndescription: test\nmetadata:\n  version: 1.2.3\n---\n"
+        )
+        assert get_installed_version(tmp_path, "test-skill") == "1.2.3"
+
+    def test_installed_with_legacy_version(self, tmp_path: Path) -> None:
+        """Legacy top-level version still detected."""
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
             "---\nname: test-skill\nversion: 1.2.3\ndescription: test\n---\n"
         )
         assert get_installed_version(tmp_path, "test-skill") == "1.2.3"
@@ -160,7 +186,7 @@ class TestBuildInstallPlans:
         skill_dir = install_dir / "old-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: old-skill\nversion: 0.9.0\ndescription: test\n---\n"
+            "---\nname: old-skill\ndescription: test\nmetadata:\n  version: 0.9.0\n---\n"
         )
         skills = [self._make_skill("old-skill", "1.0.0", tmp_path)]
         plans = build_install_plans(skills, install_dir)
@@ -172,7 +198,7 @@ class TestBuildInstallPlans:
         skill_dir = install_dir / "current-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: current-skill\nversion: 1.0.0\ndescription: test\n---\n"
+            "---\nname: current-skill\ndescription: test\nmetadata:\n  version: 1.0.0\n---\n"
         )
         skills = [self._make_skill("current-skill", "1.0.0", tmp_path)]
         plans = build_install_plans(skills, install_dir)
@@ -194,7 +220,7 @@ class TestCopySkill:
     def test_copies_files(self, tmp_path: Path) -> None:
         source = tmp_path / "source"
         source.mkdir()
-        (source / "SKILL.md").write_text("---\nname: test\nversion: 1.0.0\ndescription: t\n---\n")
+        (source / "SKILL.md").write_text("---\nname: test\ndescription: t\nmetadata:\n  version: 1.0.0\n---\n")
         (source / "refs").mkdir()
         (source / "refs" / "data.txt").write_text("data")
 
@@ -208,7 +234,7 @@ class TestCopySkill:
     def test_excludes_pycache(self, tmp_path: Path) -> None:
         source = tmp_path / "source"
         source.mkdir()
-        (source / "SKILL.md").write_text("---\nname: test\nversion: 1.0.0\ndescription: t\n---\n")
+        (source / "SKILL.md").write_text("---\nname: test\ndescription: t\nmetadata:\n  version: 1.0.0\n---\n")
         (source / "__pycache__").mkdir()
         (source / "__pycache__" / "mod.pyc").write_text("bytecode")
 
@@ -222,7 +248,7 @@ class TestCopySkill:
         """Upgrade scenario: existing target is removed first."""
         source = tmp_path / "source"
         source.mkdir()
-        (source / "SKILL.md").write_text("---\nname: test\nversion: 2.0.0\ndescription: t\n---\n")
+        (source / "SKILL.md").write_text("---\nname: test\ndescription: t\nmetadata:\n  version: 2.0.0\n---\n")
 
         target = tmp_path / "target"
         target.mkdir()

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from scripts.package_skill import (
+    extract_version,
     is_excluded,
     package_skill,
     parse_frontmatter,
@@ -19,14 +20,14 @@ class TestParseFrontmatter:
     """Tests for frontmatter parsing."""
 
     def test_valid_frontmatter(self) -> None:
-        content = "---\nname: test-skill\nversion: 1.0.0\ndescription: A test.\n---\n\n# Body"
+        content = "---\nname: test-skill\ndescription: A test.\nmetadata:\n  version: 1.0.0\n---\n\n# Body"
         result = parse_frontmatter(content)
         assert result["name"] == "test-skill"
-        assert result["version"] == "1.0.0"
+        assert result["metadata"]["version"] == "1.0.0"
         assert result["description"] == "A test."
 
     def test_multiline_description(self) -> None:
-        content = "---\nname: test\nversion: 1.0.0\ndescription: >\n  Long description\n  across lines.\n---\n"
+        content = "---\nname: test\ndescription: >\n  Long description\n  across lines.\nmetadata:\n  version: 1.0.0\n---\n"
         result = parse_frontmatter(content)
         assert "Long description" in result["description"]
 
@@ -57,14 +58,14 @@ class TestValidateFrontmatter:
         (skill_dir / "SKILL.md").write_text(
             "---\nname: test-skill\ndescription: A test.\n---\n"
         )
-        with pytest.raises(ValueError, match="missing required fields.*version"):
+        with pytest.raises(ValueError, match="missing required fields.*metadata.version"):
             validate_frontmatter(skill_dir)
 
     def test_invalid_version_format(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: test-skill\nversion: v1.0\ndescription: A test.\n---\n"
+            "---\nname: test-skill\ndescription: A test.\nmetadata:\n  version: v1.0\n---\n"
         )
         with pytest.raises(ValueError, match="Invalid version"):
             validate_frontmatter(skill_dir)
@@ -73,17 +74,47 @@ class TestValidateFrontmatter:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: test-skill\nversion: 1.0.0\ndescription: A test.\n---\n"
+            "---\nname: test-skill\ndescription: A test.\nmetadata:\n  version: 1.0.0\n---\n"
         )
         meta = validate_frontmatter(skill_dir)
         assert meta["name"] == "test-skill"
-        assert meta["version"] == "1.0.0"
+        assert meta["_resolved_version"] == "1.0.0"
+
+    def test_legacy_top_level_version(self, tmp_path: Path) -> None:
+        """Backward compat: top-level version still works."""
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test-skill\nversion: 1.0.0\ndescription: A test.\n---\n"
+        )
+        meta = validate_frontmatter(skill_dir)
+        assert meta["_resolved_version"] == "1.0.0"
 
     def test_missing_skill_md(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         with pytest.raises(FileNotFoundError):
             validate_frontmatter(skill_dir)
+
+
+class TestExtractVersion:
+    """Tests for version extraction from frontmatter."""
+
+    def test_metadata_version(self) -> None:
+        meta = {"name": "x", "metadata": {"version": "2.0.0"}}
+        assert extract_version(meta) == "2.0.0"
+
+    def test_legacy_top_level_version(self) -> None:
+        meta = {"name": "x", "version": "1.0.0"}
+        assert extract_version(meta) == "1.0.0"
+
+    def test_metadata_takes_precedence(self) -> None:
+        meta = {"name": "x", "version": "1.0.0", "metadata": {"version": "2.0.0"}}
+        assert extract_version(meta) == "2.0.0"
+
+    def test_no_version(self) -> None:
+        meta = {"name": "x"}
+        assert extract_version(meta) is None
 
 
 class TestIsExcluded:
@@ -114,7 +145,7 @@ class TestPackageSkill:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: test-skill\nversion: 2.1.0\ndescription: A test.\n---\n# Content\n"
+            "---\nname: test-skill\ndescription: A test.\nmetadata:\n  version: 2.1.0\n---\n# Content\n"
         )
 
         output_dir = tmp_path / "dist"
@@ -129,7 +160,7 @@ class TestPackageSkill:
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text(
-            "---\nname: test-skill\nversion: 1.0.0\ndescription: A test.\n---\n"
+            "---\nname: test-skill\ndescription: A test.\nmetadata:\n  version: 1.0.0\n---\n"
         )
         pycache = skill_dir / "__pycache__"
         pycache.mkdir()


### PR DESCRIPTION
## Summary

- Moves `version` from top-level SKILL.md frontmatter into `metadata.version` across all 18 skills, fixing the Claude Code installation error: `unexpected key in SKILL.md frontmatter: properties must be in ('name', 'description', 'license', 'allowed-tools', 'compatibility', 'metadata')`
- Adds `extract_version()` to all three scripts (packager, manifest generator, installer) with backward-compatible fallback to top-level `version` for already-installed skills
- Adds `--reinstall` CLI flag to the TUI installer, allowing reinstallation of skills already at the same version (`uv run scripts/install_skills.py --reinstall`)
- Fixes gitleaks CI failure on PRs by passing `GITHUB_TOKEN` env variable required by gitleaks-action v2+
- Updates test fixtures, adds `TestExtractVersion` and reinstall coverage (65 tests total), and documents the new format in CONTRIBUTING.md

## Test plan

- [x] All 65 tests pass (`uv run pytest tests/ -v`)
- [x] Manifest regenerates correctly with 18 skills
- [x] Legacy top-level `version` still detected (backward compat tests)
- [x] `metadata.version` takes precedence over top-level `version`
- [x] Reinstall flag produces REINSTALL action for same-version skills
- [x] Reinstall flag does not affect new installs or upgrades
- [x] CI checks pass (gitleaks + file-checks)
- [ ] Verify skill installation in Claude Code no longer raises frontmatter validation error