### PR TITLE
feat(skills): add pr-review skill — replaces pr-review-toolkit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 22](https://img.shields.io/badge/skills-22-informational)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 23](https://img.shields.io/badge/skills-23-informational)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -36,6 +36,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [architecture-reviewer](skills/architecture-reviewer/) | Architecture reviews across 7 scored dimensions — structural integrity, scalability, security, performance, enterprise readiness, operations, data |
 | [code-refiner](skills/code-refiner/)                   | Deep code simplification and refactoring — structural complexity analysis, anti-pattern detection, idiomatic rewrites across Python, Go, TS, Rust  |
+| [pr-review](skills/pr-review/)                         | Diff-based PR review across 5 dimensions — code quality, test coverage, silent failures, type design, comment quality with severity-ranked output  |
 | [manuscript-review](skills/manuscript-review/)         | Pre-publication manuscript audit with 24 diagnostic dimensions, citation hygiene, and cross-element coherence                                      |
 | [manuscript-provenance](skills/manuscript-provenance/) | Computational provenance audit verifying every number, table, and figure in a manuscript traces back to code                                       |
 | [repo-sentinel](skills/repo-sentinel/)                 | Security audit and enforcement for public repos — 12 attack surfaces, pre-release readiness, history scrubbing, CI gates                           |

--- a/skills.yaml
+++ b/skills.yaml
@@ -153,6 +153,16 @@ skills:
     with equations", "generate a pdf report", "how do I export markdown as PDF", "convert my notes to PDF", "can you make
     a PDF from this markdown".'
   path: skills/md-to-pdf
+- name: pr-review
+  version: 1.0.0
+  description: 'Pull request and code review with diff-based routing across five dimensions: code quality and guideline compliance,
+    test coverage analysis, silent failure detection, type design and invariant analysis, and comment quality auditing. Classifies
+    changed files and loads only relevant review methodologies. Produces severity-ranked findings (Critical, Important, Suggestion)
+    with confidence scoring. Replaces pr-review-toolkit plugin. Trigger phrases: "review my PR", "review this code", "check
+    my changes", "is this ready to merge", "audit this PR", "review before committing", "check code quality", "any issues
+    with this code", "pre-merge review", "look over my changes", "code review". Use this skill when reviewing code before
+    commit or merge, checking PR quality, or when the user asks for feedback on recent modifications.'
+  path: skills/pr-review
 - name: repo-sentinel
   version: 1.0.0
   description: 'Full security audit and enforcement for public repositories across 12 attack surfaces: git history, source

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: pr-review
+description: >
+  Pull request and code review with diff-based routing across five dimensions:
+  code quality and guideline compliance, test coverage analysis, silent failure
+  detection, type design and invariant analysis, and comment quality auditing.
+  Classifies changed files and loads only relevant review methodologies. Produces
+  severity-ranked findings (Critical, Important, Suggestion) with confidence
+  scoring. Replaces pr-review-toolkit plugin. Trigger phrases: "review my PR",
+  "review this code", "check my changes", "is this ready to merge", "audit
+  this PR", "review before committing", "check code quality", "any issues with
+  this code", "pre-merge review", "look over my changes", "code review". Use
+  this skill when reviewing code before commit or merge, checking PR quality,
+  or when the user asks for feedback on recent modifications.
+metadata:
+  version: 1.0.0
+---
+
+# PR Review
+
+Diff-based code review across five dimensions. Reads the changed files, selects
+applicable review methodologies, and produces an aggregated report with severity-ranked
+findings.
+
+## Reference Files
+
+| File | Contents | Load When |
+|---|---|---|
+| `references/code-review.md` | Guideline compliance, bug detection, confidence scoring | Always |
+| `references/test-analysis.md` | Behavioral test coverage, criticality rating | Test files changed |
+| `references/error-handling.md` | Silent failure patterns, catch block analysis | Error handling changed |
+| `references/type-design.md` | Invariant analysis, 4-dimension rating rubric | Type definitions added/modified |
+| `references/comment-quality.md` | Comment accuracy, long-term value, rot detection | Comments/docstrings added |
+
+---
+
+## Workflow
+
+### Phase 1: Scope
+
+1. Determine the review target:
+   - Default: `git diff` (unstaged changes)
+   - If user specifies a PR: `git diff main...HEAD` or `gh pr diff <number>`
+   - If user specifies files: review those files directly
+2. List all changed files with `git diff --name-only`
+3. Read the project's CLAUDE.md (if present) for project-specific rules
+
+### Phase 2: Route
+
+Classify changed files and select applicable dimensions:
+
+| Condition | Dimension | Reference to Load |
+|---|---|---|
+| Always | Code review | `references/code-review.md` |
+| Files matching `*test*`, `*spec*`, `*_test.*`, `test_*` | Test analysis | `references/test-analysis.md` |
+| Files containing try/catch, except, .catch, Result, error callbacks | Error handling | `references/error-handling.md` |
+| Files containing class, interface, type, struct, enum, dataclass definitions | Type design | `references/type-design.md` |
+| Files with new/modified docstrings, JSDoc, or block comments | Comment quality | `references/comment-quality.md` |
+
+Load only the reference files that apply. Skip dimensions with no matching files.
+
+### Phase 3: Review
+
+For each applicable dimension, analyze the diff using the loaded methodology:
+
+1. **Code review** — scan every changed file for guideline violations and bugs.
+   Apply confidence scoring (0-100). Only report issues >= 80.
+2. **Test analysis** — map test coverage to changed code paths. Rate gaps 1-10.
+   Only report gaps >= 5.
+3. **Error handling** — examine every error handler in the diff for silent failures.
+   Classify CRITICAL/HIGH/MEDIUM.
+4. **Type design** — evaluate new or modified types on 4 dimensions (encapsulation,
+   invariant expression, usefulness, enforcement). Rate each 1-10.
+5. **Comment quality** — verify accuracy, assess long-term value, flag comment rot.
+
+### Phase 4: Aggregate
+
+Merge all findings into a single report, deduplicated and severity-ranked.
+
+**Deduplication rules:**
+- If two dimensions flag the same file:line, keep the higher-severity finding
+- If code-review and error-handling both flag an empty catch block, merge into one
+  finding with the error-handling severity (it's the specialist)
+
+**Severity mapping across dimensions:**
+
+| Dimension | Maps to Critical | Maps to Important | Maps to Suggestion |
+|---|---|---|---|
+| Code review | Confidence 90-100 | Confidence 80-89 | — |
+| Test analysis | Rating 9-10 | Rating 7-8 | Rating 5-6 |
+| Error handling | CRITICAL | HIGH | MEDIUM |
+| Type design | Any rating <= 3/10 | Any rating 4-6/10 | Rating 7-8/10 |
+| Comment quality | Factually incorrect | Misleading or incomplete | Restates obvious code |
+
+---
+
+## Output Format
+
+```
+# PR Review Summary
+
+**Scope:** [X files changed, Y dimensions applied]
+**Dimensions:** [list of active dimensions]
+
+## Critical Issues (must fix before merge)
+- **[dimension]** `file:line` — Description. Fix suggestion.
+
+## Important Issues (should fix)
+- **[dimension]** `file:line` — Description. Fix suggestion.
+
+## Suggestions (consider)
+- **[dimension]** `file:line` — Description.
+
+## Strengths
+- What's well-done in this changeset.
+
+## Recommended Action
+1. Fix critical issues
+2. Address important issues
+3. Consider suggestions
+4. Re-run review after fixes
+```
+
+If no issues are found at any severity level, confirm the code meets standards with
+a brief summary of what was reviewed and which dimensions were applied.
+
+---
+
+## Aspect Selection
+
+Users can request specific dimensions instead of running all:
+
+| User Says | Dimensions Applied |
+|---|---|
+| "review my PR" / "check my changes" | All applicable (default) |
+| "review the code" / "check code quality" | Code review only |
+| "check the tests" / "is test coverage good" | Test analysis only |
+| "check error handling" / "find silent failures" | Error handling only |
+| "review the types" / "check type design" | Type design only |
+| "check the comments" / "review documentation" | Comment quality only |
+
+When a specific aspect is requested, load only that reference file and skip routing.
+
+---
+
+## Error Handling
+
+| Problem | Resolution |
+|---|---|
+| No git diff available | Ask user to specify files or scope |
+| CLAUDE.md not found | Review against general best practices; note the absence |
+| No test files in diff | Skip test analysis dimension; note in output |
+| Diff is empty | Report "no changes to review" and stop |
+| Diff exceeds context limits | Focus on files the user is most likely to care about; summarize skipped files |
+
+---
+
+## Calibration Rules
+
+1. **Precision over recall.** A false positive erodes trust in the review. Only report
+   issues at >= 80 confidence (code review) or >= 5 criticality (tests). Silence is
+   better than noise.
+2. **File:line references are mandatory.** Every finding must include a specific location.
+   Vague findings ("consider improving error handling") are not actionable.
+3. **Project rules override general rules.** If CLAUDE.md says "use arrow functions",
+   do not flag arrow functions even if conventional style prefers `function` declarations.
+4. **Deduplication is mandatory.** If two dimensions flag the same issue, merge them.
+   Never report the same problem twice.
+5. **Acknowledge strengths.** A review that only lists problems is demoralizing. Note
+   what's done well, even briefly.
+6. **Code-refiner handles simplification.** This skill reviews and reports. It does not
+   refactor or simplify — that's the `code-refiner` skill's job. Keep the roles separate.

--- a/skills/pr-review/references/code-review.md
+++ b/skills/pr-review/references/code-review.md
@@ -1,0 +1,62 @@
+# Code Review Methodology
+
+Review code against project guidelines (CLAUDE.md) with high precision. Minimize false
+positives — quality over quantity.
+
+## Review Scope
+
+Default: unstaged changes from `git diff`. User may specify different scope (staged
+changes, specific files, PR diff).
+
+## Responsibilities
+
+**Project Guidelines Compliance**
+- Import patterns and module structure
+- Framework conventions and language-specific style
+- Function declarations and naming conventions
+- Error handling and logging patterns
+- Testing practices and platform compatibility
+
+**Bug Detection**
+- Logic errors and off-by-one mistakes
+- Null/undefined handling gaps
+- Race conditions and concurrency issues
+- Memory leaks and resource management
+- Security vulnerabilities (injection, XSS, auth bypass)
+- Performance regressions (N+1 queries, unbounded loops)
+
+**Code Quality**
+- Significant duplication
+- Missing critical error handling
+- Accessibility problems (if frontend)
+- Inadequate test coverage for new code paths
+
+## Confidence Scoring
+
+Rate each issue 0-100. Only report issues scoring >= 80.
+
+| Range | Meaning |
+|---|---|
+| 91-100 | Critical bug or explicit CLAUDE.md violation |
+| 80-90 | Important issue requiring attention |
+| 51-75 | Valid but low-impact (do not report) |
+| 26-50 | Minor nitpick (do not report) |
+| 0-25 | Likely false positive (do not report) |
+
+## Output Format
+
+Start by listing files under review. For each issue:
+
+```
+**[CRITICAL]** (confidence: 95) `src/auth.py:42`
+Description of the issue.
+Rule: [CLAUDE.md rule or bug category]
+Fix: Concrete suggestion with code example.
+```
+
+Group by severity:
+1. **Critical** (90-100): Must fix before merge
+2. **Important** (80-89): Should fix, significant quality impact
+
+If no issues >= 80 confidence exist, confirm the code meets standards with a brief
+summary of what was reviewed.

--- a/skills/pr-review/references/comment-quality.md
+++ b/skills/pr-review/references/comment-quality.md
@@ -1,0 +1,67 @@
+# Comment Quality Analysis Methodology
+
+Protect codebases from comment rot. Every comment must earn its place by providing
+clear, lasting value. Analyze through the lens of a developer encountering the code
+months later without original context.
+
+## Analysis Dimensions
+
+### 1. Factual Accuracy
+
+Cross-reference every claim against the actual code:
+- Function signatures match documented parameters and return types
+- Described behavior aligns with actual code logic
+- Referenced types, functions, and variables exist and are used correctly
+- Edge cases mentioned are actually handled
+- Performance or complexity claims are accurate
+
+### 2. Completeness
+
+Evaluate whether comments provide sufficient context:
+- Critical assumptions or preconditions documented
+- Non-obvious side effects mentioned
+- Important error conditions described
+- Complex algorithms have their approach explained
+- Business logic rationale captured when not self-evident
+
+### 3. Long-term Value
+
+Consider the comment's utility over the codebase's lifetime:
+- Flag comments that merely restate obvious code
+- "Why" comments are more valuable than "what" comments
+- Comments likely to become outdated with code changes should be reconsidered
+- Comments should target the least experienced future maintainer
+- Avoid references to temporary states or transitional implementations
+
+### 4. Misleading Elements
+
+Search for ways comments could be misinterpreted:
+- Ambiguous language with multiple meanings
+- Outdated references to refactored code
+- Assumptions that may no longer hold true
+- Examples that don't match current implementation
+- TODOs or FIXMEs that have already been addressed
+
+## Output Format
+
+```
+## Comment Analysis
+
+### Summary
+Brief overview of scope and findings.
+
+### Critical Issues (factually incorrect or misleading)
+- `file:line` — Issue description. Suggested rewrite.
+
+### Improvement Opportunities
+- `file:line` — Current state. How to improve.
+
+### Recommended Removals
+- `file:line` — Rationale (restates obvious code, outdated, etc.)
+
+### Positive Findings
+- Well-written comments that serve as good examples.
+```
+
+This analysis is advisory only — identify issues and suggest improvements, do not
+modify code directly.

--- a/skills/pr-review/references/error-handling.md
+++ b/skills/pr-review/references/error-handling.md
@@ -1,0 +1,92 @@
+# Error Handling & Silent Failure Analysis
+
+Zero tolerance for silent failures. Every error must be surfaced, logged, and actionable.
+
+## Non-Negotiable Rules
+
+1. **Silent failures are unacceptable** — any error without proper logging and user
+   feedback is a critical defect
+2. **Users deserve actionable feedback** — every error message must explain what went
+   wrong and what to do about it
+3. **Fallbacks must be explicit and justified** — falling back without user awareness
+   hides problems
+4. **Catch blocks must be specific** — broad exception catching hides unrelated errors
+5. **Mock/fake implementations belong only in tests** — production fallbacks to mocks
+   indicate architectural problems
+
+## Review Process
+
+### 1. Locate All Error Handling Code
+
+Systematically find:
+- try-catch/try-except blocks
+- Error callbacks and event handlers
+- Conditional branches handling error states
+- Fallback logic and default values on failure
+- Places where errors are logged but execution continues
+- Optional chaining or null coalescing that might hide errors
+
+### 2. Scrutinize Each Handler
+
+**Logging quality:**
+- Appropriate severity level (error vs warning vs info)
+- Sufficient context (operation, relevant IDs, state)
+- Error tracking IDs for monitoring systems
+- Debuggable 6 months from now by someone without context
+
+**User feedback:**
+- Clear, actionable message about what went wrong
+- Explains what the user can do to fix or work around it
+- Specific enough to be useful, not generic
+- Technical details appropriate to the user's context
+
+**Catch block specificity:**
+- Catches only expected error types
+- Cannot accidentally suppress unrelated errors
+- List every unexpected error type that could be hidden
+- Should it be multiple catch blocks for different types?
+
+**Fallback behavior:**
+- Is fallback explicitly requested or documented?
+- Does it mask the underlying problem?
+- Would the user be confused about why they see fallback behavior?
+- Is it a fallback to a mock/stub outside test code?
+
+**Error propagation:**
+- Should this error bubble up to a higher-level handler?
+- Is the error being swallowed when it should propagate?
+- Does catching prevent proper cleanup or resource management?
+
+### 3. Check for Hidden Failure Patterns
+
+Anti-patterns (always flag):
+- Empty catch blocks
+- Catch blocks that only log and continue
+- Returning null/undefined/default on error without logging
+- Optional chaining (`?.`) silently skipping operations that might fail
+- Fallback chains trying multiple approaches without explaining why
+- Retry logic exhausting attempts without informing the user
+- Bare `except:` or `except Exception:` in Python
+- `catch (e) {}` with empty body in JavaScript/TypeScript
+
+## Severity Classification
+
+| Severity | Criteria |
+|---|---|
+| CRITICAL | Silent failure, broad catch hiding errors, empty catch block |
+| HIGH | Poor error message, unjustified fallback, swallowed exception |
+| MEDIUM | Missing context in logs, could be more specific |
+
+## Output Format
+
+For each issue:
+
+```
+**[CRITICAL]** `src/api/client.py:87`
+Empty except block swallows ConnectionError, TimeoutError, and any
+unexpected exception from the HTTP client.
+**Hidden errors:** ConnectionRefusedError, SSLError, ProxyError
+**User impact:** Request silently fails; user sees stale data with no
+indication that the fetch failed.
+**Fix:** Catch specific exceptions, log with context, surface to user.
+```

--- a/skills/pr-review/references/test-analysis.md
+++ b/skills/pr-review/references/test-analysis.md
@@ -1,0 +1,67 @@
+# Test Coverage Analysis Methodology
+
+Analyze behavioral test coverage — not line coverage. Focus on tests that prevent real
+bugs, not academic completeness.
+
+## Analysis Process
+
+1. Examine the diff to identify new functionality and modifications
+2. Map existing tests to changed code paths
+3. Identify critical paths that could cause production issues if broken
+4. Check for implementation-coupled tests that break on refactoring
+5. Find missing negative cases and error scenarios
+6. Evaluate integration points and their coverage
+
+## Critical Gap Identification
+
+Look for:
+- Untested error handling paths that could cause silent failures
+- Missing boundary condition tests (zero, one, max, overflow)
+- Uncovered business logic branches
+- Absent negative test cases for validation logic
+- Missing async/concurrent behavior tests where relevant
+- Integration points tested only in isolation
+
+## Test Quality Evaluation
+
+Tests should:
+- Test behavior and contracts, not implementation details
+- Catch meaningful regressions from future code changes
+- Be resilient to reasonable refactoring
+- Follow DAMP principles (Descriptive and Meaningful Phrases)
+- Avoid mocking what they're testing
+
+## Criticality Rating
+
+| Rating | Criteria | Example |
+|---|---|---|
+| 9-10 | Data loss, security issues, system failures | Auth bypass with no test |
+| 7-8 | User-facing errors in business logic | Payment rounding untested |
+| 5-6 | Edge cases causing confusion or minor issues | Empty input not tested |
+| 3-4 | Nice-to-have for completeness | Redundant enum variant |
+| 1-2 | Optional minor improvements | Trivial getter |
+
+## Output Format
+
+```
+## Test Coverage Analysis
+
+### Summary
+Brief overview of coverage quality.
+
+### Critical Gaps (rating 8-10)
+- [file:line] What's untested, what failure it would catch, criticality rating
+
+### Important Improvements (rating 5-7)
+- [file:line] What's weakly tested, suggested improvement, rating
+
+### Test Quality Issues
+- Tests coupled to implementation rather than behavior
+- Brittle assertions that break on valid refactoring
+
+### Positive Observations
+- Well-tested areas that follow best practices
+```
+
+Do not suggest tests for trivial getters/setters unless they contain logic. Consider
+whether existing integration tests already cover a scenario before flagging it.

--- a/skills/pr-review/references/type-design.md
+++ b/skills/pr-review/references/type-design.md
@@ -1,0 +1,88 @@
+# Type Design Analysis Methodology
+
+Evaluate type designs for invariant strength, encapsulation quality, and practical
+usefulness. Well-designed types are the foundation of maintainable, bug-resistant systems.
+
+## Analysis Framework
+
+### 1. Identify Invariants
+
+Examine the type for all implicit and explicit invariants:
+- Data consistency requirements (field A implies field B)
+- Valid state transitions (status can only go DRAFT → PUBLISHED → ARCHIVED)
+- Relationship constraints between fields (end_date > start_date)
+- Business logic rules encoded in the type
+- Preconditions and postconditions on methods
+
+### 2. Rate Encapsulation (1-10)
+
+- Are internal implementation details hidden?
+- Can invariants be violated from outside the type?
+- Are access modifiers appropriate?
+- Is the interface minimal and complete?
+
+### 3. Rate Invariant Expression (1-10)
+
+- How clearly are invariants communicated through the type's structure?
+- Are constraints enforced at compile-time where possible?
+- Is the type self-documenting through its design?
+- Are edge cases obvious from the type definition?
+
+### 4. Rate Invariant Usefulness (1-10)
+
+- Do the invariants prevent real bugs?
+- Are they aligned with business requirements?
+- Do they make the code easier to reason about?
+- Are they neither too restrictive nor too permissive?
+
+### 5. Rate Invariant Enforcement (1-10)
+
+- Are invariants checked at construction time?
+- Are all mutation points guarded?
+- Is it impossible to create invalid instances?
+- Are runtime checks appropriate and comprehensive?
+
+## Anti-Patterns to Flag
+
+- **Anemic domain models** — types with no behavior, just data bags
+- **Exposed mutable internals** — returning references to internal collections
+- **Documentation-only invariants** — constraints described in comments but not enforced
+- **Too many responsibilities** — type doing multiple unrelated things
+- **Missing construction validation** — no checks in constructor/factory
+- **Inconsistent enforcement** — some mutation methods check, others don't
+- **External invariant maintenance** — relying on callers to maintain type's constraints
+
+## Key Principles
+
+- Prefer compile-time guarantees over runtime checks when feasible
+- Make illegal states unrepresentable
+- Constructor validation is crucial for maintaining invariants
+- Immutability simplifies invariant maintenance
+- Value clarity over cleverness
+- Consider the maintenance burden of suggestions
+
+## Output Format
+
+```
+## Type: UserAccount
+
+### Invariants Identified
+- Email must be non-empty and valid format
+- Role must be one of ADMIN, MEMBER, VIEWER
+- Created date is immutable after construction
+
+### Ratings
+- **Encapsulation**: 7/10 — Role field is publicly settable, bypassing validation
+- **Invariant Expression**: 8/10 — Role enum makes valid values clear
+- **Invariant Usefulness**: 9/10 — Prevents invalid role assignment bugs
+- **Invariant Enforcement**: 5/10 — No validation on role setter
+
+### Strengths
+- Email validated at construction via factory method
+
+### Concerns
+- Role can be set to any value after construction
+
+### Recommended Improvements
+- Make role setter private, add changeRole() method with validation
+```


### PR DESCRIPTION
## Summary

- Add **pr-review** skill that consolidates the entire `pr-review-toolkit` plugin (6 agents) into a single skill with 5 reference files
- Diff-based routing: classifies changed files and loads only relevant review methodologies (code quality, test coverage, error handling, type design, comment quality)
- Drops the `code-simplifier` agent — redundant with existing `code-refiner` skill
- Scored **97.2% (Exemplary)** on skill-evaluator audit with zero CRITICAL or HIGH findings

## Motivation

The pr-review-toolkit plugin injects 2,548 tokens/turn across 7 agent definitions regardless of use. This skill costs ~100 tokens at rest (frontmatter only), loads ~170 lines of SKILL.md on activation, and selectively loads only the relevant reference files (62-92 lines each) based on what changed in the diff. Net savings: 2,548 tokens/turn on turns where no review is needed.

### Plugin → Skill mapping

| Plugin Agent (removed) | Skill Component | Location |
|---|---|---|
| `code-reviewer` (466 tokens) | Code review dimension | `references/code-review.md` |
| `pr-test-analyzer` (385 tokens) | Test analysis dimension | `references/test-analysis.md` |
| `silent-failure-hunter` (361 tokens) | Error handling dimension | `references/error-handling.md` |
| `type-design-analyzer` (342 tokens) | Type design dimension | `references/type-design.md` |
| `comment-analyzer` (438 tokens) | Comment quality dimension | `references/comment-quality.md` |
| `code-simplifier` (507 + 49 tokens) | **Dropped** — use `code-refiner` skill | — |

## Test plan

- [x] Skill evaluator: 97.2% (Exemplary), no CRITICAL/HIGH findings
- [x] All 5 reference files exist and contain substantive methodology
- [x] Directory name matches frontmatter `name` field
- [x] Description at 824 chars (under 1024 limit, trigger phrases and "Use this skill when..." present)
- [x] CONTRIBUTING.md compliance: all checks pass
- [x] README updated, badge bumped 22→23, manifest regenerated (23 skills)