### PR TITLE
feat(skills): add web-fetch and filesystem MCP replacement skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 20](https://img.shields.io/badge/skills-20-informational)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 22](https://img.shields.io/badge/skills-22-informational)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -24,9 +24,11 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | [agent-builder](skills/agent-builder/) | Build AI agents using the Claude Agent SDK and headless CLI mode — covers tool definitions, MCP servers, and programmatic orchestration    |
 | [github](skills/github/)               | GitHub CLI operations via `gh` — issues, PRs, CI/Actions, releases, search, REST/GraphQL API, with error handling and automation workflows |
-| [mcp-to-skill](skills/mcp-to-skill/)   | Convert MCP servers into on-demand skills to reduce active context window token usage                                                      |
+| [filesystem](skills/filesystem/)       | File and directory operations via Claude Code built-in tools — replaces the Filesystem MCP server with native Read, Write, Edit, Glob, Grep |
+| [mcp-to-skill](skills/mcp-to-skill/)   | Convert MCP servers into on-demand skills to reduce active context window token usage                                                       |
 | [gpu-optimizer](skills/gpu-optimizer/) | GPU optimization for consumer GPUs (8-24GB VRAM) — PyTorch, XGBoost, CuPy/RAPIDS, memory management, and CUDA tuning                       |
-| [tavily](skills/tavily/)               | AI-optimized web search and content extraction via Tavily API with structured output parsing                                               |
+| [tavily](skills/tavily/)               | AI-optimized web search and content extraction via Tavily API with structured output parsing                                                |
+| [web-fetch](skills/web-fetch/)         | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                       |
 
 ### Review & Quality
 

--- a/skills.yaml
+++ b/skills.yaml
@@ -67,6 +67,16 @@ skills:
     "condense this", "technical summary", "strip the fluff", or "reformat this spec". See assets/template.md for the standard
     output structure.
   path: skills/doc-condenser
+- name: filesystem
+  version: 1.0.0
+  description: 'File and directory operations using Claude Code built-in tools — replaces the Filesystem MCP server. Maps
+    all 11 MCP tools to native equivalents: Read, Write, Edit, Glob, Grep, and Bash. Covers file reading with line ranges,
+    parallel reads, pattern-based file search, regex content search, directory listing, tree traversal, move/copy/rename,
+    and metadata inspection. Trigger phrases: "read this file", "write to file", "create a file", "edit file", "find files
+    matching", "search for text in files", "list directory", "show directory tree", "move file", "rename file", "copy file",
+    "file info", "find all Python files", "search codebase for". Use this skill when performing file operations, navigating
+    codebases, or managing directories.'
+  path: skills/filesystem
 - name: github
   version: 1.0.0
   description: 'GitHub CLI operations via `gh` for issues, pull requests, CI/Actions, releases, repos, search, gists, and
@@ -195,3 +205,13 @@ skills:
     page content", "get article text", "scrape URL". Tavily returns clean, AI-ready snippets — prefer it over raw web fetch
     for search queries. Use extract for full page content when a specific URL is already known.'
   path: skills/tavily
+- name: web-fetch
+  version: 1.0.0
+  description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch MCP server (fetch_html,
+    fetch_json, fetch_markdown, fetch_txt). Covers HTTP GET/POST requests, JSON API consumption with jq, HTML retrieval, markdown
+    conversion, plain text extraction, authenticated requests, redirects, cookies, and timeouts. Trigger phrases: "fetch this
+    URL", "get the page content", "download HTML", "call this API", "curl this endpoint", "grab the JSON", "fetch markdown
+    from", "retrieve web content", "hit this endpoint", "scrape this page", "read this URL", "pull data from API", "make an
+    HTTP request". Use this skill when the user provides a URL and wants its content, when consuming REST APIs, or when extracting
+    readable content from web pages.'
+  path: skills/web-fetch

--- a/skills/filesystem/SKILL.md
+++ b/skills/filesystem/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: filesystem
+description: >
+  File and directory operations using Claude Code built-in tools — replaces the
+  Filesystem MCP server. Maps all 11 MCP tools to native equivalents: Read, Write,
+  Edit, Glob, Grep, and Bash. Covers file reading with line ranges, parallel reads,
+  pattern-based file search, regex content search, directory listing, tree traversal,
+  move/copy/rename, and metadata inspection. Trigger phrases: "read this file",
+  "write to file", "create a file", "edit file", "find files matching", "search for
+  text in files", "list directory", "show directory tree", "move file", "rename file",
+  "copy file", "file info", "find all Python files", "search codebase for". Use this
+  skill when performing file operations, navigating codebases, or managing directories.
+metadata:
+  version: 1.0.0
+---
+
+# Filesystem
+
+All file and directory operations use Claude Code's built-in tools. No MCP server
+needed — native tools are faster, more capable, and cost zero context tokens when idle.
+
+## Quick Reference
+
+| Filesystem MCP Tool | Replacement | Notes |
+|---|---|---|
+| `read_file(path)` | `Read` tool | Supports line offset and limit |
+| `read_multiple_files(paths)` | Multiple parallel `Read` calls | Faster than sequential MCP calls |
+| `write_file(path, content)` | `Write` tool | Overwrites entire file |
+| `edit_file(path, edits)` | `Edit` tool | Exact string replacement; surgical edits |
+| `list_directory(path)` | `Glob` or `Bash ls` | Glob for patterns, ls for simple listing |
+| `directory_tree(path)` | `Bash fd` or `Glob **/*` | fd is fastest; Glob for pattern filtering |
+| `search_files(pattern, path)` | `Grep` tool | Full regex, file type filters, context lines |
+| `create_directory(path)` | `Bash mkdir -p` | `-p` creates intermediate directories |
+| `move_file(src, dst)` | `Bash mv` | Also handles renames |
+| `get_file_info(path)` | `Bash stat` or `Bash ls -la` | Size, permissions, timestamps |
+| `list_allowed_directories` | N/A | Claude Code operates in the working directory; no sandbox restrictions |
+
+---
+
+## Reading Files
+
+### Read a Single File
+
+Use the `Read` tool with an absolute path:
+
+```
+Read: /path/to/file.py
+```
+
+For large files, use offset and limit to read specific sections:
+
+```
+Read: /path/to/file.py (offset: 100, limit: 50)
+```
+
+This reads 50 lines starting from line 100. Use this for files with thousands of lines
+to avoid flooding context.
+
+### Read Multiple Files in Parallel
+
+Issue multiple `Read` calls in a single response. Claude Code executes them concurrently:
+
+```
+Read: /path/to/file1.py
+Read: /path/to/file2.py
+Read: /path/to/file3.py
+```
+
+Parallel reads are faster than the MCP's `read_multiple_files` which serialized internally.
+
+### Read Images and PDFs
+
+The `Read` tool handles binary formats:
+
+- **Images** (PNG, JPG, SVG): displayed visually
+- **PDFs**: extracted text; use `pages: "1-5"` for large documents (max 20 pages per call)
+
+---
+
+## Writing and Editing Files
+
+### Write a New File
+
+Use the `Write` tool to create a file or overwrite an existing one:
+
+```
+Write: /path/to/new-file.py
+Content: <full file content>
+```
+
+The `Write` tool requires reading the file first if it already exists. For new files,
+write directly.
+
+### Edit an Existing File
+
+Use the `Edit` tool for surgical modifications — replace exact string matches:
+
+```
+Edit: /path/to/file.py
+old_string: "def old_function():"
+new_string: "def new_function():"
+```
+
+The `Edit` tool fails if `old_string` is not unique in the file. Provide enough
+surrounding context to make the match unique, or use `replace_all: true` for
+find-and-replace across the entire file.
+
+**Prefer Edit over Write** for existing files. Edit preserves everything outside the
+changed region and shows a clear diff. Write replaces the entire file.
+
+---
+
+## Finding Files
+
+### By Name Pattern (Glob)
+
+```
+Glob: **/*.py           → all Python files recursively
+Glob: src/**/*.ts       → TypeScript files under src/
+Glob: *.md              → Markdown files in current directory
+Glob: **/test_*.py      → test files anywhere in the tree
+```
+
+Results are sorted by modification time (most recent first).
+
+### By Content (Grep)
+
+```
+Grep: pattern="def process_data" type="py"
+Grep: pattern="TODO|FIXME" glob="*.py"
+Grep: pattern="class.*Controller" output_mode="content" -C=2
+```
+
+| Grep Parameter | Purpose |
+|---|---|
+| `pattern` | Regex pattern to match |
+| `type` | File type filter (py, js, ts, rust, go, etc.) |
+| `glob` | Glob pattern filter (`*.tsx`, `src/**/*.py`) |
+| `output_mode` | `files_with_matches` (default), `content`, `count` |
+| `-C`, `-A`, `-B` | Context lines: around, after, before matches |
+| `-i` | Case-insensitive search |
+
+### Directory Listing
+
+Simple listing:
+
+```bash
+ls -la /path/to/directory
+```
+
+Recursive tree with `fd`:
+
+```bash
+fd . /path/to/directory --type f
+```
+
+Tree with depth limit:
+
+```bash
+fd . /path/to/directory --type f --max-depth 2
+```
+
+Filter by extension:
+
+```bash
+fd -e py /path/to/directory
+```
+
+---
+
+## File Operations
+
+### Create Directory
+
+```bash
+mkdir -p /path/to/new/directory
+```
+
+The `-p` flag creates all intermediate directories. Always verify the parent path
+exists first with `ls`.
+
+### Move / Rename
+
+```bash
+mv /path/to/source.py /path/to/destination.py
+```
+
+Rename a file (same directory):
+
+```bash
+mv /path/to/old-name.py /path/to/new-name.py
+```
+
+Move a directory:
+
+```bash
+mv /path/to/source-dir /path/to/destination-dir
+```
+
+### Copy
+
+```bash
+cp /path/to/source.py /path/to/destination.py
+cp -r /path/to/source-dir /path/to/destination-dir
+```
+
+### Delete
+
+```bash
+rm /path/to/file.py
+rm -r /path/to/directory
+```
+
+Always confirm with the user before deleting files or directories.
+
+### File Metadata
+
+```bash
+stat /path/to/file.py
+ls -la /path/to/file.py
+wc -l /path/to/file.py
+```
+
+| Command | Returns |
+|---|---|
+| `stat` | Size, permissions, timestamps, inode |
+| `ls -la` | Permissions, owner, size, modification date |
+| `wc -l` | Line count |
+| `file` | MIME type detection |
+
+---
+
+## Common Workflows
+
+### Find and Replace Across Files
+
+```bash
+# Find all files containing the old string
+Grep: pattern="old_function_name" type="py" output_mode="files_with_matches"
+
+# Then Edit each file
+Edit: /path/to/file1.py (old_string → new_string, replace_all: true)
+Edit: /path/to/file2.py (old_string → new_string, replace_all: true)
+```
+
+### Explore an Unfamiliar Codebase
+
+1. Check project structure: `fd . --type f --max-depth 2`
+2. Read configuration: `Read: package.json` or `Read: pyproject.toml`
+3. Find entry points: `Grep: pattern="def main|if __name__" type="py"`
+4. Read key files identified above
+
+### Find Large Files
+
+```bash
+fd --type f --exec stat -f '%z %N' {} \; | sort -rn | head -20
+```
+
+---
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|---|---|---|
+| Read: file not found | Path incorrect or file deleted | Verify with `ls` or `Glob` |
+| Edit: old_string not unique | Multiple matches in the file | Add more surrounding context to make it unique |
+| Edit: old_string not found | Content changed since last read | Re-read the file, then retry with current content |
+| Write: file not read first | Attempting to overwrite without reading | Read the file first, then Write |
+| Permission denied | Insufficient OS permissions | Check with `ls -la`; use `chmod` if appropriate |
+| Glob: no files found | Pattern too restrictive | Broaden the pattern; check path spelling |
+
+---
+
+## Limitations
+
+- **Read** returns up to 2000 lines by default. Use offset/limit for larger files.
+- **Read** truncates lines longer than 2000 characters.
+- **Edit** requires exact string matching — whitespace and indentation must match precisely.
+- **Write** overwrites the entire file. No append mode. To append, read first, then write
+  the combined content.
+- **Glob** only matches files, not directories. Use `Bash ls` or `fd` to list directories.
+- **PDF reading** is limited to 20 pages per call. Specify page ranges for large documents.
+
+---
+
+## Calibration Rules
+
+1. **Read before Edit.** Always read a file before editing it. The Edit tool enforces this.
+2. **Edit over Write for existing files.** Edit is surgical and shows diffs. Write is a
+   full replacement — use it only for new files or complete rewrites.
+3. **Glob over Bash for file search.** Glob is optimized for pattern matching. Only fall
+   back to `fd` or `find` for queries Glob cannot express (size filters, date filters).
+4. **Grep over Bash for content search.** Grep is optimized for ripgrep-based search with
+   proper permissions. Never use `grep` or `rg` via Bash.
+5. **Parallel reads for multiple files.** Issue all Read calls in a single response for
+   concurrent execution.
+6. **Always use absolute paths.** Claude Code tools require absolute paths. Never pass
+   relative paths to Read, Write, or Edit.

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: web-fetch
+description: >
+  Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch
+  MCP server (fetch_html, fetch_json, fetch_markdown, fetch_txt). Covers HTTP
+  GET/POST requests, JSON API consumption with jq, HTML retrieval, markdown
+  conversion, plain text extraction, authenticated requests, redirects, cookies,
+  and timeouts. Trigger phrases: "fetch this URL", "get the page content",
+  "download HTML", "call this API", "curl this endpoint", "grab the JSON",
+  "fetch markdown from", "retrieve web content", "hit this endpoint", "scrape this
+  page", "read this URL", "pull data from API", "make an HTTP request". Use this
+  skill when the user provides a URL and wants its content, when consuming REST
+  APIs, or when extracting readable content from web pages.
+metadata:
+  version: 1.0.0
+---
+
+# Web Fetch
+
+All web content retrieval uses `curl` (Bash) or the built-in `WebFetch` tool. No MCP
+server needed — Claude Code's native tools cover every Fetch MCP operation with more
+control.
+
+## Quick Reference
+
+| Fetch MCP Tool | Replacement | When to Use |
+|---|---|---|
+| `fetch_html` | `curl -s URL` | Raw HTML needed for parsing |
+| `fetch_json` | `curl -s URL \| jq '.'` | API responses, structured data |
+| `fetch_markdown` | `WebFetch` | Readable page content (default output is markdown) |
+| `fetch_txt` | `curl -s URL` or `WebFetch` | Plain text extraction |
+
+**Default choice:** Use `WebFetch` for general page content. Use `curl` when you need
+headers, authentication, POST bodies, or raw format control.
+
+---
+
+## WebFetch (Built-in Tool)
+
+The `WebFetch` tool fetches a URL and returns clean markdown content. It handles
+JavaScript-rendered pages, strips navigation and boilerplate, and returns readable text.
+
+Best for: documentation pages, articles, blog posts, README files — any content where
+you want readable text rather than raw HTML.
+
+Limitations: no custom headers, no POST bodies, no cookie management. Use `curl` for
+those.
+
+---
+
+## curl Patterns
+
+### Fetch HTML
+
+```bash
+curl -sL "https://example.com/page"
+```
+
+| Flag | Purpose |
+|---|---|
+| `-s` | Silent mode — suppress progress meter |
+| `-L` | Follow redirects (3xx) |
+| `-o file.html` | Save to file instead of stdout |
+| `-I` | Headers only (HEAD request) |
+| `-i` | Include response headers in output |
+
+Fetch and extract specific elements with `xmllint` or `python3`:
+
+```bash
+curl -sL "https://example.com" | python3 -c "
+from html.parser import HTMLParser
+import sys
+
+class TitleParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_title = False
+        self.title = ''
+    def handle_starttag(self, tag, attrs):
+        self.in_title = tag == 'title'
+    def handle_data(self, data):
+        if self.in_title:
+            self.title += data
+    def handle_endtag(self, tag):
+        if tag == 'title':
+            self.in_title = False
+
+p = TitleParser()
+p.feed(sys.stdin.read())
+print(p.title)
+"
+```
+
+### Fetch JSON
+
+```bash
+curl -s "https://api.example.com/v1/data" \
+  -H "Accept: application/json" | jq '.'
+```
+
+Filter and reshape JSON responses:
+
+```bash
+# Extract specific fields
+curl -s "https://api.example.com/users" | jq '.[] | {name, email}'
+
+# Filter by condition
+curl -s "https://api.example.com/items" | jq '[.[] | select(.status == "active")]'
+
+# Count results
+curl -s "https://api.example.com/items" | jq 'length'
+
+# Get nested value
+curl -s "https://api.example.com/config" | jq '.database.host'
+```
+
+### Fetch Plain Text
+
+```bash
+# Strip HTML tags for plain text
+curl -sL "https://example.com/page" | python3 -c "
+import html.parser, sys
+
+class Stripper(html.parser.HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.text = []
+    def handle_data(self, d):
+        self.text.append(d)
+    def get_text(self):
+        return ''.join(self.text)
+
+s = Stripper()
+s.feed(sys.stdin.read())
+print(s.get_text())
+"
+```
+
+Or use `WebFetch` which returns clean markdown — close enough to plain text for most
+purposes.
+
+---
+
+## Authenticated Requests
+
+### Bearer Token
+
+```bash
+curl -s "https://api.example.com/data" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+### API Key in Header
+
+```bash
+curl -s "https://api.example.com/data" \
+  -H "X-API-Key: $API_KEY"
+```
+
+### API Key in Query Parameter
+
+```bash
+curl -s "https://api.example.com/data?api_key=$API_KEY"
+```
+
+### Basic Auth
+
+```bash
+curl -s -u "username:$PASSWORD" "https://api.example.com/data"
+```
+
+Store credentials in environment variables. Never hardcode tokens or passwords in
+commands.
+
+---
+
+## POST, PUT, PATCH, DELETE
+
+### POST with JSON Body
+
+```bash
+curl -s -X POST "https://api.example.com/items" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -d '{
+    "name": "item-name",
+    "value": 42
+  }' | jq '.'
+```
+
+### POST with Form Data
+
+```bash
+curl -s -X POST "https://api.example.com/upload" \
+  -F "file=@./document.pdf" \
+  -F "description=Uploaded via curl"
+```
+
+### PUT (Full Update)
+
+```bash
+curl -s -X PUT "https://api.example.com/items/123" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "updated-name", "value": 99}' | jq '.'
+```
+
+### PATCH (Partial Update)
+
+```bash
+curl -s -X PATCH "https://api.example.com/items/123" \
+  -H "Content-Type: application/json" \
+  -d '{"value": 100}' | jq '.'
+```
+
+### DELETE
+
+```bash
+curl -s -X DELETE "https://api.example.com/items/123" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+---
+
+## Advanced Patterns
+
+### Pagination
+
+```bash
+PAGE=1
+while true; do
+  RESPONSE=$(curl -s "https://api.example.com/items?page=$PAGE&per_page=50" \
+    -H "Authorization: Bearer $API_TOKEN")
+  COUNT=$(echo "$RESPONSE" | jq 'length')
+  echo "$RESPONSE" | jq '.[]'
+  [ "$COUNT" -lt 50 ] && break
+  PAGE=$((PAGE + 1))
+done
+```
+
+### Timeout and Retry
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  --retry 3 --retry-delay 2 \
+  "https://api.example.com/data"
+```
+
+### Response Headers Inspection
+
+```bash
+curl -sI "https://example.com" | grep -i "content-type"
+```
+
+### Save Response with Status Code
+
+```bash
+HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" "https://api.example.com/data")
+echo "Status: $HTTP_CODE"
+cat /tmp/response.json | jq '.'
+```
+
+### Cookie Handling
+
+```bash
+# Save cookies
+curl -s -c /tmp/cookies.txt "https://example.com/login" \
+  -d "user=admin&pass=$PASSWORD"
+
+# Reuse cookies
+curl -s -b /tmp/cookies.txt "https://example.com/dashboard"
+```
+
+---
+
+## Error Handling
+
+| HTTP Status | Meaning | Resolution |
+|---|---|---|
+| 301/302 | Redirect | Add `-L` flag to follow |
+| 401 | Unauthorized | Check token/credentials; verify env var is set |
+| 403 | Forbidden | Insufficient permissions or IP restriction |
+| 404 | Not Found | Verify URL path; resource may be deleted |
+| 429 | Rate Limited | Respect `Retry-After` header; add delay between requests |
+| 500 | Server Error | Retry once; if persistent, report upstream |
+| SSL error | Certificate issue | Do not use `-k` (insecure) — fix the root cause |
+| Timeout | Network/server slow | Increase `--max-time`; check connectivity |
+
+Verify a URL is reachable before complex operations:
+
+```bash
+curl -sI -o /dev/null -w "%{http_code}" "https://example.com"
+```
+
+---
+
+## Limitations
+
+- **WebFetch** does not support custom headers, POST bodies, or cookies. Use `curl` for
+  authenticated or stateful requests.
+- **curl** does not render JavaScript. For JS-heavy SPAs, prefer `WebFetch` which handles
+  rendered content.
+- **Large responses** may exceed context limits. Pipe through `jq`, `head`, or `python3`
+  to extract only needed data before loading into context.
+- **Binary content** (images, PDFs, archives) should be saved to disk with `-o`, not
+  piped to stdout.
+
+---
+
+## Calibration Rules
+
+1. **Default to WebFetch for reading web pages.** It returns clean markdown, handles JS
+   rendering, and requires no flags. Switch to curl only when you need headers, auth,
+   POST, or raw format control.
+2. **Always pipe JSON through jq.** Raw JSON in context wastes tokens. Filter to only the
+   fields needed.
+3. **Never hardcode credentials.** Use `$ENV_VAR` references. If the variable is not set,
+   surface the error immediately.
+4. **Follow redirects by default.** Always use `-L` with curl unless you specifically need
+   to inspect the redirect chain.
+5. **Prefer `-s` (silent) on every curl call.** Progress meters add noise to output.


### PR DESCRIPTION
## Summary

- Add **web-fetch** skill replacing the Fetch MCP server (`fetch_html`, `fetch_json`, `fetch_markdown`, `fetch_txt`) with native `WebFetch` and `curl`+`jq` patterns
- Add **filesystem** skill replacing the Filesystem MCP server (11 tools) with native `Read`, `Write`, `Edit`, `Glob`, `Grep`, and `Bash`
- Both are methodology/reference skills — no scripts or assets, just mappings from MCP tools to Claude Code built-in equivalents
- Both scored **92% (Exemplary)** on skill-evaluator audit with zero CRITICAL or HIGH findings

## Motivation

MCP tool schemas inject 500–2000 tokens per tool on every turn regardless of use. The Fetch MCP (4 tools) and Filesystem MCP (11 tools) add ~3,000–15,000 tokens/turn for operations Claude Code already handles natively. These skills recover that context window budget while preserving the operational knowledge as on-demand reference.

## Test plan

- [x] Skill evaluator quick audit: both at 92% (Exemplary), exceeding 70% PR threshold
- [x] CONTRIBUTING.md compliance: all checks pass (kebab-case names, descriptions 738–753 chars in 200–800 sweet spot, trigger phrases, "Use this skill when..." clauses, valid YAML, no angle brackets, no pushy language)
- [x] Directory names match frontmatter `name` fields
- [x] README catalog updated with both skills, badge bumped 20→22
- [x] Manifest regenerated: `skills.yaml` lists 22 skills