### PR TITLE
docs(readme): update catalog and manifest for linkedin-post-style v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 
 | Skill                                              | Description                                                                                         |
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [linkedin-post-style](skills/linkedin-post-style/) | Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored |
+| [linkedin-post-style](skills/linkedin-post-style/) | Write LinkedIn posts in a specific technical voice with visual companion support — carousels via md-to-pdf, images via concept-to-image, video via concept-to-video |
 | [sequential-thinking](skills/sequential-thinking/) | Structured chain-of-thought reasoning with revision, branching, and scope tracking                  |
 
 ---

--- a/skills.yaml
+++ b/skills.yaml
@@ -167,12 +167,14 @@ skills:
     structure if not already specified.
   path: skills/html-presentation
 - name: linkedin-post-style
-  version: 1.0.0
+  version: 1.1.0
   description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and precise.
-    Use this skill whenever the user asks to write, draft, rewrite, or edit a LinkedIn post, social media post, tech commentary,
-    or any public-facing short-form writing about technology, AI, software engineering, or developer tools. Also trigger when
-    the user says "write this in my style", "post about this", "rewrite this for LinkedIn", "draft a post in my style", or
-    provides raw content/notes and wants it shaped into a post.
+    Use this skill whenever the user asks to write, draft, rewrite, review, improve, or refine a LinkedIn post, social media
+    post, tech commentary, or any public-facing short-form writing about technology, AI, software engineering, or developer
+    tools. Also trigger when the user says "write this in my style", "post about this", "rewrite this for LinkedIn", "draft
+    a post in my style", "does this sound right", "how should I phrase this", or provides raw content/notes and wants it shaped
+    into a post. Includes visual companion guidance for pairing posts with document carousels (via md-to-pdf with Mermaid
+    diagrams), custom images (via concept-to-image), or animations (via concept-to-video).
   path: skills/linkedin-post-style
 - name: manuscript-provenance
   version: 1.0.0


### PR DESCRIPTION
## Summary

- Regenerate `skills.yaml` manifest via `scripts/generate_manifest.py` to reflect linkedin-post-style v1.1.0 (expanded triggers, visual companion mention)
- Update `README.md` catalog entry to reflect carousel, image, and video companion support

Follow-up to PR #10 which enhanced the skill itself.

## Test plan

- [ ] CI `Validate manifest` step passes (`git diff --exit-code skills.yaml`)
- [ ] README catalog entry links resolve correctly