### PR TITLE
feat(skills): add concept-to-video skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 18](https://img.shields.io/badge/skills-18-informational)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 19](https://img.shields.io/badge/skills-19-informational)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -44,6 +44,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | [architecture-diagram](skills/architecture-diagram/)                 | Layered architecture diagrams as self-contained HTML with inline SVG icons and CSS Grid layout                   |
 | [concept-to-image](skills/concept-to-image/)                         | Turn concepts into polished HTML visuals, export as PNG or SVG                                                   |
+| [concept-to-video](skills/concept-to-video/)                         | Turn concepts into animated explainer videos using Manim — MP4/GIF output with iterative preview                 |
 | [html-presentation](skills/html-presentation/)                       | Convert documents and outlines into self-contained HTML slide presentations                                      |
 | [static-web-artifacts-builder](skills/static-web-artifacts-builder/) | Self-contained interactive HTML artifacts — infographics, dashboards, diagrams                                   |
 | [md-to-pdf](skills/md-to-pdf/)                                       | Markdown to styled PDF with Mermaid diagrams, KaTeX math, and syntax highlighting                                |

--- a/skills.yaml
+++ b/skills.yaml
@@ -39,6 +39,16 @@ skills:
     of", "make a visual", "design a graphic", "export as PNG", "save as SVG", "concept to image", "turn this into an image",
     "screenshot this HTML", "generate an infographic", or any request combining a concept description with image output.'
   path: skills/concept-to-image
+- name: concept-to-video
+  version: 1.0.0
+  description: 'Turn any concept into an animated explainer video using Manim (Python). Use whenever the user wants animated
+    visualizations, motion graphics, or video output (MP4/GIF) for technical concepts. Covers: architecture animations, data
+    flow visualizations, algorithm step-throughs, pipeline explainers, math proofs, comparisons, agent interactions, training
+    loops, or any "animate X" / "make a video of X" request. Also trigger for existing Manim scene edits or re-renders. Trigger
+    on: "create a video", "animate this", "make an explainer", "concept to video", "manim animation", "show this as a video",
+    "motion graphic", "visualize this process", or any concept + video/animation output request. Use this skill even for casual
+    "animate" requests about technical ideas.'
+  path: skills/concept-to-video
 - name: doc-condenser
   version: 1.0.0
   description: Transform verbose technical documentation into concise, scannable specs. Use this skill when you need to condense,

--- a/skills/concept-to-video/SKILL.md
+++ b/skills/concept-to-video/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: concept-to-video
+description: >
+  Turn any concept into an animated explainer video using Manim (Python). Use whenever the user
+  wants animated visualizations, motion graphics, or video output (MP4/GIF) for technical concepts.
+  Covers: architecture animations, data flow visualizations, algorithm step-throughs, pipeline
+  explainers, math proofs, comparisons, agent interactions, training loops, or any "animate X" /
+  "make a video of X" request. Also trigger for existing Manim scene edits or re-renders.
+  Trigger on: "create a video", "animate this", "make an explainer", "concept to video",
+  "manim animation", "show this as a video", "motion graphic", "visualize this process",
+  or any concept + video/animation output request. Use this skill even for casual "animate"
+  requests about technical ideas.
+metadata:
+  version: 1.0.0
+---
+
+# Concept to Video
+
+Creates animated explainer videos from concepts using Manim (Python) as a programmatic animation engine.
+
+## Reference Files
+
+| File                            | Purpose                                                                    |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `references/scene-patterns.md`  | Common scene patterns for different concept types with reusable templates  |
+| `scripts/render_video.py`       | Wrapper around Manim CLI — handles quality, format, output path cleanup    |
+
+## Why Manim as the engine
+
+Manim is the "SVG of video" — you write Python code that describes animations declaratively, and it renders to MP4/GIF at any resolution. The Python scene file IS the editable intermediate: the user can see the code, request changes ("make the arrows red", "add a third step", "slow down the transition"), and only do a final high-quality render once satisfied. This makes the workflow iterative and controllable, exactly like concept-to-image uses HTML as an intermediate.
+
+## Workflow
+
+```
+Concept → Manim scene (.py) → Preview (low-quality) → Iterate → Final render (MP4/GIF)
+```
+
+1. **Interpret** the user's concept — determine the best animation approach
+2. **Design** a self-contained Manim scene file — one file, one Scene class
+3. **Preview** by rendering at low quality (`-ql`) for fast iteration
+4. **Iterate** on the scene based on user feedback
+5. **Export** final video at high quality using `scripts/render_video.py`
+
+## Step 0: Ensure dependencies
+
+Before writing any scene, ensure Manim is installed:
+
+```bash
+# System deps (usually pre-installed)
+apt-get install -y libpango1.0-dev libcairo2-dev ffmpeg 2>/dev/null
+
+# Python package
+pip install manim --break-system-packages -q
+```
+
+Verify with: `python3 -c "import manim; print(manim.__version__)"`
+
+## Step 1: Interpret the concept
+
+Determine the best animation pattern. Read `references/scene-patterns.md` for detailed templates.
+
+| User intent                     | Animation pattern            | Key Manim primitives                          |
+| ------------------------------- | ---------------------------- | --------------------------------------------- |
+| Explain a pipeline/flow         | Sequential flow animation    | Arrow, Rectangle, Text, AnimationGroup        |
+| Show architecture layers        | Layer build-up               | VGroup, Arrange, FadeIn with shift            |
+| Algorithm step-through          | State machine transitions    | Transform, ReplacementTransform, Indicate     |
+| Compare approaches              | Side-by-side morph           | Split screen VGroups, simultaneous animations |
+| Data transformation             | Object metamorphosis         | Transform chains, color transitions           |
+| Mathematical concept            | Equation + geometric proof   | MathTex, geometric shapes, Rotate, Scale      |
+| Agent/multi-system interaction  | Message passing animation    | Arrows between entities, Create/FadeOut       |
+| Training/optimization loop      | Iterative cycle animation    | Loop with Transform, ValueTracker, plots      |
+| Timeline/history                | Left-to-right progression    | NumberLine, sequential Indicate                |
+
+## Step 2: Design the Manim scene
+
+Core rules:
+
+- **Single file, single Scene class**: Everything in one `.py` file with one `class XxxScene(Scene)`.
+- **Self-contained**: No external assets unless absolutely necessary. Use Manim primitives for everything.
+- **Readable code**: The scene file IS the user's artifact. Use clear variable names, comments for each animation beat.
+- **Color with intention**: Use Manim's color constants (BLUE, RED, GREEN, YELLOW, etc.) or hex colors. Max 4-5 colors. Every color should encode meaning.
+- **Pacing**: Include `self.wait()` calls between logical sections. 0.5s for breathing room, 1-2s for major transitions.
+- **Text legibility**: Use `font_size=36` minimum for body text, `font_size=48+` for titles. Test at target resolution.
+- **Scene dimensions**: Default Manim canvas is 14.2 × 8 units (16:9). Keep content within ±6 horizontal, ±3.5 vertical.
+
+### Animation best practices
+
+```python
+# DO: Use animation groups for simultaneous effects
+self.play(FadeIn(box), Write(label), run_time=1)
+
+# DO: Use .animate syntax for property changes
+self.play(box.animate.shift(RIGHT * 2).set_color(GREEN))
+
+# DO: Stagger related elements
+self.play(LaggedStart(*[FadeIn(item) for item in items], lag_ratio=0.2))
+
+# DON'T: Add/remove without animation (jarring)
+self.add(box)  # Only for setup before first frame
+
+# DON'T: Make animations too fast
+self.play(Transform(a, b), run_time=0.3)  # Too fast to read
+```
+
+### Structure template
+
+```python
+from manim import *
+
+class ConceptScene(Scene):
+    def construct(self):
+        # === Section 1: Title / Setup ===
+        title = Text("Concept Name", font_size=56, weight=BOLD)
+        self.play(Write(title))
+        self.wait(1)
+        self.play(FadeOut(title))
+
+        # === Section 2: Core animation ===
+        # ... main content here ...
+
+        # === Section 3: Summary / Conclusion ===
+        # ... wrap-up animation ...
+        self.wait(2)
+```
+
+## Step 3: Preview render
+
+Use low quality for fast iteration:
+
+```bash
+python3 scripts/render_video.py scene.py ConceptScene --quality low --format mp4
+```
+
+This renders at 480p/15fps — fast enough for previewing timing and layout. Present the video to the user.
+
+## Step 4: Iterate
+
+Common refinement requests and how to handle them:
+
+| Request                    | Action                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| "Slower/faster"            | Adjust `run_time=` params and `self.wait()` durations   |
+| "Change colors"            | Update color constants                                  |
+| "Add a step"               | Insert new animation block between sections             |
+| "Reorder"                  | Move code blocks around                                 |
+| "Different layout"         | Adjust `.shift()`, `.next_to()`, `.arrange()` calls     |
+| "Add labels/annotations"   | Add `Text` or `MathTex` objects with `.next_to()`       |
+| "Make it loop"             | Add matching intro/outro states                         |
+
+## Step 5: Final export
+
+Once the user is satisfied:
+
+```bash
+python3 scripts/render_video.py scene.py ConceptScene --quality high --format mp4
+```
+
+### Quality presets
+
+| Preset   | Resolution | FPS | Flag  | Use case             |
+| -------- | ---------- | --- | ----- | -------------------- |
+| `low`    | 480p       | 15  | `-ql` | Fast preview         |
+| `medium` | 720p       | 30  | `-qm` | Draft review         |
+| `high`   | 1080p      | 60  | `-qh` | Final delivery       |
+| `4k`     | 2160p      | 60  | `-qk` | Presentation quality |
+
+### Format options
+
+| Format | Flag            | Use case                        |
+| ------ | --------------- | ------------------------------- |
+| `mp4`  | `--format mp4`  | Standard video delivery         |
+| `gif`  | `--format gif`  | Embeddable in docs, social      |
+| `webm` | `--format webm` | Web-optimized                   |
+
+### Delivering the output
+
+Present both:
+1. The `.py` scene file (for future editing)
+2. The rendered video file (final output)
+
+Copy the final video to `/mnt/user-data/outputs/` and present it.
+
+## Error Handling
+
+| Error                          | Cause                                      | Resolution                                                |
+| ------------------------------ | ------------------------------------------ | --------------------------------------------------------- |
+| `ModuleNotFoundError: manim`   | Manim not installed                        | Run Step 0 setup commands                                 |
+| `pangocairo` build error       | Missing system dev headers                 | `apt-get install -y libpango1.0-dev`                      |
+| `FileNotFoundError: ffmpeg`    | ffmpeg not installed                       | `apt-get install -y ffmpeg`                               |
+| Scene class not found          | Class name mismatch                        | Verify class name matches CLI argument                    |
+| Overlapping objects            | Positions not calculated                   | Use `.next_to()`, `.arrange()`, explicit `.shift()` calls |
+| Text cut off                   | Text too large or positioned near edge     | Reduce `font_size` or adjust position within ±6,±3.5      |
+| Slow render                    | Too many objects or complex transformations | Reduce object count, simplify paths, use lower quality    |
+| `LaTeX Error`                  | LaTeX not installed (for MathTex)          | Use `Text` instead, or install `texlive-latex-base`       |
+
+### LaTeX fallback
+
+If LaTeX is not available, avoid `MathTex` and `Tex`. Use `Text` with Unicode math symbols instead:
+
+```python
+# Instead of: MathTex(r"\frac{1}{n} \sum_{i=1}^{n} x_i")
+# Use:        Text("(1/n) Σ xᵢ", font_size=36)
+```
+
+## Limitations
+
+- **Manim + ffmpeg required** — cannot render without these dependencies.
+- **No audio support in this workflow** — Manim supports audio but adds complexity. Keep videos silent or add audio post-export.
+- **LaTeX optional** — MathTex requires a LaTeX installation. Fall back to Text with Unicode for math.
+- **Render time scales with complexity** — a 30-second 1080p scene with many objects can take 1-2 minutes to render.
+- **3D scenes require OpenGL** — ThreeDScene may not work in headless containers. Stick to 2D Scene class.
+- **No interactivity** — output is a static video file, not an interactive widget.
+
+## Design anti-patterns to avoid
+
+- Walls of text on screen — keep to 3-5 words per label, max 2 lines
+- Everything appearing at once — use staged animations with LaggedStart
+- Uniform timing — vary run_time to create rhythm (fast for simple, slow for important)
+- No visual hierarchy — use size, color, and position to guide attention
+- Rainbow colors — 3-4 intentional colors max
+- Ignoring the grid — align objects to consistent positions using arrange/align

--- a/skills/concept-to-video/references/scene-patterns.md
+++ b/skills/concept-to-video/references/scene-patterns.md
@@ -1,0 +1,423 @@
+# Scene Patterns Reference
+
+Reusable templates for common concept visualization types. Each pattern includes a minimal working example that can be adapted.
+
+---
+
+## Pattern 1: Pipeline / Data Flow
+
+For: RAG pipelines, ETL processes, request flows, CI/CD stages.
+
+```python
+from manim import *
+
+class PipelineScene(Scene):
+    def construct(self):
+        # Define stages
+        stages = ["Ingest", "Embed", "Index", "Retrieve", "Generate"]
+        colors = [BLUE, TEAL, GREEN, YELLOW, RED]
+
+        boxes = VGroup()
+        for i, (name, color) in enumerate(zip(stages, colors)):
+            box = VGroup(
+                RoundedRectangle(corner_radius=0.2, width=2, height=1, color=color, fill_opacity=0.2),
+                Text(name, font_size=28, color=color)
+            )
+            boxes.add(box)
+
+        boxes.arrange(RIGHT, buff=0.5)
+        boxes.move_to(ORIGIN)
+
+        # Animate stage by stage
+        for i, box in enumerate(boxes):
+            self.play(FadeIn(box, shift=UP * 0.3), run_time=0.5)
+            if i < len(boxes) - 1:
+                arrow = Arrow(
+                    boxes[i].get_right(), boxes[i + 1].get_left(),
+                    buff=0.1, color=WHITE, stroke_width=2
+                )
+                self.play(GrowArrow(arrow), run_time=0.3)
+
+        self.wait(2)
+```
+
+---
+
+## Pattern 2: Architecture Layers
+
+For: System architecture, network stacks, abstraction layers.
+
+```python
+from manim import *
+
+class ArchitectureScene(Scene):
+    def construct(self):
+        layers = [
+            ("Application", BLUE),
+            ("API Gateway", TEAL),
+            ("Service Mesh", GREEN),
+            ("Infrastructure", ORANGE),
+        ]
+
+        layer_group = VGroup()
+        for name, color in layers:
+            layer = VGroup(
+                Rectangle(width=8, height=1.2, color=color, fill_opacity=0.15),
+                Text(name, font_size=32, color=color)
+            )
+            layer_group.add(layer)
+
+        layer_group.arrange(DOWN, buff=0.15)
+        layer_group.move_to(ORIGIN)
+
+        # Build from bottom up
+        for layer in reversed(layer_group):
+            self.play(FadeIn(layer, shift=UP * 0.5), run_time=0.6)
+
+        # Add connecting arrows
+        for i in range(len(layer_group) - 1):
+            arrow = Arrow(
+                layer_group[i].get_bottom(),
+                layer_group[i + 1].get_top(),
+                buff=0.05, color=GREY, stroke_width=2
+            )
+            self.play(GrowArrow(arrow), run_time=0.3)
+
+        self.wait(2)
+```
+
+---
+
+## Pattern 3: Algorithm Step-Through
+
+For: Sorting, search, graph traversal, any stateful algorithm.
+
+```python
+from manim import *
+
+class AlgorithmScene(Scene):
+    def construct(self):
+        title = Text("Binary Search", font_size=48, weight=BOLD)
+        self.play(Write(title))
+        self.wait(0.5)
+        self.play(title.animate.to_edge(UP))
+
+        # Create array
+        values = [2, 5, 8, 12, 16, 23, 38, 56, 72, 91]
+        cells = VGroup()
+        for v in values:
+            cell = VGroup(
+                Square(side_length=0.8, color=WHITE, stroke_width=1),
+                Text(str(v), font_size=24)
+            )
+            cells.add(cell)
+
+        cells.arrange(RIGHT, buff=0)
+        cells.move_to(ORIGIN)
+        self.play(FadeIn(cells))
+
+        target_text = Text("Target: 23", font_size=32, color=YELLOW)
+        target_text.next_to(cells, DOWN, buff=1)
+        self.play(Write(target_text))
+
+        # Simulate search steps
+        lo, hi = 0, len(values) - 1
+        target = 23
+
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            # Highlight search range
+            highlight = SurroundingRectangle(
+                VGroup(*cells[lo:hi + 1]),
+                color=BLUE, buff=0.05
+            )
+            pointer = Arrow(
+                cells[mid].get_top() + UP * 0.5,
+                cells[mid].get_top(),
+                buff=0.05, color=RED
+            )
+            mid_label = Text("mid", font_size=20, color=RED)
+            mid_label.next_to(pointer, UP, buff=0.1)
+
+            self.play(Create(highlight), GrowArrow(pointer), Write(mid_label), run_time=0.6)
+            self.wait(0.5)
+
+            if values[mid] == target:
+                cells[mid][0].set_fill(GREEN, opacity=0.5)
+                self.play(Indicate(cells[mid], color=GREEN, scale_factor=1.3))
+                found = Text("Found!", font_size=40, color=GREEN)
+                found.next_to(target_text, DOWN)
+                self.play(Write(found))
+                break
+            elif values[mid] < target:
+                lo = mid + 1
+            else:
+                hi = mid - 1
+
+            self.play(FadeOut(highlight), FadeOut(pointer), FadeOut(mid_label), run_time=0.3)
+
+        self.wait(2)
+```
+
+---
+
+## Pattern 4: Side-by-Side Comparison
+
+For: Before/after, two approaches, trade-off visualization.
+
+```python
+from manim import *
+
+class ComparisonScene(Scene):
+    def construct(self):
+        title = Text("Monolith vs Microservices", font_size=44, weight=BOLD)
+        self.play(Write(title))
+        self.wait(0.5)
+        self.play(title.animate.to_edge(UP))
+
+        divider = Line(UP * 2.5, DOWN * 2.5, color=GREY, stroke_width=1)
+        self.play(Create(divider))
+
+        # Left side: Monolith
+        left_title = Text("Monolith", font_size=32, color=BLUE)
+        left_title.move_to(LEFT * 3.5 + UP * 2)
+        mono_box = Rectangle(width=3, height=4, color=BLUE, fill_opacity=0.1)
+        mono_box.move_to(LEFT * 3.5 + DOWN * 0.5)
+        mono_labels = VGroup(*[
+            Text(s, font_size=18) for s in ["Auth", "API", "DB", "UI", "Logic"]
+        ]).arrange(DOWN, buff=0.3).move_to(mono_box)
+
+        # Right side: Microservices
+        right_title = Text("Microservices", font_size=32, color=GREEN)
+        right_title.move_to(RIGHT * 3.5 + UP * 2)
+        micro_boxes = VGroup()
+        for name, pos in [("Auth", UL), ("API", UR), ("DB", DL), ("UI", DR), ("Logic", DOWN)]:
+            box = VGroup(
+                RoundedRectangle(width=1.2, height=0.8, corner_radius=0.1,
+                                 color=GREEN, fill_opacity=0.1),
+                Text(name, font_size=16, color=GREEN)
+            )
+            micro_boxes.add(box)
+        micro_boxes.arrange_in_grid(rows=2, cols=3, buff=0.3)
+        micro_boxes.move_to(RIGHT * 3.5 + DOWN * 0.5)
+
+        self.play(Write(left_title), Write(right_title))
+        self.play(FadeIn(mono_box), FadeIn(mono_labels))
+        self.play(LaggedStart(*[FadeIn(b, scale=0.8) for b in micro_boxes], lag_ratio=0.15))
+
+        self.wait(2)
+```
+
+---
+
+## Pattern 5: Message Passing / Agent Interaction
+
+For: Multi-agent systems, distributed systems, pub/sub, request/response.
+
+```python
+from manim import *
+
+class AgentInteractionScene(Scene):
+    def construct(self):
+        # Create agents
+        agents = {}
+        positions = {"Orchestrator": UP * 2, "Planner": LEFT * 4, "Executor": RIGHT * 4, "Memory": DOWN * 2}
+        colors = {"Orchestrator": BLUE, "Planner": GREEN, "Executor": ORANGE, "Memory": PURPLE}
+
+        for name, pos in positions.items():
+            circle = Circle(radius=0.6, color=colors[name], fill_opacity=0.2)
+            label = Text(name, font_size=20, color=colors[name])
+            label.next_to(circle, DOWN, buff=0.15)
+            agent = VGroup(circle, label).move_to(pos)
+            agents[name] = agent
+
+        all_agents = VGroup(*agents.values())
+        self.play(LaggedStart(*[FadeIn(a, scale=0.5) for a in all_agents], lag_ratio=0.2))
+        self.wait(0.5)
+
+        # Animate message passing
+        messages = [
+            ("Orchestrator", "Planner", "Plan task", YELLOW),
+            ("Planner", "Orchestrator", "Steps ready", GREEN),
+            ("Orchestrator", "Executor", "Execute step 1", YELLOW),
+            ("Executor", "Memory", "Store result", ORANGE),
+            ("Executor", "Orchestrator", "Step complete", GREEN),
+        ]
+
+        for src, dst, msg_text, color in messages:
+            src_pos = agents[src][0].get_center()
+            dst_pos = agents[dst][0].get_center()
+
+            msg = Text(msg_text, font_size=16, color=color)
+            arrow = Arrow(src_pos, dst_pos, buff=0.7, color=color, stroke_width=2)
+            msg.next_to(arrow, UP if src_pos[1] >= dst_pos[1] else DOWN, buff=0.1)
+
+            self.play(GrowArrow(arrow), FadeIn(msg), run_time=0.6)
+            self.play(Indicate(agents[dst][0], color=color), run_time=0.3)
+            self.play(FadeOut(arrow), FadeOut(msg), run_time=0.3)
+
+        self.wait(2)
+```
+
+---
+
+## Pattern 6: Equation / Mathematical Concept
+
+For: Loss functions, attention mechanisms, probability, any math.
+
+Note: Uses `Text` with Unicode instead of `MathTex` to avoid LaTeX dependency.
+
+```python
+from manim import *
+
+class MathConceptScene(Scene):
+    def construct(self):
+        title = Text("Attention Mechanism", font_size=48, weight=BOLD)
+        self.play(Write(title))
+        self.wait(0.5)
+        self.play(title.animate.to_edge(UP))
+
+        # Show the formula using Text (LaTeX-free)
+        formula = Text("Attention(Q, K, V) = softmax(QKᵀ / √dₖ) · V", font_size=30)
+        formula.move_to(UP * 1)
+        self.play(Write(formula), run_time=1.5)
+        self.wait(1)
+
+        # Break down components
+        components = [
+            ("Q = Query", "What am I looking for?", BLUE),
+            ("K = Key", "What do I contain?", GREEN),
+            ("V = Value", "What do I provide?", ORANGE),
+        ]
+
+        comp_group = VGroup()
+        for symbol, desc, color in components:
+            row = VGroup(
+                Text(symbol, font_size=28, color=color),
+                Text(f"→ {desc}", font_size=22, color=GREY),
+            ).arrange(RIGHT, buff=0.5)
+            comp_group.add(row)
+
+        comp_group.arrange(DOWN, buff=0.4, aligned_edge=LEFT)
+        comp_group.move_to(DOWN * 1.2)
+
+        self.play(LaggedStart(*[FadeIn(c, shift=RIGHT * 0.3) for c in comp_group], lag_ratio=0.3))
+        self.wait(2)
+```
+
+---
+
+## Pattern 7: Iterative Process / Training Loop
+
+For: Gradient descent, RL loops, feedback systems, any cyclic process.
+
+```python
+from manim import *
+
+class TrainingLoopScene(Scene):
+    def construct(self):
+        title = Text("Training Loop", font_size=48, weight=BOLD)
+        self.play(Write(title))
+        self.play(title.animate.to_edge(UP).scale(0.7))
+
+        # Create cycle nodes
+        steps = ["Forward\nPass", "Compute\nLoss", "Backward\nPass", "Update\nWeights"]
+        colors = [BLUE, RED, ORANGE, GREEN]
+        radius = 2.2
+        n = len(steps)
+
+        nodes = VGroup()
+        for i, (step, color) in enumerate(zip(steps, colors)):
+            angle = PI / 2 - i * TAU / n  # start from top, go clockwise
+            pos = radius * np.array([np.cos(angle), np.sin(angle), 0])
+            box = VGroup(
+                RoundedRectangle(width=2, height=1, corner_radius=0.15,
+                                 color=color, fill_opacity=0.15),
+                Text(step, font_size=20, color=color)
+            ).move_to(pos)
+            nodes.add(box)
+
+        self.play(LaggedStart(*[FadeIn(n, scale=0.5) for n in nodes], lag_ratio=0.2))
+
+        # Add arrows between nodes
+        arrows = VGroup()
+        for i in range(n):
+            start = nodes[i].get_center()
+            end = nodes[(i + 1) % n].get_center()
+            direction = end - start
+            arrow = Arrow(start, end, buff=0.85, color=GREY, stroke_width=2)
+            arrows.add(arrow)
+            self.play(GrowArrow(arrow), run_time=0.3)
+
+        # Animate one "cycle" with a highlight traveling around
+        for i in range(n):
+            self.play(
+                nodes[i][0].animate.set_fill(colors[i], opacity=0.5),
+                run_time=0.4
+            )
+            self.play(
+                nodes[i][0].animate.set_fill(colors[i], opacity=0.15),
+                run_time=0.2
+            )
+
+        # Epoch counter
+        epoch = Text("Epoch: 1 → 2 → 3 → ... → N", font_size=24, color=YELLOW)
+        epoch.to_edge(DOWN)
+        self.play(Write(epoch))
+        self.wait(2)
+```
+
+---
+
+## Utility Snippets
+
+### Fade transition between sections
+
+```python
+# Clear everything and transition
+self.play(*[FadeOut(mob) for mob in self.mobjects])
+self.wait(0.3)
+```
+
+### Highlight / call attention
+
+```python
+# Flash a specific element
+self.play(Indicate(element, color=YELLOW, scale_factor=1.2))
+
+# Surround with box
+box = SurroundingRectangle(element, color=RED, buff=0.15)
+self.play(Create(box))
+```
+
+### Animated text replacement
+
+```python
+old_text = Text("Before", font_size=36)
+new_text = Text("After", font_size=36, color=GREEN)
+new_text.move_to(old_text)
+self.play(ReplacementTransform(old_text, new_text))
+```
+
+### Progressive reveal with bullet points
+
+```python
+points = VGroup(*[
+    Text(f"• {t}", font_size=24)
+    for t in ["First point", "Second point", "Third point"]
+]).arrange(DOWN, aligned_edge=LEFT, buff=0.3)
+points.move_to(ORIGIN)
+
+for point in points:
+    self.play(FadeIn(point, shift=RIGHT * 0.3), run_time=0.5)
+    self.wait(0.5)
+```
+
+### Screen wipe / scene transition
+
+```python
+# Slide everything left and bring new content from right
+old_content = VGroup(*self.mobjects)
+self.play(old_content.animate.shift(LEFT * 15), run_time=0.8)
+self.remove(*old_content)
+```

--- a/skills/concept-to-video/scripts/render_video.py
+++ b/skills/concept-to-video/scripts/render_video.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+render_video.py — Render Manim scenes to video files with simplified CLI.
+
+Wraps the Manim CLI to handle quality presets, output format, and file path
+management (Manim's default output nesting is deep and unintuitive).
+
+Usage:
+    python3 render_video.py scene.py SceneName --quality high --format mp4
+    python3 render_video.py scene.py SceneName --quality low --format gif --output /path/to/output.gif
+"""
+
+import argparse
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+QUALITY_MAP = {
+    "low":    ("-ql",  "480p15"),
+    "medium": ("-qm",  "720p30"),
+    "high":   ("-qh",  "1080p60"),
+    "4k":     ("-qk",  "2160p60"),
+}
+
+FORMAT_MAP = {
+    "mp4":  "--format=mp4",
+    "gif":  "--format=gif",
+    "webm": "--format=webm",
+    "png":  "--format=png",   # renders each frame as PNG sequence
+}
+
+
+def find_rendered_file(media_dir: Path, scene_name: str, quality_dir: str, fmt: str) -> Path | None:
+    """
+    Locate the rendered file in Manim's nested output structure.
+    Manim outputs to: media/videos/<script_name>/<quality_dir>/<SceneName>.<ext>
+    """
+    ext = fmt if fmt != "png" else "mp4"  # png sequence still gets combined
+
+    # Search all video subdirs for the scene
+    for video_dir in media_dir.rglob(quality_dir):
+        candidate = video_dir / f"{scene_name}.{ext}"
+        if candidate.exists():
+            return candidate
+
+    # Fallback: search by scene name anywhere under media
+    for match in media_dir.rglob(f"{scene_name}.{ext}"):
+        return match
+
+    # GIF fallback: manim sometimes puts gifs in a different subdir
+    if fmt == "gif":
+        for match in media_dir.rglob(f"{scene_name}.gif"):
+            return match
+
+    return None
+
+
+def ensure_manim_installed() -> bool:
+    """Check if manim is importable."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import manim; print(manim.__version__)"],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            print(f"Manim version: {result.stdout.strip()}")
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render Manim scene to video")
+    parser.add_argument("scene_file", help="Path to the .py file containing the Scene class")
+    parser.add_argument("scene_name", help="Name of the Scene class to render")
+    parser.add_argument("--quality", choices=QUALITY_MAP.keys(), default="high",
+                        help="Render quality preset (default: high)")
+    parser.add_argument("--format", dest="fmt", choices=FORMAT_MAP.keys(), default="mp4",
+                        help="Output format (default: mp4)")
+    parser.add_argument("--output", "-o", type=str, default=None,
+                        help="Output file path. If not specified, outputs next to scene file.")
+    parser.add_argument("--media-dir", type=str, default=None,
+                        help="Custom media directory for Manim output")
+
+    args = parser.parse_args()
+
+    scene_path = Path(args.scene_file).resolve()
+    if not scene_path.exists():
+        print(f"ERROR: Scene file not found: {scene_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not ensure_manim_installed():
+        print("ERROR: Manim is not installed. Run: pip install manim --break-system-packages", file=sys.stderr)
+        sys.exit(1)
+
+    quality_flag, quality_dir = QUALITY_MAP[args.quality]
+    format_flag = FORMAT_MAP[args.fmt]
+
+    # Build manim command
+    media_dir = Path(args.media_dir) if args.media_dir else scene_path.parent / "media"
+
+    cmd = [
+        sys.executable, "-m", "manim", "render",
+        quality_flag,
+        format_flag,
+        f"--media_dir={media_dir}",
+        str(scene_path),
+        args.scene_name,
+    ]
+
+    print(f"Rendering: {args.scene_name} @ {args.quality} quality ({args.fmt})")
+    print(f"Command: {' '.join(cmd)}")
+    print()
+
+    result = subprocess.run(cmd, capture_output=False, text=True)
+
+    if result.returncode != 0:
+        print(f"\nERROR: Manim render failed with exit code {result.returncode}", file=sys.stderr)
+        sys.exit(result.returncode)
+
+    # Find the rendered file
+    rendered = find_rendered_file(media_dir, args.scene_name, quality_dir, args.fmt)
+
+    if not rendered:
+        print(f"\nWARNING: Could not locate rendered file. Check {media_dir} manually.", file=sys.stderr)
+        # List what's there for debugging
+        print("Contents of media dir:", file=sys.stderr)
+        for p in sorted(media_dir.rglob("*")):
+            if p.is_file():
+                print(f"  {p} ({p.stat().st_size:,} bytes)", file=sys.stderr)
+        sys.exit(1)
+
+    # Copy to output location if specified
+    if args.output:
+        output_path = Path(args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(rendered, output_path)
+        final_path = output_path
+    else:
+        final_path = rendered
+
+    size = final_path.stat().st_size
+    print(f"\nRendered: {final_path}")
+    print(f"  Quality:   {args.quality} ({quality_dir})")
+    print(f"  Format:    {args.fmt}")
+    print(f"  File size: {size:,} bytes ({size / 1024:.1f} KB)")
+
+    return str(final_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `concept-to-video` skill — Manim-based animated explainer video generation from concepts (MP4/GIF output)
- Includes render wrapper script (`scripts/render_video.py`) and scene pattern reference library
- Regenerate `skills.yaml` manifest (18 → 19 skills), update README catalog and badge count

## Test plan

- [ ] Verify `skills.yaml` lists `concept-to-video` with correct name, version, path
- [ ] Verify README catalog shows the new entry under Visualization & Documents
- [ ] Verify badge count reads 19
- [ ] Run `uv run scripts/install_skills.py` and confirm concept-to-video appears as installable