### PR TITLE
feat(skills): add code-refiner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 19](https://img.shields.io/badge/skills-19-informational)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 20](https://img.shields.io/badge/skills-20-informational)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -33,6 +33,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | Skill                                                  | Description                                                                                                                                        |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [architecture-reviewer](skills/architecture-reviewer/) | Architecture reviews across 7 scored dimensions — structural integrity, scalability, security, performance, enterprise readiness, operations, data |
+| [code-refiner](skills/code-refiner/)                   | Deep code simplification and refactoring — structural complexity analysis, anti-pattern detection, idiomatic rewrites across Python, Go, TS, Rust  |
 | [manuscript-review](skills/manuscript-review/)         | Pre-publication manuscript audit with 24 diagnostic dimensions, citation hygiene, and cross-element coherence                                      |
 | [manuscript-provenance](skills/manuscript-provenance/) | Computational provenance audit verifying every number, table, and figure in a manuscript traces back to code                                       |
 | [repo-sentinel](skills/repo-sentinel/)                 | Security audit and enforcement for public repos — 12 attack surfaces, pre-release readiness, history scrubbing, CI gates                           |

--- a/skills.yaml
+++ b/skills.yaml
@@ -28,6 +28,16 @@ skills:
     security", "enterprise readiness", "architecture assessment", "technical due diligence", or when user provides a system
     design document or codebase and asks for feedback or improvements.'
   path: skills/architecture-reviewer
+- name: code-refiner
+  version: 1.0.0
+  description: 'Deep code simplification, refactoring, and quality refinement. Analyzes structural complexity, anti-patterns,
+    and readability debt, then applies targeted refactoring preserving exact behavior. Language-agnostic: Python, Go, TypeScript/JavaScript,
+    Rust. Use this skill when the goal is simplification and clarity rather than bug-finding. Triggers on: "simplify this
+    code", "clean up my code", "refactor for clarity", "reduce complexity", "make this more readable", "code quality pass",
+    "tech debt cleanup", "run the code refiner", "simplify recent changes", "this code is messy", "too much nesting", "this
+    function is too long", "clean this up before I PR it", "tidy up my code", cyclomatic complexity, cognitive complexity,
+    code smells.'
+  path: skills/code-refiner
 - name: concept-to-image
   version: 1.0.0
   description: 'Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG

--- a/skills/code-refiner/SKILL.md
+++ b/skills/code-refiner/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: code-refiner
+description: >
+  Deep code simplification, refactoring, and quality refinement. Analyzes structural complexity,
+  anti-patterns, and readability debt, then applies targeted refactoring preserving exact behavior.
+  Language-agnostic: Python, Go, TypeScript/JavaScript, Rust. Use this skill when the goal is
+  simplification and clarity rather than bug-finding. Triggers on: "simplify this code",
+  "clean up my code", "refactor for clarity", "reduce complexity", "make this more readable",
+  "code quality pass", "tech debt cleanup", "run the code refiner", "simplify recent changes",
+  "this code is messy", "too much nesting", "this function is too long", "clean this up before
+  I PR it", "tidy up my code", cyclomatic complexity, cognitive complexity, code smells.
+metadata:
+  version: 1.0.0
+---
+
+# Code Refiner
+
+A structured, multi-pass code refinement skill that transforms complex, verbose, or tangled code
+into clean, idiomatic, maintainable implementations — without changing what the code does.
+
+## Philosophy
+
+The goal is **not** fewer lines. The goal is code that a tired engineer at 2am can read, understand,
+and safely modify. Every change must pass three tests:
+
+1. **Behavioral equivalence** — identical inputs produce identical outputs, side effects, and errors
+2. **Cognitive load reduction** — a reader unfamiliar with the code understands it faster after the change
+3. **Maintenance leverage** — the change makes future modifications easier, not harder
+
+When clarity and brevity conflict, clarity wins. When idiom and explicitness conflict, consider the
+team's experience level. When DRY and locality conflict, prefer locality for code read more than modified.
+
+## Prerequisites
+
+- **git** — used in Phase 1 for scope detection (`git diff`) when the user doesn't specify target files
+- **Python 3.10+** — required to run `scripts/complexity_report.py` for quantitative complexity metrics
+
+## Workflow
+
+Follow this sequence. Each phase builds on the previous one. Do not skip phases, but adapt depth
+to the scope of the request (a single function gets a lighter pass than a full module).
+
+### Phase 1: Reconnaissance
+
+Before touching anything, build a mental model:
+
+1. **Identify scope** — What files/functions are in play? If the user hasn't specified, check recent
+   git modifications: `git diff --name-only HEAD~5` or `git diff --staged --name-only`
+2. **Detect language and ecosystem** — Read file extensions, imports, config files (package.json,
+   pyproject.toml, go.mod, Cargo.toml). Load the appropriate language reference from
+   `references/` if needed for idiom-specific guidance
+3. **Read project conventions** — Check for CLAUDE.md, .editorconfig, linter configs (eslint,
+   ruff, golangci-lint, clippy). These override generic idiom preferences
+4. **Understand test coverage** — Locate test files. If tests exist, note the test runner so you
+   can verify behavioral equivalence after changes
+5. **Baseline complexity snapshot** — For each target function/method, mentally note:
+   - Nesting depth (max indentation levels)
+   - Number of branches (if/else/match/switch arms)
+   - Number of early returns vs single-exit
+   - Parameter count
+   - Lines of code
+   - Number of responsibilities (does it do more than one thing?)
+
+### Phase 2: Structural Analysis
+
+Identify what's actually wrong before reaching for solutions. Categorize issues by severity:
+
+**Critical** (always fix):
+- Dead code (unreachable branches, unused variables/imports)
+- Redundant operations (double-checking the same condition, re-computing cached values)
+- Logic that can be replaced by a stdlib/language built-in
+- Mutation of shared state that could be avoided
+
+**High** (fix unless there's a clear reason not to):
+- Functions with >3 levels of nesting
+- Functions with >5 parameters
+- God functions (>40 lines or >3 responsibilities)
+- Repeated code blocks (3+ occurrences of similar logic)
+- Inverted or confusing boolean logic
+- Stringly-typed enumerations
+
+**Medium** (fix when it improves clarity without adding risk):
+- Unclear variable/function names
+- Missing or misleading type annotations
+- Unnecessary intermediate variables
+- Over-abstraction (wrappers that add no value)
+- Comments that restate the code instead of explaining *why*
+
+**Low** (fix only in a dedicated cleanup pass):
+- Inconsistent formatting (defer to linter)
+- Import ordering
+- Trailing whitespace, line length
+
+### Phase 3: Refactoring Execution
+
+Apply changes using these tactics, ordered by impact-to-risk ratio:
+
+#### 3a. Eliminate Dead Weight
+Remove before restructuring. Less code = less to think about.
+- Delete unused imports, variables, functions
+- Remove unreachable branches (but verify they're truly unreachable)
+- Strip comments that restate the obvious (keep comments that explain *why*)
+- Remove no-op wrapper functions that just forward calls
+
+#### 3b. Flatten Structure
+Reduce nesting and cognitive load:
+- **Guard clauses**: Convert deep `if` nesting to early returns
+- **Extract conditions**: Name complex boolean expressions (`is_valid_order = ...`)
+- **Decompose loops**: If a loop does filter + transform + accumulate, break it apart
+  (or use language-appropriate constructs: list comprehensions, iterators, streams)
+- **Invert conditionals**: When the `else` branch is the "happy path", flip it
+
+#### 3c. Consolidate and Name
+Make the code's intent visible:
+- **Extract functions** for repeated logic or distinct responsibilities
+  - Name by *what it accomplishes*, not *how it works*
+  - Functions should do one thing at one level of abstraction
+- **Replace magic values** with named constants
+- **Rename for intent**: `data` → `user_records`, `process` → `validate_and_enqueue`
+- **Group related parameters** into a config/options struct when count > 3
+
+#### 3d. Leverage Language Idioms
+Apply language-specific patterns (consult `references/<language>.md` for details):
+- Python: comprehensions, context managers, dataclasses, structural pattern matching
+- Go: table-driven tests, error wrapping, functional options, interface satisfaction
+- TypeScript: discriminated unions, branded types, const assertions, satisfies
+- Rust: iterator chains, `?` operator, From/Into, newtype pattern
+
+#### 3e. Tighten Types
+Types are documentation that the compiler checks:
+- Add return type annotations to public functions
+- Replace stringly-typed parameters with enums/unions
+- Narrow `any`/`interface{}` to specific types where possible
+- Use branded/newtype patterns for identifiers that shouldn't be confused
+
+### Phase 4: Verification
+
+**Never skip this phase.** Simplification that breaks behavior is not simplification.
+
+1. **Run existing tests** — If a test suite exists, run it. Report pass/fail.
+2. **Run linter/type checker** — If configured, run it. Fix new violations your changes introduced.
+3. **Manual trace** — For each refactored function, mentally trace one happy-path and one
+   error-path input through the old and new code. Confirm identical behavior.
+4. **Side effect audit** — If the original code had side effects (I/O, mutation, logging),
+   verify the new code preserves them in the same order and conditions.
+
+If tests fail or behavior diverges: revert the specific change, don't try to fix the test.
+
+### Phase 5: Report
+
+Present changes as a structured summary. This is important — the developer needs to understand
+and trust what changed before committing.
+
+For each file modified, provide:
+
+```
+## <filename>
+
+### Changes
+- [Critical] Removed unreachable error branch in `parse_config` (dead code after L42 guard)
+- [High] Extracted `validate_credentials()` from 60-line `handle_login()` (was 3 responsibilities)
+- [Medium] Renamed `d` → `document`, `proc` → `process_batch`
+
+### Complexity Delta
+- `handle_login`: 4 levels nesting → 2, 8 branches → 5
+- `parse_config`: removed 12 lines of dead code
+
+### Risk Assessment
+- Low risk: all changes are structural, no logic modifications
+- Tests: 47/47 passing
+```
+
+Adjust verbosity to scope. Single-function cleanup gets a one-liner. Multi-file refactor gets the full report.
+
+## Behavioral Constraints
+
+These are hard rules. Do not violate them regardless of how much cleaner the code would look:
+
+1. **Never change observable behavior** — This includes error messages, log output, return values,
+   side effect ordering, and exception types
+2. **Never remove error handling** — Even if it looks redundant. Defensive code often exists
+   for a reason you can't see from the code alone
+3. **Never introduce new dependencies** — Simplification adds nothing to the dependency tree
+4. **Never refactor code outside the specified scope** — Unless the user explicitly asks for a
+   broader pass. Resist the urge to "fix one more thing"
+5. **Preserve public API surfaces** — Function signatures, export names, and type definitions
+   visible to consumers do not change without explicit user approval
+6. **Respect existing tests** — If a test asserts specific behavior, that behavior is a requirement,
+   even if it seems wrong. Flag it in the report, don't change it
+
+## Configuring Scope and Aggressiveness
+
+The user may specify different modes. If they don't, default to **standard**.
+
+| Mode | Scope | Severity Threshold | Test Requirement |
+|------|-------|--------------------|------------------|
+| `quick` | Single file or function | Critical + High only | Tests recommended |
+| `standard` | Recent git changes | Critical + High + Medium | Tests required if they exist |
+| `deep` | Entire module/package | All severities | Tests mandatory |
+| `surgical` | User-specified lines/functions | All severities | Manual trace sufficient |
+
+The user can specify mode by saying things like "just do a quick pass" or "deep clean this module".
+
+## When NOT to Refine
+
+Push back (politely) if:
+- The code has no tests and the user wants a deep refactor → suggest writing tests first
+- The code is auto-generated (protobuf, OpenAPI, ORM models) → suggest modifying the generator
+- The request is really a feature change disguised as "cleanup" → clarify intent
+- The code is in a hot path and "simplification" would introduce allocation/copies → flag the tradeoff
+
+## Language References
+
+For language-specific idiom guidance, read the appropriate reference file:
+
+- `references/python.md` — Python-specific patterns, anti-patterns, and stdlib alternatives
+- `references/go.md` — Go idioms, error handling patterns, and interface design
+- `references/typescript.md` — TypeScript/JavaScript patterns, type narrowing, and module design
+- `references/rust.md` — Rust idioms, ownership patterns, and iterator usage
+
+Only load the reference file for the language(s) in the current scope. These provide detailed
+pattern catalogs that supplement the general methodology above.

--- a/skills/code-refiner/references/go.md
+++ b/skills/code-refiner/references/go.md
@@ -1,0 +1,167 @@
+# Go Refinement Patterns
+
+## Table of Contents
+1. [Error Handling](#error-handling)
+2. [Structural Patterns](#structural-patterns)
+3. [Interface Design](#interface-design)
+4. [Concurrency](#concurrency)
+5. [Anti-Patterns](#anti-patterns)
+
+---
+
+## Error Handling
+
+### Wrap Errors with Context
+```go
+// Before
+if err != nil {
+    return err
+}
+
+// After — adds context for debugging
+if err != nil {
+    return fmt.Errorf("parsing config %s: %w", path, err)
+}
+```
+
+### Sentinel Errors for Expected Conditions
+```go
+var ErrNotFound = errors.New("record not found")
+
+// Callers check with errors.Is:
+if errors.Is(err, ErrNotFound) { ... }
+```
+
+### Error Type Assertion
+```go
+var pathErr *os.PathError
+if errors.As(err, &pathErr) {
+    log.Printf("failed path: %s", pathErr.Path)
+}
+```
+
+### Don't Log and Return
+Either log the error (if you're the handler) or return it (if you're a library).
+Never both — it creates duplicate noise.
+
+---
+
+## Structural Patterns
+
+### Table-Driven Tests
+Replace repetitive test functions with a test table:
+```go
+tests := []struct {
+    name     string
+    input    string
+    expected int
+    wantErr  bool
+}{
+    {"empty", "", 0, true},
+    {"valid", "42", 42, false},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        got, err := Parse(tt.input)
+        if (err != nil) != tt.wantErr {
+            t.Errorf("unexpected error: %v", err)
+        }
+        if got != tt.expected {
+            t.Errorf("got %d, want %d", got, tt.expected)
+        }
+    })
+}
+```
+
+### Functional Options
+Replace large config structs with functional options for optional configuration:
+```go
+type Option func(*Server)
+
+func WithPort(port int) Option {
+    return func(s *Server) { s.port = port }
+}
+
+func NewServer(opts ...Option) *Server {
+    s := &Server{port: 8080} // sensible defaults
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+### Guard Clauses
+Same principle as other languages — exit early, keep the happy path at the lowest indent:
+```go
+func (s *Service) Process(ctx context.Context, req *Request) error {
+    if req == nil {
+        return errors.New("nil request")
+    }
+    if err := req.Validate(); err != nil {
+        return fmt.Errorf("invalid request: %w", err)
+    }
+    // Happy path at indent level 1
+    return s.store.Save(ctx, req)
+}
+```
+
+---
+
+## Interface Design
+
+### Accept Interfaces, Return Structs
+Functions should accept the narrowest interface they need and return concrete types.
+
+### Small Interfaces
+Prefer 1-2 method interfaces. Compose larger behaviors from small interfaces.
+```go
+type Reader interface { Read(p []byte) (n int, err error) }
+type Writer interface { Write(p []byte) (n int, err error) }
+type ReadWriter interface { Reader; Writer }
+```
+
+### Define Interfaces at the Consumer
+The package that *uses* the interface should define it, not the package that implements it.
+This keeps dependencies flowing in one direction.
+
+---
+
+## Concurrency
+
+### Use `errgroup` for Parallel Work with Error Collection
+```go
+g, ctx := errgroup.WithContext(ctx)
+for _, url := range urls {
+    g.Go(func() error {
+        return fetch(ctx, url)
+    })
+}
+if err := g.Wait(); err != nil {
+    return err
+}
+```
+
+### Don't Start Goroutines in Library Code Without Lifecycle Control
+If you must, accept a context and/or return a cleanup function.
+
+### Channel Direction Annotations
+```go
+func producer(ch chan<- int) { ... }  // send only
+func consumer(ch <-chan int) { ... }  // receive only
+```
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|-------------|-----|
+| `init()` with side effects | Move to explicit initialization function |
+| Package-level `var` for mutable state | Pass dependencies explicitly |
+| `interface{}` / `any` when concrete type is known | Use the concrete type or a constrained generic |
+| Panicking in library code | Return errors |
+| Ignoring errors with `_` | Handle or wrap. If truly ignorable, add a comment explaining why |
+| `sync.Mutex` protecting a single field | Consider `atomic` types |
+| Channels for simple mutual exclusion | Use `sync.Mutex` |
+| Deeply nested `if err != nil` chains | Extract into helper functions with named returns |

--- a/skills/code-refiner/references/python.md
+++ b/skills/code-refiner/references/python.md
@@ -1,0 +1,202 @@
+# Python Refinement Patterns
+
+## Table of Contents
+1. [Structural Patterns](#structural-patterns)
+2. [Anti-Patterns to Eliminate](#anti-patterns-to-eliminate)
+3. [Stdlib Replacements](#stdlib-replacements)
+4. [Type Annotation Guidance](#type-annotation-guidance)
+5. [Modern Python (3.10+)](#modern-python)
+
+---
+
+## Structural Patterns
+
+### Guard Clauses over Nested Conditionals
+
+```python
+# Before
+def process_order(order):
+    if order is not None:
+        if order.is_valid():
+            if order.has_inventory():
+                return fulfill(order)
+            else:
+                return "out of stock"
+        else:
+            return "invalid order"
+    else:
+        return "no order"
+
+# After
+def process_order(order):
+    if order is None:
+        return "no order"
+    if not order.is_valid():
+        return "invalid order"
+    if not order.has_inventory():
+        return "out of stock"
+    return fulfill(order)
+```
+
+### Comprehensions over Accumulator Loops
+
+Replace manual append loops with comprehensions when the logic is a straightforward
+filter-map. Do NOT use comprehensions for complex multi-step logic or side effects.
+
+```python
+# Replace: filter + transform
+results = []
+for item in items:
+    if item.is_active():
+        results.append(item.name.lower())
+# With:
+results = [item.name.lower() for item in items if item.is_active()]
+
+# Do NOT replace: complex logic with side effects
+for item in items:
+    validated = validate(item)  # may raise
+    cache.store(validated)
+    results.append(validated.id)
+```
+
+### Context Managers for Resource Cleanup
+
+Any open/close, acquire/release, setup/teardown pair should use a context manager.
+
+```python
+# Before
+f = open(path)
+try:
+    data = f.read()
+finally:
+    f.close()
+
+# After
+with open(path) as f:
+    data = f.read()
+```
+
+For custom resources, prefer `contextlib.contextmanager` over writing `__enter__`/`__exit__`
+for simple cases.
+
+### Dataclasses over Raw Dicts/Tuples
+
+When a dict has a fixed schema, replace with a dataclass. This gives you type checking,
+immutability options, and readable attribute access.
+
+```python
+# Before
+config = {"host": "localhost", "port": 8080, "debug": True}
+
+# After
+@dataclass(frozen=True)
+class Config:
+    host: str
+    port: int
+    debug: bool = False
+```
+
+---
+
+## Anti-Patterns to Eliminate
+
+### Bare `except`
+Always catch specific exceptions. `except Exception` is acceptable as a last resort
+with logging; bare `except:` catches SystemExit and KeyboardInterrupt.
+
+### Mutable Default Arguments
+```python
+# Bug: shared mutable default
+def append_to(item, target=[]):  # WRONG
+    target.append(item)
+    return target
+
+# Fix:
+def append_to(item, target=None):
+    if target is None:
+        target = []
+    target.append(item)
+    return target
+```
+
+### Type Checking with `type()` instead of `isinstance()`
+`isinstance()` respects inheritance and supports union checks.
+
+### String Concatenation in Loops
+Use `"".join()` or f-strings. Repeated `+=` on strings creates O(n²) behavior.
+
+### Redundant Boolean Comparisons
+```python
+# Before
+if is_valid == True:
+if len(items) > 0:
+if result is not None:
+
+# After
+if is_valid:
+if items:
+if result is not None:  # Keep this one — explicit None check is intentional
+```
+Note: `if x is not None` is NOT the same as `if x`. Keep explicit None checks.
+
+---
+
+## Stdlib Replacements
+
+| Pattern | Replace With |
+|---------|-------------|
+| Manual dict grouping loop | `collections.defaultdict` or `itertools.groupby` |
+| `dict.get(k)` then check None | `dict.setdefault(k, default)` or `collections.defaultdict` |
+| Manual counter loop | `collections.Counter` |
+| Nested dict access with KeyError handling | `dict.get(k, {}).get(k2, default)` or a helper |
+| Manual LRU cache | `functools.lru_cache` or `functools.cache` (3.9+) |
+| Manual partial application | `functools.partial` |
+| Manual chain of iterables | `itertools.chain` |
+| `os.path.join` + `os.path.exists` | `pathlib.Path` |
+| `subprocess.Popen` for simple commands | `subprocess.run` |
+| Manual retry loops | Consider `tenacity` if already a dependency, otherwise a small helper |
+
+---
+
+## Type Annotation Guidance
+
+- Annotate all public function signatures (parameters + return)
+- Use `X | None` (3.10+) instead of `Optional[X]`
+- Use `list[str]` (3.9+) instead of `List[str]`
+- Use `TypeAlias` for complex types used more than once
+- Use `Protocol` over ABC when you only need structural typing
+- Use `@overload` when return type depends on input type
+
+---
+
+## Modern Python
+
+### Structural Pattern Matching (3.10+)
+Replace complex if/elif chains on type/structure with `match`:
+
+```python
+# Before
+if isinstance(event, ClickEvent):
+    handle_click(event.x, event.y)
+elif isinstance(event, KeyEvent) and event.key == "enter":
+    handle_submit()
+elif isinstance(event, KeyEvent):
+    handle_key(event.key)
+
+# After
+match event:
+    case ClickEvent(x=x, y=y):
+        handle_click(x, y)
+    case KeyEvent(key="enter"):
+        handle_submit()
+    case KeyEvent(key=key):
+        handle_key(key)
+```
+
+Only use when there are 3+ branches and the pattern destructuring adds clarity.
+
+### Exception Groups (3.11+)
+For concurrent error collection, use `ExceptionGroup` and `except*`.
+
+### `tomllib` (3.11+)
+Don't use third-party TOML parsers if you only need reading.

--- a/skills/code-refiner/references/rust.md
+++ b/skills/code-refiner/references/rust.md
@@ -1,0 +1,162 @@
+# Rust Refinement Patterns
+
+## Table of Contents
+1. [Error Handling](#error-handling)
+2. [Iterator Patterns](#iterator-patterns)
+3. [Ownership and Borrowing](#ownership-and-borrowing)
+4. [Type Design](#type-design)
+5. [Anti-Patterns](#anti-patterns)
+
+---
+
+## Error Handling
+
+### `?` Operator over Match Chains
+```rust
+// Before
+fn read_config(path: &str) -> Result<Config, Error> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => return Err(e.into()),
+    };
+    let contents = match read_to_string(file) {
+        Ok(c) => c,
+        Err(e) => return Err(e.into()),
+    };
+    Ok(parse(contents)?)
+}
+
+// After
+fn read_config(path: &str) -> Result<Config, Error> {
+    let contents = std::fs::read_to_string(path)?;
+    Ok(parse(&contents)?)
+}
+```
+
+### Custom Error Types with `thiserror`
+```rust
+#[derive(Debug, thiserror::Error)]
+enum AppError {
+    #[error("config not found: {path}")]
+    ConfigNotFound { path: PathBuf },
+    #[error("parse error at line {line}")]
+    ParseError { line: usize, #[source] cause: serde_json::Error },
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+```
+
+### `anyhow` for Application Code, `thiserror` for Libraries
+Applications use `anyhow::Result` for convenience. Libraries define explicit error types.
+
+---
+
+## Iterator Patterns
+
+### Chain over Manual Loops
+```rust
+// Before
+let mut results = Vec::new();
+for item in items {
+    if item.is_active() {
+        results.push(item.name().to_lowercase());
+    }
+}
+
+// After
+let results: Vec<String> = items.iter()
+    .filter(|item| item.is_active())
+    .map(|item| item.name().to_lowercase())
+    .collect();
+```
+
+### `flat_map` for Nested Iteration
+```rust
+let all_tags: Vec<&str> = posts.iter()
+    .flat_map(|post| post.tags.iter())
+    .map(|tag| tag.as_str())
+    .collect();
+```
+
+### `fold` / `reduce` for Accumulation
+Prefer `.sum()`, `.product()`, `.min()`, `.max()` when they apply directly.
+Use `.fold()` for custom accumulation.
+
+### Avoid `.clone()` in Iterator Chains
+If you're cloning inside `.map()`, check if you can restructure to borrow instead.
+Sometimes moving the `.collect()` earlier or changing the return type eliminates the need.
+
+---
+
+## Ownership and Borrowing
+
+### Accept `&str` not `String` in Function Parameters
+Unless the function needs to own the string:
+```rust
+fn greet(name: &str) -> String {        // borrows
+    format!("Hello, {name}")
+}
+fn store_name(name: String) { ... }      // takes ownership — caller decides when to clone
+```
+
+### `impl Trait` in Argument Position
+Prefer `impl AsRef<Path>` over `&Path` for flexibility:
+```rust
+fn read_file(path: impl AsRef<Path>) -> io::Result<String> {
+    std::fs::read_to_string(path)
+}
+```
+
+### Cow for Conditional Ownership
+```rust
+fn normalize(input: &str) -> Cow<'_, str> {
+    if input.contains(' ') {
+        Cow::Owned(input.replace(' ', "_"))
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+```
+
+---
+
+## Type Design
+
+### Newtype Pattern
+Prevent primitive obsession and make the type system work for you:
+```rust
+struct UserId(u64);
+struct OrderId(u64);
+// These are distinct types — can't accidentally pass UserId where OrderId expected
+```
+
+### Builder Pattern for Complex Construction
+When a struct has >3 optional fields, use a builder instead of dozens of `new_with_*` variants.
+
+### `From` / `Into` for Type Conversions
+Implement `From<A> for B` to get `Into<B> for A` automatically.
+Idiomatic for error type conversion and newtype unwrapping.
+
+### Enum State Machines
+Encode valid states as enum variants. Invalid transitions become compile errors:
+```rust
+enum Connection {
+    Disconnected,
+    Connecting { attempt: u32 },
+    Connected { session: Session },
+}
+```
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|-------------|-----|
+| `.unwrap()` in library code | Return `Result` or `Option` |
+| `.clone()` to satisfy borrow checker without understanding why | Restructure lifetimes or use `Rc`/`Arc` if shared ownership is needed |
+| `String` in struct fields that are always static | Use `&'static str` or `Cow<'static, str>` |
+| `Box<dyn Error>` in library error types | Use `thiserror` enum |
+| Manual `impl Display` + `impl Error` | Use `thiserror` derive |
+| `Arc<Mutex<Vec<T>>>` as default concurrency pattern | Consider channels, `dashmap`, or redesign for less sharing |
+| Returning `impl Iterator` when the caller needs to store it | Return a concrete type or `Box<dyn Iterator>` |

--- a/skills/code-refiner/references/typescript.md
+++ b/skills/code-refiner/references/typescript.md
@@ -1,0 +1,170 @@
+# TypeScript / JavaScript Refinement Patterns
+
+## Table of Contents
+1. [Type System Leverage](#type-system-leverage)
+2. [Structural Patterns](#structural-patterns)
+3. [Module Design](#module-design)
+4. [Anti-Patterns](#anti-patterns)
+5. [React Specific](#react-specific)
+
+---
+
+## Type System Leverage
+
+### Discriminated Unions over Type Guards
+```typescript
+// Before — stringly typed, easy to miss a case
+type Event = { type: string; payload: unknown };
+
+function handle(event: Event) {
+    if (event.type === "click") { ... }
+    else if (event.type === "key") { ... }
+}
+
+// After — exhaustive, compiler-checked
+type Event =
+    | { type: "click"; x: number; y: number }
+    | { type: "key"; key: string };
+
+function handle(event: Event) {
+    switch (event.type) {
+        case "click": return handleClick(event.x, event.y);
+        case "key": return handleKey(event.key);
+    }
+    // Exhaustiveness: event is `never` here
+    const _exhaustive: never = event;
+}
+```
+
+### `satisfies` for Validated Object Literals
+```typescript
+const config = {
+    port: 8080,
+    host: "localhost",
+} satisfies ServerConfig;
+// Type is inferred precisely (literal types), but validated against ServerConfig
+```
+
+### Branded Types for Domain Identifiers
+```typescript
+type UserId = string & { readonly __brand: "UserId" };
+type OrderId = string & { readonly __brand: "OrderId" };
+
+// Prevents accidentally passing a UserId where OrderId is expected
+function getOrder(id: OrderId): Order { ... }
+```
+
+### `const` Assertions for Immutable Literals
+```typescript
+const DIRECTIONS = ["north", "south", "east", "west"] as const;
+type Direction = typeof DIRECTIONS[number]; // "north" | "south" | "east" | "west"
+```
+
+---
+
+## Structural Patterns
+
+### Early Returns / Guard Clauses
+Same principle as all languages. Flatten the happy path:
+```typescript
+// Before — deeply nested
+async function processRequest(req: Request): Promise<Response> {
+    if (req.body) {
+        const parsed = JSON.parse(req.body);
+        if (parsed.userId) {
+            const user = await getUser(parsed.userId);
+            if (user) {
+                return buildResponse(user);
+            }
+        }
+    }
+    return errorResponse(400);
+}
+
+// After
+async function processRequest(req: Request): Promise<Response> {
+    if (!req.body) return errorResponse(400);
+    const parsed = JSON.parse(req.body);
+    if (!parsed.userId) return errorResponse(400);
+    const user = await getUser(parsed.userId);
+    if (!user) return errorResponse(400);
+    return buildResponse(user);
+}
+```
+
+### Object Destructuring for Clarity
+```typescript
+// Before
+function render(props: Props) {
+    return h("div", null, props.title, props.description, props.author.name);
+}
+
+// After
+function render({ title, description, author: { name } }: Props) {
+    return h("div", null, title, description, name);
+}
+```
+
+### `Map` / `Set` over Object Lookup
+When keys are dynamic or non-string, use `Map`/`Set`. They have proper iteration
+order, `.size`, and don't conflict with prototype properties.
+
+---
+
+## Module Design
+
+### Named Exports over Default
+Named exports enable better tree-shaking, refactoring support, and import consistency.
+
+### Barrel Files — Use Sparingly
+`index.ts` re-exports are convenient but can break tree-shaking and create circular
+dependency issues. Use for public API surfaces, not internal organization.
+
+### Explicit Extensions in Imports
+For ESM projects, include `.js` extensions in import paths (even for `.ts` source files
+when targeting Node ESM).
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|-------------|-----|
+| `any` type annotations | Narrow to specific types; use `unknown` + type guards if truly dynamic |
+| Nested ternaries | `switch`, if/else chain, or extracted function |
+| `== null` vs `=== null` | Use `== null` to catch both null and undefined (this is intentional) |
+| `Promise` constructor for async/await wrapping | Just use `async`/`await` directly |
+| `setTimeout(fn, 0)` for ordering | Use `queueMicrotask` or restructure logic |
+| `for...in` on arrays | Use `for...of`, `.forEach()`, or array methods |
+| Throwing strings | Throw `Error` instances (preserves stack traces) |
+| Enum with string values for simple union | Use string literal union type instead |
+
+---
+
+## React Specific
+
+### Component Extraction Signals
+Extract a component when:
+- A JSX block has its own state or effects
+- The same markup pattern appears 3+ times
+- A section has a distinct responsibility (form, list, header)
+
+### Hook Composition
+Extract custom hooks when:
+- Multiple state/effect pairs work together
+- The same hook combination appears in multiple components
+- Business logic can be separated from presentation
+
+### Avoid Inline Object/Array Literals in JSX Props
+```tsx
+// Before — creates new reference every render, breaks memoization
+<Chart options={{ animate: true }} data={[1, 2, 3]} />
+
+// After
+const chartOptions = useMemo(() => ({ animate: true }), []);
+const data = useMemo(() => [1, 2, 3], []);
+<Chart options={chartOptions} data={data} />
+```
+
+### Prefer `key` on List Items from Stable Identifiers
+Never use array index as key for lists that can reorder.

--- a/skills/code-refiner/scripts/complexity_report.py
+++ b/skills/code-refiner/scripts/complexity_report.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Lightweight code complexity analyzer.
+Produces a JSON report of per-function complexity metrics for Python, Go, TS/JS files.
+No external dependencies — uses AST parsing for Python, regex heuristics for others.
+
+Usage:
+    python complexity_report.py <file_or_directory> [--format json|markdown]
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+
+@dataclass
+class FunctionMetrics:
+    file: str
+    name: str
+    line_start: int
+    line_end: int
+    lines_of_code: int
+    max_nesting_depth: int
+    branch_count: int  # if/elif/else/match/case/for/while/try/except
+    parameter_count: int
+    return_count: int
+    cognitive_complexity: int  # simplified cognitive complexity score
+
+
+@dataclass
+class FileReport:
+    file: str
+    language: str
+    total_lines: int
+    functions: list
+    dead_imports: list  # Python only
+
+
+# ---------------------------------------------------------------------------
+# Python analysis (AST-based, precise)
+# ---------------------------------------------------------------------------
+
+class PythonAnalyzer(ast.NodeVisitor):
+    def __init__(self, source: str, filepath: str):
+        self.source = source
+        self.filepath = filepath
+        self.functions: list[FunctionMetrics] = []
+        self.imports: set[str] = set()
+        self.used_names: set[str] = set()
+        self._lines = source.splitlines()
+
+    def analyze(self) -> FileReport:
+        tree = ast.parse(self.source)
+        self.visit(tree)
+        # Detect potentially unused imports (heuristic)
+        dead = sorted(self.imports - self.used_names)
+        return FileReport(
+            file=self.filepath,
+            language="python",
+            total_lines=len(self._lines),
+            functions=[asdict(f) for f in self.functions],
+            dead_imports=dead,
+        )
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            name = alias.asname or alias.name.split(".")[0]
+            self.imports.add(name)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        for alias in node.names:
+            name = alias.asname or alias.name
+            self.imports.add(name)
+        self.generic_visit(node)
+
+    def visit_Name(self, node):
+        self.used_names.add(node.id)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        self._analyze_function(node)
+
+    def visit_AsyncFunctionDef(self, node):
+        self._analyze_function(node)
+
+    def _analyze_function(self, node):
+        metrics = FunctionMetrics(
+            file=self.filepath,
+            name=node.name,
+            line_start=node.lineno,
+            line_end=node.end_lineno or node.lineno,
+            lines_of_code=(node.end_lineno or node.lineno) - node.lineno + 1,
+            max_nesting_depth=self._max_nesting(node),
+            branch_count=self._count_branches(node),
+            parameter_count=len(node.args.args) + len(node.args.kwonlyargs),
+            return_count=self._count_returns(node),
+            cognitive_complexity=self._cognitive_complexity(node),
+        )
+        self.functions.append(metrics)
+        self.generic_visit(node)
+
+    def _max_nesting(self, node, depth=0) -> int:
+        max_d = depth
+        for child in ast.walk(node):
+            if isinstance(child, (ast.If, ast.For, ast.While, ast.With, ast.Try,
+                                  ast.ExceptHandler, ast.Match)):
+                child_depth = self._nesting_depth_of(child, node)
+                max_d = max(max_d, child_depth)
+        return max_d
+
+    def _nesting_depth_of(self, target, root) -> int:
+        """Count nesting depth of target relative to root."""
+        nesting_types = (ast.If, ast.For, ast.While, ast.With, ast.Try,
+                         ast.ExceptHandler, ast.Match, ast.FunctionDef,
+                         ast.AsyncFunctionDef)
+        depth = 0
+        for node in ast.walk(root):
+            if node is target:
+                return depth
+            if isinstance(node, nesting_types) and node is not root:
+                depth += 1
+        return depth
+
+    def _count_branches(self, node) -> int:
+        count = 0
+        for child in ast.walk(node):
+            if isinstance(child, (ast.If, ast.For, ast.While, ast.Try,
+                                  ast.ExceptHandler, ast.Match)):
+                count += 1
+        return count
+
+    def _count_returns(self, node) -> int:
+        return sum(1 for child in ast.walk(node) if isinstance(child, ast.Return))
+
+    def _cognitive_complexity(self, node, nesting=0) -> int:
+        """Simplified cognitive complexity: +1 per branch, +nesting for nested branches."""
+        total = 0
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.If, ast.For, ast.While)):
+                total += 1 + nesting
+                total += self._cognitive_complexity(child, nesting + 1)
+            elif isinstance(child, (ast.Try, ast.ExceptHandler)):
+                total += 1 + nesting
+                total += self._cognitive_complexity(child, nesting + 1)
+            elif isinstance(child, ast.BoolOp):
+                total += 1  # each and/or adds +1
+                total += self._cognitive_complexity(child, nesting)
+            else:
+                total += self._cognitive_complexity(child, nesting)
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Generic analysis (regex-based heuristic for Go, TS, JS, Rust)
+# ---------------------------------------------------------------------------
+
+FUNC_PATTERNS = {
+    "go": re.compile(r"^func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(([^)]*)\)"),
+    "typescript": re.compile(r"(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)"),
+    "javascript": re.compile(r"(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)"),
+    "rust": re.compile(r"(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)"),
+}
+
+BRANCH_KEYWORDS = re.compile(r"\b(if|else if|elif|else|for|while|match|switch|case|try|catch|except)\b")
+
+
+def analyze_generic(source: str, filepath: str, language: str) -> FileReport:
+    lines = source.splitlines()
+    functions: list[FunctionMetrics] = []
+    pattern = FUNC_PATTERNS.get(language)
+
+    if pattern:
+        i = 0
+        while i < len(lines):
+            m = pattern.match(lines[i].strip())
+            if m:
+                name = m.group(1)
+                params = m.group(2).strip()
+                param_count = len([p for p in params.split(",") if p.strip()]) if params else 0
+                start = i + 1
+                # Find function end by brace counting
+                end = _find_block_end(lines, i)
+                block = lines[i:end]
+                block_str = "\n".join(block)
+
+                branches = len(BRANCH_KEYWORDS.findall(block_str))
+                max_nest = _estimate_max_nesting(block)
+                returns = block_str.count("return ")
+
+                functions.append(asdict(FunctionMetrics(
+                    file=filepath,
+                    name=name,
+                    line_start=start,
+                    line_end=end,
+                    lines_of_code=end - i,
+                    max_nesting_depth=max_nest,
+                    branch_count=branches,
+                    parameter_count=param_count,
+                    return_count=returns,
+                    cognitive_complexity=branches + max_nest,  # rough estimate
+                )))
+                i = end
+            else:
+                i += 1
+
+    return FileReport(
+        file=filepath,
+        language=language,
+        total_lines=len(lines),
+        functions=functions,
+        dead_imports=[],
+    )
+
+
+def _find_block_end(lines: list[str], start: int) -> int:
+    depth = 0
+    for i in range(start, len(lines)):
+        depth += lines[i].count("{") - lines[i].count("}")
+        if depth <= 0 and i > start:
+            return i + 1
+    return len(lines)
+
+
+def _estimate_max_nesting(block: list[str]) -> int:
+    """Estimate max nesting by indentation delta."""
+    if not block:
+        return 0
+    base_indent = len(block[0]) - len(block[0].lstrip())
+    max_depth = 0
+    for line in block:
+        if line.strip():
+            indent = len(line) - len(line.lstrip())
+            depth = max(0, (indent - base_indent) // 4)  # assume 4-space or tab
+            max_depth = max(max_depth, depth)
+    return max_depth
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+LANG_MAP = {
+    ".py": "python",
+    ".go": "go",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".rs": "rust",
+}
+
+
+def analyze_file(filepath: str) -> FileReport | None:
+    path = Path(filepath)
+    lang = LANG_MAP.get(path.suffix)
+    if not lang:
+        return None
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+
+    if lang == "python":
+        try:
+            return PythonAnalyzer(source, filepath).analyze()
+        except SyntaxError:
+            return None
+    else:
+        return analyze_generic(source, filepath, lang)
+
+
+def analyze_path(target: str) -> list[dict]:
+    target_path = Path(target)
+    reports = []
+
+    if target_path.is_file():
+        report = analyze_file(str(target_path))
+        if report:
+            reports.append(asdict(report))
+    elif target_path.is_dir():
+        for root, dirs, files in os.walk(target_path):
+            # Skip hidden dirs and common non-source dirs
+            dirs[:] = [d for d in dirs if not d.startswith(".")
+                       and d not in ("node_modules", "vendor", "__pycache__", "target", ".git")]
+            for f in sorted(files):
+                fpath = os.path.join(root, f)
+                report = analyze_file(fpath)
+                if report:
+                    reports.append(asdict(report))
+
+    return reports
+
+
+def format_markdown(reports: list[dict]) -> str:
+    lines = ["# Complexity Report\n"]
+    for r in reports:
+        lines.append(f"## {r['file']} ({r['language']}, {r['total_lines']} lines)\n")
+        if r["dead_imports"]:
+            lines.append(f"⚠️  Potentially unused imports: {', '.join(r['dead_imports'])}\n")
+        if r["functions"]:
+            lines.append("| Function | Lines | Nesting | Branches | Params | Cognitive |")
+            lines.append("|----------|-------|---------|----------|--------|-----------|")
+            for f in r["functions"]:
+                flag = " ⚠️" if f["cognitive_complexity"] > 10 or f["max_nesting_depth"] > 3 else ""
+                lines.append(
+                    f"| `{f['name']}` | {f['lines_of_code']} | {f['max_nesting_depth']} | "
+                    f"{f['branch_count']} | {f['parameter_count']} | {f['cognitive_complexity']}{flag} |"
+                )
+            lines.append("")
+        else:
+            lines.append("No functions detected.\n")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file_or_directory> [--format json|markdown]", file=sys.stderr)
+        sys.exit(1)
+
+    target = sys.argv[1]
+    fmt = "json"
+    if "--format" in sys.argv:
+        idx = sys.argv.index("--format")
+        if idx + 1 < len(sys.argv):
+            fmt = sys.argv[idx + 1]
+
+    reports = analyze_path(target)
+
+    if fmt == "markdown":
+        print(format_markdown(reports))
+    else:
+        print(json.dumps(reports, indent=2))


### PR DESCRIPTION
## Summary

- Add **code-refiner** skill — multi-pass code refinement for Python, Go, TypeScript/JavaScript, and Rust
- Structured 5-phase workflow: reconnaissance → structural analysis → refactoring execution → verification → report
- Includes `scripts/complexity_report.py` for quantitative complexity metrics and 4 language-specific reference guides
- Skill evaluated at **91.2% (Exemplary)** via skill-evaluator; all findings addressed before commit
- README catalog updated, skill count bumped to 20, `skills.yaml` manifest regenerated

## Test plan

- [ ] Verify `skills.yaml` lists code-refiner with correct name, version, and description
- [ ] Verify README badge shows 20 skills and code-refiner appears in Review & Quality table
- [ ] Run `python3 skills/code-refiner/scripts/complexity_report.py skills/ --format markdown` to confirm script works
- [ ] Install skill via `claude --add-dir skills/code-refiner` and trigger with "simplify this code"
- [ ] Confirm CI checks pass