### PR TITLE
ci(release): add rolling latest release on push to main

### DIFF
--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -2,6 +2,8 @@ name: Package Skills
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -40,9 +42,29 @@ jobs:
             fi
           done
 
-      - name: Create GitHub Release
+      - name: Create versioned release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
+          files: dist/*.skill
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          tag_name: latest
+          name: Latest Skills (rolling)
+          body: |
+            Rolling release — automatically updated on every push to `main`.
+
+            Contains the latest packaged `.skill` files from the repository.
+            For stable releases, use a versioned tag (e.g., `v1.0.0`).
+
+            **Last updated:** ${{ github.sha }}
+          prerelease: true
+          make_latest: false
           files: dist/*.skill
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Trigger `package-skills` workflow on `main` branch push (PR merge) in addition to tag push
- Main push updates a rolling `latest` pre-release with current `.skill` archives
- Tag push creates versioned releases as before (no behavior change)

## Details

Split the release step into two conditional steps:
- **`Create versioned release`** — runs on `refs/tags/v*`, unchanged behavior
- **`Update latest release`** — runs on `refs/heads/main`, creates/updates a `latest` pre-release with `make_latest: false` so versioned releases retain the "Latest" badge

## Test plan

- [ ] Merge this PR — confirm `Package Skills` workflow runs on the merge commit
- [ ] Confirm a `latest` pre-release appears on the releases page with all `.skill` files
- [ ] Push a `v*` tag — confirm versioned release still works (no regression)