### PR TITLE
feat(skills): add youtube-analysis skill v1.0.0

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -348,3 +348,13 @@ skills:
     HTTP request". Use this skill when the user provides a URL and wants its content, when consuming REST APIs, or when extracting
     readable content from web pages.'
   path: skills/web-fetch
+- name: youtube-analysis
+  version: 1.0.0
+  description: 'Extract YouTube video transcripts and produce structured concept analysis with multi-level summaries, key
+    concepts, and actionable takeaways. Pure Python, no API keys, no MCP dependency. Fetches transcripts via youtube-transcript-api
+    with yt-dlp fallback, then Claude analyzes the content directly. Use this skill when the user mentions: analyze youtube
+    video, youtube transcript, summarize this video, what does this video cover, extract concepts from video, video analysis,
+    watch this for me, break down this talk, youtube URL, video summary, lecture notes from video, podcast transcript, conference
+    talk notes, tech talk breakdown, video key points, TL;DR of video, video takeaways, or pastes any URL containing youtube.com
+    or youtu.be.'
+  path: skills/youtube-analysis

--- a/skills/youtube-analysis/SKILL.md
+++ b/skills/youtube-analysis/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: youtube-analysis
+description: >
+  Extract YouTube video transcripts and produce structured concept analysis
+  with multi-level summaries, key concepts, and actionable takeaways. Pure
+  Python, no API keys, no MCP dependency. Fetches transcripts via
+  youtube-transcript-api with yt-dlp fallback, then Claude analyzes the
+  content directly. Use this skill when the user mentions: analyze youtube
+  video, youtube transcript, summarize this video, what does this video
+  cover, extract concepts from video, video analysis, watch this for me,
+  break down this talk, youtube URL, video summary, lecture notes from
+  video, podcast transcript, conference talk notes, tech talk breakdown,
+  video key points, TL;DR of video, video takeaways, or pastes any URL
+  containing youtube.com or youtu.be.
+metadata:
+  version: 1.0.0
+---
+
+# YouTube Analysis
+
+Extract transcripts from YouTube videos and produce structured concept analysis — key ideas, arguments, technical terms, takeaways, and multi-level summaries — all without API keys or MCP servers.
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/fetch_transcript.py` | Core transcript + metadata fetcher (CLI + importable) |
+| `scripts/analyze_video.py` | Orchestrator: fetch → structure → export scaffold |
+| `scripts/utils.py` | URL parsing, timestamp formatting, transcript chunking |
+| `references/analysis-patterns.md` | Prompt patterns for each video type |
+| `assets/output-template.md` | Markdown template for final output |
+
+## Workflow
+
+```
+User provides YouTube URL
+        │
+        ▼
+┌─────────────────────┐
+│  Step 0: Deps check │
+└────────┬────────────┘
+         ▼
+┌─────────────────────┐
+│  Step 1: Parse URL  │
+└────────┬────────────┘
+         ▼
+┌─────────────────────┐     ┌──────────────┐
+│  Step 2: Transcript │────▶│  yt-dlp      │
+│  (youtube-t-api)    │fail │  (fallback)  │
+└────────┬────────────┘     └──────┬───────┘
+         │◀───────────────────────┘
+         ▼
+┌─────────────────────┐
+│  Step 3: Metadata   │
+│  (yt-dlp --dump-json│
+└────────┬────────────┘
+         ▼
+┌─────────────────────┐
+│  Step 4: Claude     │
+│  analyzes transcript│
+└────────┬────────────┘
+         ▼
+┌─────────────────────┐
+│  Step 5: Export MD  │
+└─────────────────────┘
+```
+
+## Step 0: Ensure Dependencies
+
+Before running any script, verify dependencies are installed:
+
+```bash
+uv pip install youtube-transcript-api yt-dlp -q
+```
+
+Or run scripts directly with `uv run`:
+
+```bash
+uv run --with youtube-transcript-api --no-project python scripts/fetch_transcript.py "URL"
+```
+
+Verify:
+
+```bash
+python -c "from youtube_transcript_api import YouTubeTranscriptApi; print('OK')"
+yt-dlp --version
+```
+
+## Step 1: URL Parsing and Validation
+
+Use `scripts/utils.py:parse_youtube_url()` to extract the video ID. Supported formats:
+
+| Format | Example |
+|--------|---------|
+| Standard watch | `youtube.com/watch?v=dQw4w9WgXcQ` |
+| Short URL | `youtu.be/dQw4w9WgXcQ` |
+| Shorts | `youtube.com/shorts/dQw4w9WgXcQ` |
+| Embed | `youtube.com/embed/dQw4w9WgXcQ` |
+| Live | `youtube.com/live/dQw4w9WgXcQ` |
+| With params | `youtube.com/watch?v=dQw4w9WgXcQ&t=120&list=PLxxx` |
+| Bare ID | `dQw4w9WgXcQ` |
+| Mobile | `m.youtube.com/watch?v=dQw4w9WgXcQ` |
+| Music | `music.youtube.com/watch?v=dQw4w9WgXcQ` |
+
+If parsing fails, ask the user to provide the URL in a standard format.
+
+## Step 2: Transcript Extraction
+
+Run `fetch_transcript.py` to get the transcript:
+
+```bash
+cd <skill_dir>/scripts
+python fetch_transcript.py "YOUTUBE_URL" --lang en
+```
+
+This outputs JSON to stdout. The script:
+
+1. **Primary path**: Uses `youtube-transcript-api` to scrape captions directly (no API key)
+2. **Fallback path**: If primary fails, uses `yt-dlp --write-sub --write-auto-sub` to extract subtitle files
+3. **Language handling**: Tries requested language first, falls back to any available transcript
+
+The returned JSON contains both individual timestamped segments and a joined `transcript_text` field.
+
+**Or import as a module** (used by `analyze_video.py`):
+
+```python
+from fetch_transcript import fetch_video
+data = fetch_video("https://youtube.com/watch?v=VIDEO_ID", lang="en")
+```
+
+## Step 3: Metadata Extraction
+
+Metadata is fetched automatically by `fetch_transcript.py` via `yt-dlp --dump-json`:
+
+- Title, channel name
+- Duration (seconds)
+- Upload date (YYYY-MM-DD)
+- Description (first 500 chars in scaffold)
+- View count
+- Tags
+
+No separate step needed — `fetch_video()` returns everything.
+
+## Step 4: Concept Analysis
+
+**This is where you (Claude) do the work.** The scripts provide raw data; you perform the analysis.
+
+### Analysis Depth
+
+Choose based on user request or video duration:
+
+| Depth | When to Use | Sections to Fill |
+|-------|-------------|-----------------|
+| `quick` | User wants fast overview, or video < 10 min | TL;DR, Key Concepts, Takeaways |
+| `standard` | Default for most videos | All template sections |
+| `deep` | User wants thorough breakdown, or video > 30 min | All sections + timestamped section-by-section |
+
+### Analysis Process
+
+1. **Read the full transcript** from the JSON output
+2. **Identify the video type** (or use user-provided hint). See `references/analysis-patterns.md` for type-specific guidance
+3. **Extract key concepts**: Main ideas, arguments, claims — each as a bullet with brief explanation
+4. **Identify technical terms**: Definitions as presented in the video
+5. **Pull notable statements**: Paraphrase key quotes with approximate timestamps
+6. **Synthesize takeaways**: Actionable items the viewer should consider
+7. **Write the TL;DR**: One to three sentences capturing the core message
+8. **Suggest related topics**: Based on concepts mentioned, what should the viewer explore next
+
+### For Deep Analysis
+
+Use `utils.chunk_transcript()` to break the transcript into 5-minute segments, then analyze each chunk with timestamps:
+
+```python
+from utils import chunk_transcript
+chunks = chunk_transcript(data["transcript"], chunk_minutes=5)
+for chunk in chunks:
+    print(f"[{chunk['start_formatted']} - {chunk['end_formatted']}]")
+    print(chunk["text"])
+```
+
+Or run the orchestrator with `--depth deep`:
+
+```bash
+python analyze_video.py "YOUTUBE_URL" --depth deep
+```
+
+### Video Type Patterns
+
+| Type | Key Extraction Focus | See |
+|------|---------------------|-----|
+| Lecture | Thesis, arguments, citations, definitions | `references/analysis-patterns.md` |
+| Tutorial | Steps, tools, prerequisites, gotchas | `references/analysis-patterns.md` |
+| Interview | Perspectives, disagreements, attributed positions | `references/analysis-patterns.md` |
+| Podcast | Topic threads, opinions, recommendations | `references/analysis-patterns.md` |
+| Tech Talk | Architecture, trade-offs, benchmarks, lessons | `references/analysis-patterns.md` |
+| Panel | Consensus vs. disagreement, per-speaker views | `references/analysis-patterns.md` |
+
+Read `references/analysis-patterns.md` for detailed extraction guidance per type.
+
+## Step 5: Export to Markdown
+
+The orchestrator generates a scaffold:
+
+```bash
+cd <skill_dir>/scripts
+python analyze_video.py "YOUTUBE_URL" --output ./analysis.md --depth standard --type auto
+```
+
+Flags:
+- `--output PATH`: Where to write (default: `./{sanitized_title}.md`)
+- `--depth quick|standard|deep`: Analysis depth
+- `--type auto|lecture|tutorial|interview|podcast|tech-talk|panel`: Video type hint
+- `--lang CODE`: Transcript language (default: `en`)
+- `--json`: Output raw JSON instead of Markdown scaffold
+
+The scaffold contains populated metadata and `[TO BE ANALYZED]` placeholders. Claude replaces these with actual analysis.
+
+**Preferred workflow**: Run `fetch_transcript.py` to get JSON, analyze in context, then produce the final Markdown directly using `assets/output-template.md` as the structure guide. The orchestrator is useful for batch processing or when the user wants a file written.
+
+## Error Handling
+
+| Error | Exit Code | Cause | Resolution |
+|-------|-----------|-------|------------|
+| URL parse failure | 1 | Invalid or unsupported URL format | Ask user for standard YouTube URL |
+| No transcript | 2 | Video has no captions (manual or auto) | Inform user; suggest a different video |
+| Video unavailable | 1 | Private, deleted, or geo-blocked | Inform user of the restriction |
+| Age-restricted | 1 | Requires authentication | Inform user; yt-dlp may work with cookies |
+| Metadata fetch fail | 0 | yt-dlp network issue | Transcript still works; metadata shows "Unknown" |
+| Language unavailable | 0 | Requested lang not available | Auto-falls back to available language |
+| yt-dlp not installed | 1 | Missing dependency | Run Step 0 dependency installation |
+
+## Limitations
+
+- **No visual analysis**: Transcript-only; slides, diagrams, code on screen, and demos are not captured. Note this in output when relevant.
+- **Auto-caption quality**: Auto-generated captions may contain errors, especially for technical terms, proper nouns, and non-English accents.
+- **Music videos**: Lyrics may not be available as captions. Music-only content produces poor results.
+- **Live streams**: Ongoing live streams may have incomplete or unavailable transcripts.
+- **Rate limiting**: Excessive requests to YouTube may trigger temporary blocks. Space requests if processing multiple videos.
+- **Language coverage**: Best results for English. Other languages depend on caption availability and quality.
+- **Speaker attribution**: Transcripts rarely identify individual speakers. Claude infers from context where possible.

--- a/skills/youtube-analysis/assets/output-template.md
+++ b/skills/youtube-analysis/assets/output-template.md
@@ -1,0 +1,38 @@
+# {title}
+
+**Channel:** {channel} | **Duration:** {duration} | **Published:** {upload_date}
+**Source:** [{video_url}]({video_url})
+
+---
+
+## TL;DR
+
+{tldr}
+
+## Key Concepts
+
+{key_concepts}
+
+## Detailed Analysis
+
+{detailed_analysis}
+
+## Notable Quotes / Statements
+
+{notable_quotes}
+
+## Technical Terms & Definitions
+
+{terms}
+
+## Actionable Takeaways
+
+{takeaways}
+
+## Related Topics / Further Reading
+
+{related}
+
+---
+
+*Analysis generated from video transcript. Some nuance may be lost without visual context.*

--- a/skills/youtube-analysis/references/analysis-patterns.md
+++ b/skills/youtube-analysis/references/analysis-patterns.md
@@ -1,0 +1,261 @@
+# Analysis Patterns by Video Type
+
+Reference document for structuring transcript analysis based on video format.
+Claude reads this to calibrate extraction strategy per video type.
+
+---
+
+## Lecture
+
+**Focus areas:** Core thesis, supporting arguments, cited works, key definitions, logical flow
+
+**What to extract:**
+- Central thesis or claim (state in one sentence)
+- Supporting arguments with evidence cited
+- Definitions of domain-specific terms (quote or paraphrase)
+- Logical structure: premise → reasoning → conclusion
+- References to papers, books, researchers, or prior work
+- Counterarguments the speaker addresses
+
+**What to skip:** Housekeeping remarks, repeated summaries, audience Q&A tangents
+
+**Output structure:**
+```
+## TL;DR
+[One-sentence thesis]
+
+## Key Concepts
+- **[Term]**: [Definition as presented]
+- ...
+
+## Detailed Analysis
+### Thesis
+### Supporting Arguments
+### Counterarguments Addressed
+### Cited Works
+
+## Notable Quotes / Statements
+- "[Quote]" — on [topic] ([timestamp])
+
+## Actionable Takeaways
+[What the audience should do or investigate next]
+```
+
+---
+
+## Tutorial
+
+**Focus areas:** Steps, tools/technologies, prerequisites, gotchas, versions
+
+**What to extract:**
+- Prerequisites (tools, accounts, prior knowledge)
+- Exact steps in order, with commands/code when spoken
+- Tools and their versions mentioned
+- Common pitfalls the presenter warns about
+- Alternatives mentioned but not chosen (and why)
+- Final result or expected output
+
+**What to skip:** Setup troubleshooting for specific OSes (unless the tutorial is OS-specific), sponsor segments
+
+**Output structure:**
+```
+## TL;DR
+[What you'll build/achieve]
+
+## Key Concepts
+- **Prerequisites**: [list]
+- **Stack**: [tools and versions]
+
+## Detailed Analysis
+### Step 1: [Action] ([timestamp])
+### Step 2: [Action] ([timestamp])
+...
+
+## Notable Quotes / Statements
+- Warnings or gotchas the presenter emphasizes
+
+## Technical Terms & Definitions
+[Terms introduced during the tutorial]
+
+## Actionable Takeaways
+- Step-by-step checklist to reproduce
+```
+
+---
+
+## Interview
+
+**Focus areas:** Key perspectives, disagreements, unique insights, background context
+
+**What to extract:**
+- Each speaker's core positions (attributed)
+- Points of agreement and disagreement
+- Anecdotes or examples that illustrate key points
+- Paraphrased notable statements (with timestamps)
+- Background context the interviewer provides
+- Recommendations (books, tools, practices) each person makes
+
+**What to skip:** Small talk, repeated questions, filler conversation
+
+**Output structure:**
+```
+## TL;DR
+[Core topic and main takeaway]
+
+## Key Concepts
+- **[Speaker A]'s position**: [summary]
+- **[Speaker B]'s position**: [summary]
+
+## Detailed Analysis
+### Topic 1: [Theme]
+- [Speaker A]: [position]
+- [Speaker B]: [position]
+### Topic 2: [Theme]
+...
+
+## Notable Quotes / Statements
+- "[Paraphrased quote]" — [Speaker], on [topic] ([timestamp])
+
+## Actionable Takeaways
+[Synthesized advice from all speakers]
+```
+
+---
+
+## Podcast
+
+**Focus areas:** Topics covered, opinions, recommendations, tangents worth noting
+
+**What to extract:**
+- Topic thread progression (what was discussed, in what order)
+- Opinions expressed (attributed to speaker)
+- Recommendations: books, tools, services, people, content
+- Anecdotes that illustrate points
+- Running jokes or references (for context)
+- Disagreements between hosts/guests
+
+**What to skip:** Ad reads, repeated self-promotion, extensive inside jokes without substance
+
+**Output structure:**
+```
+## TL;DR
+[Main topics and one key insight]
+
+## Key Concepts
+### Topic Thread: [Theme 1]
+### Topic Thread: [Theme 2]
+...
+
+## Detailed Analysis
+[Topic-by-topic breakdown with speaker attributions]
+
+## Notable Quotes / Statements
+[Memorable or insightful statements]
+
+## Actionable Takeaways
+- Recommendations mentioned:
+  - Books: [list]
+  - Tools: [list]
+  - People to follow: [list]
+```
+
+---
+
+## Tech Talk
+
+**Focus areas:** Architecture decisions, trade-offs, benchmarks, lessons learned, production experience
+
+**What to extract:**
+- Problem statement and constraints
+- Architecture or system design described
+- Trade-offs explicitly discussed (chose X over Y because Z)
+- Performance numbers, benchmarks, scale metrics
+- Lessons learned from production
+- Technologies and versions mentioned
+- What they'd do differently
+
+**What to skip:** Company recruiting pitches, overly basic background for the audience level
+
+**Output structure:**
+```
+## TL;DR
+[Problem solved and approach taken]
+
+## Key Concepts
+- **Problem**: [statement]
+- **Solution**: [approach]
+- **Scale**: [numbers if mentioned]
+
+## Detailed Analysis
+### Problem & Constraints
+### Architecture / Design
+### Trade-offs
+| Decision | Chose | Over | Rationale |
+|----------|-------|------|-----------|
+### Performance / Results
+### Lessons Learned
+
+## Technical Terms & Definitions
+[Domain-specific terms defined in context]
+
+## Actionable Takeaways
+[What to apply in your own systems]
+```
+
+---
+
+## Panel
+
+**Focus areas:** Consensus vs. disagreement, unique perspectives per speaker, emerging themes
+
+**What to extract:**
+- Each panelist's background (as introduced)
+- Consensus points (what everyone agrees on)
+- Disagreement points (attributed positions)
+- Unique perspectives only one panelist holds
+- Moderator's framing questions
+- Audience questions that shifted discussion
+
+**What to skip:** Introductions beyond establishing expertise, repeated moderator summaries
+
+**Output structure:**
+```
+## TL;DR
+[Panel topic and the one thing that emerged]
+
+## Key Concepts
+### Panelists
+- **[Name]**: [role/background], key position: [summary]
+...
+
+## Detailed Analysis
+### Theme 1: [Topic]
+- **Consensus**: [what all agree on]
+- **[Panelist A]**: [unique angle]
+- **[Panelist B]**: [contrasting view]
+### Theme 2: [Topic]
+...
+
+## Notable Quotes / Statements
+- "[Quote]" — [Speaker] ([timestamp])
+
+## Actionable Takeaways
+[Synthesized wisdom across all panelists]
+```
+
+---
+
+## Auto-Detection Heuristics
+
+When `--type auto`, Claude should infer the video type from:
+
+| Signal | Likely Type |
+|--------|-------------|
+| Single speaker, academic tone, citations | Lecture |
+| "Let me show you how to..." / screen share references | Tutorial |
+| Two speakers, question-answer pattern | Interview |
+| Casual conversation, multiple topics, recurring hosts | Podcast |
+| Conference stage, system/architecture focus | Tech Talk |
+| 3+ speakers, moderator, topic rotation | Panel |
+
+If uncertain, default to a generic analysis that pulls from all patterns.

--- a/skills/youtube-analysis/scripts/analyze_video.py
+++ b/skills/youtube-analysis/scripts/analyze_video.py
@@ -1,0 +1,174 @@
+"""Orchestrator: fetch transcript + metadata, structure output for Claude analysis.
+
+This script handles data acquisition and formatting. The actual concept analysis
+is performed by Claude using SKILL.md instructions, not by this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from fetch_transcript import fetch_video
+from utils import (
+    chunk_transcript,
+    estimate_duration_category,
+    format_timestamp,
+    sanitize_filename,
+)
+
+
+def load_template() -> str:
+    """Load the output Markdown template.
+
+    Returns:
+        Template string with {placeholders}.
+    """
+    template_path = Path(__file__).parent.parent / "assets" / "output-template.md"
+    return template_path.read_text()
+
+
+def build_scaffold(
+    data: dict,
+    depth: str,
+    video_type: str,
+) -> str:
+    """Build the Markdown scaffold from video data.
+
+    Populates metadata fields and prepares transcript sections.
+    Analysis placeholders remain for Claude to fill.
+
+    Args:
+        data: Video data dict from fetch_video().
+        depth: Analysis depth (quick, standard, deep).
+        video_type: Video type hint (auto, lecture, tutorial, etc.).
+
+    Returns:
+        Markdown string with metadata populated and transcript appended.
+    """
+    template = load_template()
+    duration = format_timestamp(data["duration_seconds"])
+    video_url = f"https://www.youtube.com/watch?v={data['video_id']}"
+
+    # Populate metadata fields
+    output = template.format(
+        title=data["title"],
+        channel=data["channel"],
+        duration=duration,
+        upload_date=data["upload_date"],
+        video_url=video_url,
+        tldr="[TO BE ANALYZED]",
+        key_concepts="[TO BE ANALYZED]",
+        detailed_analysis="[TO BE ANALYZED]",
+        notable_quotes="[TO BE ANALYZED]",
+        terms="[TO BE ANALYZED]",
+        takeaways="[TO BE ANALYZED]",
+        related="[TO BE ANALYZED]",
+    )
+
+    # Append analysis context
+    duration_cat = estimate_duration_category(data["duration_seconds"])
+    sections = [
+        output,
+        "",
+        "---",
+        "",
+        "## Analysis Context",
+        "",
+        f"- **Video type**: {video_type}",
+        f"- **Analysis depth**: {depth}",
+        f"- **Duration category**: {duration_cat}",
+        f"- **Transcript language**: {data['language']}",
+        f"- **Transcript source**: {data['source']}",
+        f"- **Segment count**: {len(data['transcript'])}",
+    ]
+
+    if data.get("tags"):
+        sections.append(f"- **Tags**: {', '.join(data['tags'][:20])}")
+
+    if data.get("description"):
+        desc = data["description"][:500]
+        if len(data["description"]) > 500:
+            desc += "..."
+        sections.extend(["", "### Video Description", "", desc])
+
+    # Chunked transcript for deep analysis
+    if depth == "deep":
+        chunks = chunk_transcript(data["transcript"], chunk_minutes=5)
+        sections.extend(["", "### Transcript (Chunked by 5-minute segments)", ""])
+        for chunk in chunks:
+            sections.append(
+                f"**[{chunk['start_formatted']} - {chunk['end_formatted']}]**"
+            )
+            sections.append("")
+            sections.append(chunk["text"])
+            sections.append("")
+    else:
+        sections.extend(["", "### Full Transcript", "", data["transcript_text"]])
+
+    return "\n".join(sections)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Fetch and structure YouTube video data for analysis."
+    )
+    parser.add_argument("url", help="YouTube URL or video ID")
+    parser.add_argument(
+        "--output",
+        help="Output file path (default: ./{sanitized_title}.md)",
+    )
+    parser.add_argument(
+        "--depth",
+        choices=["quick", "standard", "deep"],
+        default="standard",
+        help="Analysis depth (default: standard)",
+    )
+    parser.add_argument(
+        "--type",
+        dest="video_type",
+        choices=["auto", "lecture", "tutorial", "interview", "podcast", "tech-talk", "panel"],
+        default="auto",
+        help="Video type hint (default: auto)",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Preferred transcript language (default: en)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON instead of Markdown scaffold",
+    )
+    args = parser.parse_args()
+
+    # Fetch video data
+    data = fetch_video(args.url, args.lang)
+
+    if args.json:
+        json.dump(data, sys.stdout, ensure_ascii=False, indent=2)
+        print()
+        sys.exit(0)
+
+    # Build scaffold
+    scaffold = build_scaffold(data, args.depth, args.video_type)
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        filename = sanitize_filename(data["title"]) + ".md"
+        output_path = Path.cwd() / filename
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(scaffold)
+    print(f"Output written to: {output_path}", file=sys.stderr)
+    print(str(output_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/youtube-analysis/scripts/fetch_transcript.py
+++ b/skills/youtube-analysis/scripts/fetch_transcript.py
@@ -1,0 +1,265 @@
+"""Fetch YouTube video transcript and metadata.
+
+Standalone CLI tool. Outputs JSON to stdout, status messages to stderr.
+Primary: youtube-transcript-api (no API key). Fallback: yt-dlp subtitles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+from utils import parse_youtube_url
+
+
+def _log(msg: str) -> None:
+    """Print status message to stderr."""
+    print(msg, file=sys.stderr)
+
+
+def fetch_transcript_api(video_id: str, lang: str) -> tuple[list[dict], str, str]:
+    """Fetch transcript via youtube-transcript-api.
+
+    Args:
+        video_id: YouTube video ID.
+        lang: Preferred language code.
+
+    Returns:
+        Tuple of (transcript_segments, language_used, source_name).
+
+    Raises:
+        RuntimeError: If transcript unavailable or library fails.
+    """
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    _log(f"Fetching transcript via youtube-transcript-api (lang={lang})...")
+
+    ytt = YouTubeTranscriptApi()
+
+    # Try direct fetch with requested language first
+    try:
+        fetched = ytt.fetch(video_id, languages=[lang])
+        segments = [
+            {"start": s.start, "duration": s.duration, "text": s.text}
+            for s in fetched
+        ]
+        return segments, lang, "youtube-transcript-api"
+    except Exception:
+        pass
+
+    # Fall back: list available transcripts, pick first available
+    try:
+        transcript_list = ytt.list(video_id)
+        available = list(transcript_list)
+        if not available:
+            raise RuntimeError("No transcripts available for this video")
+        transcript = available[0]
+        _log(f"Requested lang '{lang}' unavailable. Using '{transcript.language_code}'")
+        fetched = transcript.fetch()
+        segments = [
+            {"start": s.start, "duration": s.duration, "text": s.text}
+            for s in fetched
+        ]
+        return segments, transcript.language_code, "youtube-transcript-api"
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"No usable transcript found: {exc}") from exc
+
+
+def fetch_transcript_ytdlp(video_id: str, lang: str) -> tuple[list[dict], str, str]:
+    """Fetch transcript via yt-dlp subtitle extraction.
+
+    Args:
+        video_id: YouTube video ID.
+        lang: Preferred language code.
+
+    Returns:
+        Tuple of (transcript_segments, language_used, source_name).
+
+    Raises:
+        RuntimeError: If yt-dlp fails or no subtitles found.
+    """
+    import json as _json
+    import tempfile
+    from pathlib import Path
+
+    _log("Falling back to yt-dlp for transcript...")
+    url = f"https://www.youtube.com/watch?v={video_id}"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = [
+            "yt-dlp",
+            "--write-sub",
+            "--write-auto-sub",
+            "--sub-lang", lang,
+            "--sub-format", "json3",
+            "--skip-download",
+            "--output", f"{tmpdir}/%(id)s",
+            url,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            raise RuntimeError(f"yt-dlp subtitle extraction failed: {result.stderr.strip()}")
+
+        # Find the subtitle file
+        sub_files = list(Path(tmpdir).glob("*.json3"))
+        if not sub_files:
+            raise RuntimeError("yt-dlp produced no subtitle files")
+
+        sub_data = _json.loads(sub_files[0].read_text())
+        events = sub_data.get("events", [])
+        segments = []
+        for event in events:
+            segs = event.get("segs")
+            if not segs:
+                continue
+            text = "".join(s.get("utf8", "") for s in segs).strip()
+            if not text or text == "\n":
+                continue
+            start_ms = event.get("tStartMs", 0)
+            duration_ms = event.get("dDurationMs", 0)
+            segments.append({
+                "start": start_ms / 1000.0,
+                "duration": duration_ms / 1000.0,
+                "text": text,
+            })
+
+        if not segments:
+            raise RuntimeError("yt-dlp subtitle file contained no usable segments")
+
+        # Determine actual language from filename
+        actual_lang = lang
+        fname = sub_files[0].name
+        parts = fname.rsplit(".", 2)
+        if len(parts) >= 3:
+            actual_lang = parts[-2]
+
+        return segments, actual_lang, "yt-dlp"
+
+
+def fetch_metadata(video_id: str) -> dict[str, Any]:
+    """Extract video metadata via yt-dlp.
+
+    Args:
+        video_id: YouTube video ID.
+
+    Returns:
+        Dict with title, channel, duration_seconds, upload_date,
+        description, view_count, tags.
+    """
+    _log("Fetching metadata via yt-dlp...")
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    cmd = ["yt-dlp", "--dump-json", "--no-download", url]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        _log(f"Metadata fetch failed: {result.stderr.strip()}")
+        return {
+            "title": "Unknown",
+            "channel": "Unknown",
+            "duration_seconds": 0,
+            "upload_date": "Unknown",
+            "description": "",
+            "view_count": 0,
+            "tags": [],
+        }
+
+    data = json.loads(result.stdout)
+    upload_date = data.get("upload_date", "")
+    if len(upload_date) == 8:
+        upload_date = f"{upload_date[:4]}-{upload_date[4:6]}-{upload_date[6:]}"
+
+    return {
+        "title": data.get("title", "Unknown"),
+        "channel": data.get("channel", data.get("uploader", "Unknown")),
+        "duration_seconds": data.get("duration", 0),
+        "upload_date": upload_date,
+        "description": data.get("description", ""),
+        "view_count": data.get("view_count", 0),
+        "tags": data.get("tags") or [],
+    }
+
+
+def fetch_video(url_or_id: str, lang: str = "en") -> dict[str, Any]:
+    """Fetch transcript and metadata for a YouTube video.
+
+    Args:
+        url_or_id: YouTube URL or video ID.
+        lang: Preferred transcript language.
+
+    Returns:
+        Complete video data dict ready for JSON serialization.
+
+    Raises:
+        SystemExit: On unrecoverable errors.
+    """
+    video_id = parse_youtube_url(url_or_id)
+    if not video_id:
+        _log(f"ERROR: Cannot parse YouTube URL or video ID: {url_or_id}")
+        sys.exit(1)
+
+    _log(f"Video ID: {video_id}")
+
+    # Fetch transcript: primary then fallback
+    segments: list[dict] = []
+    language = lang
+    source = ""
+
+    try:
+        segments, language, source = fetch_transcript_api(video_id, lang)
+    except (RuntimeError, ImportError) as exc:
+        _log(f"Primary transcript fetch failed: {exc}")
+        try:
+            segments, language, source = fetch_transcript_ytdlp(video_id, lang)
+        except RuntimeError as exc2:
+            _log(f"Fallback transcript fetch failed: {exc2}")
+            _log("ERROR: No transcript available for this video")
+            sys.exit(2)
+
+    _log(f"Transcript: {len(segments)} segments via {source} (lang={language})")
+
+    # Fetch metadata
+    metadata = fetch_metadata(video_id)
+
+    transcript_text = " ".join(seg["text"] for seg in segments)
+
+    return {
+        "video_id": video_id,
+        "title": metadata["title"],
+        "channel": metadata["channel"],
+        "duration_seconds": metadata["duration_seconds"],
+        "upload_date": metadata["upload_date"],
+        "description": metadata["description"],
+        "view_count": metadata["view_count"],
+        "tags": metadata["tags"],
+        "transcript": segments,
+        "transcript_text": transcript_text,
+        "language": language,
+        "source": source,
+    }
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Fetch YouTube video transcript and metadata."
+    )
+    parser.add_argument("url", help="YouTube URL or video ID")
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Preferred transcript language (default: en)",
+    )
+    args = parser.parse_args()
+
+    data = fetch_video(args.url, args.lang)
+    json.dump(data, sys.stdout, ensure_ascii=False, indent=2)
+    print()  # trailing newline
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/youtube-analysis/scripts/utils.py
+++ b/skills/youtube-analysis/scripts/utils.py
@@ -1,0 +1,177 @@
+"""Shared utilities for YouTube video analysis."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+
+def parse_youtube_url(url: str) -> str | None:
+    """Extract video ID from any YouTube URL format.
+
+    Supports:
+        - youtube.com/watch?v=ID
+        - youtu.be/ID
+        - youtube.com/shorts/ID
+        - youtube.com/embed/ID
+        - youtube.com/v/ID
+        - youtube.com/live/ID
+        - URLs with extra params (timestamps, playlists, etc.)
+        - Bare video IDs (11 chars, alphanumeric + - _)
+
+    Args:
+        url: YouTube URL or bare video ID.
+
+    Returns:
+        Video ID string, or None if unparseable.
+    """
+    url = url.strip()
+
+    # Bare video ID: exactly 11 chars of [A-Za-z0-9_-]
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", url):
+        return url
+
+    parsed = urlparse(url)
+
+    # youtu.be/ID
+    if parsed.hostname in ("youtu.be", "www.youtu.be"):
+        video_id = parsed.path.lstrip("/").split("/")[0]
+        if re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id):
+            return video_id
+        return None
+
+    # youtube.com variants
+    if parsed.hostname not in (
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+    ):
+        return None
+
+    # /watch?v=ID
+    if parsed.path == "/watch":
+        params = parse_qs(parsed.query)
+        video_ids = params.get("v")
+        if video_ids:
+            video_id = video_ids[0]
+            if re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id):
+                return video_id
+        return None
+
+    # /shorts/ID, /embed/ID, /v/ID, /live/ID
+    path_match = re.match(r"/(?:shorts|embed|v|live)/([A-Za-z0-9_-]{11})", parsed.path)
+    if path_match:
+        return path_match.group(1)
+
+    return None
+
+
+def format_timestamp(seconds: float) -> str:
+    """Convert seconds to HH:MM:SS or MM:SS format.
+
+    Args:
+        seconds: Time in seconds.
+
+    Returns:
+        Formatted timestamp string.
+    """
+    total = int(seconds)
+    h, remainder = divmod(total, 3600)
+    m, s = divmod(remainder, 60)
+    if h > 0:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+def sanitize_filename(title: str) -> str:
+    """Clean a video title for filesystem use.
+
+    Args:
+        title: Raw video title.
+
+    Returns:
+        Filesystem-safe filename (no extension).
+    """
+    # Replace filesystem-unsafe chars with hyphens
+    cleaned = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "-", title)
+    # Collapse whitespace and hyphens
+    cleaned = re.sub(r"[\s-]+", "-", cleaned)
+    # Strip leading/trailing hyphens and dots
+    cleaned = cleaned.strip("-.")
+    # Truncate to 200 chars to avoid path length issues
+    return cleaned[:200] if cleaned else "untitled"
+
+
+def chunk_transcript(
+    transcript: list[dict], chunk_minutes: int = 5
+) -> list[dict]:
+    """Group transcript segments into N-minute chunks for analysis.
+
+    Args:
+        transcript: List of segments with 'start', 'duration', 'text' keys.
+        chunk_minutes: Size of each chunk in minutes.
+
+    Returns:
+        List of chunk dicts with 'start', 'end', 'text', 'start_formatted',
+        'end_formatted' keys.
+    """
+    if not transcript:
+        return []
+
+    chunk_seconds = chunk_minutes * 60
+    chunks: list[dict] = []
+    current_texts: list[str] = []
+    chunk_start = 0.0
+    chunk_boundary = chunk_seconds
+
+    for segment in transcript:
+        seg_start = segment.get("start", 0.0)
+        seg_text = segment.get("text", "").strip()
+
+        if seg_start >= chunk_boundary and current_texts:
+            chunks.append({
+                "start": chunk_start,
+                "end": seg_start,
+                "start_formatted": format_timestamp(chunk_start),
+                "end_formatted": format_timestamp(seg_start),
+                "text": " ".join(current_texts),
+            })
+            current_texts = []
+            chunk_start = seg_start
+            chunk_boundary = chunk_start + chunk_seconds
+
+        if seg_text:
+            current_texts.append(seg_text)
+
+    # Final chunk
+    if current_texts:
+        last_seg = transcript[-1]
+        end_time = last_seg.get("start", 0.0) + last_seg.get("duration", 0.0)
+        chunks.append({
+            "start": chunk_start,
+            "end": end_time,
+            "start_formatted": format_timestamp(chunk_start),
+            "end_formatted": format_timestamp(end_time),
+            "text": " ".join(current_texts),
+        })
+
+    return chunks
+
+
+def estimate_duration_category(seconds: int) -> str:
+    """Classify video duration for analysis depth calibration.
+
+    Args:
+        seconds: Video duration in seconds.
+
+    Returns:
+        One of: 'short' (<10m), 'medium' (10-30m), 'long' (30-90m), 'extended' (>90m).
+    """
+    if seconds < 600:
+        return "short"
+    if seconds < 1800:
+        return "medium"
+    if seconds < 5400:
+        return "long"
+    return "extended"


### PR DESCRIPTION
## Summary

- Add `youtube-analysis` skill for extracting YouTube video transcripts and producing structured concept analysis — no API keys, no MCP dependency
- Core Python scripts: URL parsing (9 formats), transcript extraction via `youtube-transcript-api` v1.x with `yt-dlp` fallback, metadata extraction, Markdown scaffold generation
- SKILL.md with 19 trigger phrases, 6-step workflow, error handling table, and limitations section (scored **95.8% Exemplary** by skill-evaluator)
- Analysis patterns for 6 video types (lecture, tutorial, interview, podcast, tech talk, panel) with per-type extraction guidance and auto-detection heuristics
- Manifest updated: 37 → 38 skills

## Test plan

- [x] `utils.py`: All 12 URL parsing tests pass (9 valid formats + 3 invalid)
- [x] `utils.py`: Timestamp formatting, filename sanitization, duration categorization verified
- [x] `fetch_transcript.py`: Short video (jNQXAC9IVRw, 19s) — 6 segments via youtube-transcript-api
- [x] `fetch_transcript.py`: Long video (Unzc731iCUY, 63min MIT lecture) — 1166 segments via youtube-transcript-api
- [x] `fetch_transcript.py`: yt-dlp fallback path verified when primary library unavailable
- [x] `fetch_transcript.py`: Invalid video ID returns exit code 1 with clear error
- [x] `analyze_video.py`: Scaffold output with metadata populated, `[TO BE ANALYZED]` placeholders
- [x] SKILL.md under 500 lines (240 lines)
- [x] Frontmatter description 740 chars with 19 trigger phrases and "Use this skill when..." clause
- [x] All 5 referenced files exist on disk
- [x] Manifest regenerated with 38 skills
- [x] Skill evaluator: 95.8% Exemplary, no CRITICAL or HIGH findings