### PR TITLE
Modernise skill catalog: trigger resolution, deprecations, 100% eval coverage, CI gate

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,65 @@
+name: Skill Evals
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/validate_evals.py'
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+  schedule:
+    - cron: '0 0 * * 1'  # Weekly Monday — catches model drift
+
+jobs:
+  validate:
+    name: Validate eval schema & manifest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate manifest is up to date
+        run: |
+          python scripts/generate_manifest.py
+          git diff --exit-code skills.yaml || {
+            echo "ERROR: skills.yaml is out of sync with SKILL.md files"
+            echo "Run 'python scripts/generate_manifest.py' and commit the result"
+            exit 1
+          }
+
+      - name: Validate eval cases schema
+        run: python scripts/validate_evals.py
+
+      - name: Check eval coverage for changed skills
+        if: github.event_name == 'pull_request'
+        run: |
+          changed_skills=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- skills/ \
+            | grep 'SKILL.md' \
+            | sed 's|skills/\([^/]*\)/.*|\1|' \
+            | sort -u)
+
+          missing=0
+          for skill in $changed_skills; do
+            if [ ! -f "skills/${skill}/evals/cases.yaml" ]; then
+              echo "WARNING: skills/${skill}/SKILL.md changed but no evals/cases.yaml found"
+              missing=$((missing + 1))
+            fi
+          done
+
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "${missing} changed skill(s) have no eval cases."
+            echo "Consider adding evals/cases.yaml for modified skills."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ playwright-report/
 
 # ── Skill packaging ──────────────────────────
 *.skill
-evals/
+evals/results/
 
 # ── Editors & IDE ─────────────────────────────
 .vscode/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[extend]
+# Use default gitleaks rules, extend with commit-specific allowlist below
+
+[[allowlist.commits]]
+# Historical commits with intentionally fake API keys in eval test prompts.
+# These were replaced in later commits but gitleaks scans full history.
+# Pinned to exact commit fingerprints — future commits are still scanned.
+commits = [
+  "4f1f98ffbce533991460754d0ea64e56789ab674",
+  "70478446ae4c2e9153561721e49ede93fbde4acd",
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,10 @@
 [extend]
 # Use default gitleaks rules, extend with commit-specific allowlist below
 
-[[allowlist.commits]]
+[allowlist]
 # Historical commits with intentionally fake API keys in eval test prompts.
 # These were replaced in later commits but gitleaks scans full history.
-# Pinned to exact commit fingerprints — future commits are still scanned.
+# Pinned to exact commit SHAs — future commits are still scanned.
 commits = [
   "4f1f98ffbce533991460754d0ea64e56789ab674",
   "70478446ae4c2e9153561721e49ede93fbde4acd",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: generate-manifest
+        name: Regenerate skills.yaml
+        entry: python scripts/generate_manifest.py
+        language: python
+        additional_dependencies: [pyyaml]
+        pass_filenames: false
+        files: ^skills/
+
       - id: block-env-files
         name: block-env-files
         entry: bash -c 'if git diff --cached --name-only | grep -qE "^\.env"; then echo "Blocked: .env file"; exit 1; fi'

--- a/scripts/validate_evals.py
+++ b/scripts/validate_evals.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate eval cases.yaml files across all skills."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+REQUIRED_CASE_FIELDS = {"id", "prompt", "rubric", "trigger_expected"}
+
+
+def validate_case(case: dict, skill_name: str, idx: int) -> list[str]:
+    """Validate a single eval case and return errors."""
+    errors: list[str] = []
+    prefix = f"{skill_name} case #{idx}"
+
+    missing = REQUIRED_CASE_FIELDS - set(case.keys())
+    if missing:
+        errors.append(f"{prefix}: missing required fields: {missing}")
+        return errors
+
+    if not isinstance(case["id"], str) or not case["id"]:
+        errors.append(f"{prefix}: 'id' must be a non-empty string")
+
+    if not isinstance(case["prompt"], str) or not case["prompt"].strip():
+        errors.append(f"{prefix}: 'prompt' must be a non-empty string")
+
+    if not isinstance(case["trigger_expected"], bool):
+        errors.append(f"{prefix}: 'trigger_expected' must be a boolean")
+
+    if not isinstance(case["rubric"], list) or len(case["rubric"]) == 0:
+        errors.append(f"{prefix}: 'rubric' must be a non-empty list")
+
+    return errors
+
+
+def validate_skill_evals(skill_dir: Path) -> list[str]:
+    """Validate evals/cases.yaml for a single skill."""
+    cases_file = skill_dir / "evals" / "cases.yaml"
+    if not cases_file.exists():
+        return []
+
+    skill_name = skill_dir.name
+    errors: list[str] = []
+
+    try:
+        data = yaml.safe_load(cases_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        return [f"{skill_name}: invalid YAML in cases.yaml: {e}"]
+
+    if not isinstance(data, dict) or "cases" not in data:
+        return [f"{skill_name}: cases.yaml must have a top-level 'cases' key"]
+
+    cases = data["cases"]
+    if not isinstance(cases, list) or len(cases) == 0:
+        return [f"{skill_name}: 'cases' must be a non-empty list"]
+
+    ids: set[str] = set()
+    positive_count = 0
+    negative_count = 0
+
+    for i, case in enumerate(cases, 1):
+        errors.extend(validate_case(case, skill_name, i))
+
+        case_id = case.get("id", "")
+        if case_id in ids:
+            errors.append(f"{skill_name} case #{i}: duplicate id '{case_id}'")
+        ids.add(case_id)
+
+        if case.get("trigger_expected") is True:
+            positive_count += 1
+        elif case.get("trigger_expected") is False:
+            negative_count += 1
+
+    if positive_count == 0:
+        errors.append(f"{skill_name}: must have at least 1 positive case (trigger_expected: true)")
+
+    if negative_count < 2:
+        errors.append(f"{skill_name}: must have at least 2 negative cases (trigger_expected: false), found {negative_count}")
+
+    return errors
+
+
+def main() -> int:
+    """Validate all eval cases across skills."""
+    all_errors: list[str] = []
+    validated = 0
+
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        cases_file = skill_dir / "evals" / "cases.yaml"
+        if not cases_file.exists():
+            continue
+
+        errors = validate_skill_evals(skill_dir)
+        all_errors.extend(errors)
+        validated += 1
+
+    if all_errors:
+        print(f"FAILED: {len(all_errors)} error(s) in {validated} eval file(s):", file=sys.stderr)
+        for error in all_errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {validated} eval file(s) — all passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_evals.py
+++ b/scripts/validate_evals.py
@@ -13,6 +13,25 @@ SKILLS_DIR = REPO_ROOT / "skills"
 REQUIRED_CASE_FIELDS = {"id", "prompt", "rubric", "trigger_expected"}
 
 
+def is_deprecated(skill_dir: Path) -> bool:
+    """Check if a skill is deprecated by reading its SKILL.md frontmatter."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            return False
+        end = text.index("---", 3)
+        frontmatter = yaml.safe_load(text[3:end])
+        return (
+            isinstance(frontmatter, dict)
+            and frontmatter.get("metadata", {}).get("status") == "deprecated"
+        )
+    except (ValueError, yaml.YAMLError):
+        return False
+
+
 def validate_case(case: dict, skill_name: str, idx: int) -> list[str]:
     """Validate a single eval case and return errors."""
     errors: list[str] = []
@@ -45,6 +64,7 @@ def validate_skill_evals(skill_dir: Path) -> list[str]:
         return []
 
     skill_name = skill_dir.name
+    deprecated = is_deprecated(skill_dir)
     errors: list[str] = []
 
     try:
@@ -76,8 +96,12 @@ def validate_skill_evals(skill_dir: Path) -> list[str]:
         elif case.get("trigger_expected") is False:
             negative_count += 1
 
-    if positive_count == 0:
-        errors.append(f"{skill_name}: must have at least 1 positive case (trigger_expected: true)")
+    if deprecated:
+        if positive_count > 0:
+            errors.append(f"{skill_name}: deprecated skill must have 0 positive cases, found {positive_count}")
+    else:
+        if positive_count == 0:
+            errors.append(f"{skill_name}: must have at least 1 positive case (trigger_expected: true)")
 
     if negative_count < 2:
         errors.append(f"{skill_name}: must have at least 2 negative cases (trigger_expected: false), found {negative_count}")

--- a/skills.yaml
+++ b/skills.yaml
@@ -165,6 +165,15 @@ skills:
     minimal, corporate, hacker terminal). Consider asking the user for clarification on theme, navigation direction, and content
     structure if not already specified.
   path: skills/html-presentation
+- name: immune
+  version: 3.0.0
+  description: 'Hybrid adaptive memory system with two complementary memories: Cheatsheet (positive patterns injected before
+    generation) and Immune (negative patterns scanned after generation). Uses Hot/Cold tiered memory with multi-domain support
+    and auto-learning. Detects known errors via antibodies, discovers new threats, and learns winning strategies over time.
+    Triggers on: "scan for errors", "immune scan", "check output quality", "detect patterns", "scan content", "cheatsheet
+    injection", "antibody scan", "adaptive memory scan", "immune check", "quality scan", "pattern detection". NOT for general
+    code review or PR review — use pr-review instead. NOT for security audits of repositories — use repo-sentinel instead.'
+  path: skills/immune
 - name: linkedin-post-style
   version: 1.1.0
   description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and precise.

--- a/skills.yaml
+++ b/skills.yaml
@@ -95,12 +95,13 @@ skills:
   path: skills/concept-to-video
 - name: debug-investigator
   version: 1.0.0
-  description: 'Hypothesis-driven debugging framework: symptom capture, evidence analysis, hypothesis ranking, bisection strategy,
-    log analysis, instrumentation, and minimal reproduction. Triggers on: "debug this", "why is this failing", "root cause",
-    "diagnose", "this error", "this exception", "this stacktrace", "not working", "broken", "unexpected behavior", "bisect",
-    "narrow down", "isolate the issue", "help me debug". Use this skill when confronted with a bug, error, or unexpected behavior
-    in code. NOT for abstract reasoning, trade-off evaluation, or general problem decomposition without a specific error —
-    use sequential-thinking instead.'
+  description: 'Hypothesis-driven debugging methodology: ranked hypotheses with confirming/refuting tests, git bisect strategy,
+    log analysis, instrumentation point planning, and minimal reproduction design. Triggers on: "debug this systematically",
+    "root cause analysis", "bisect this bug", "rank hypotheses for this error", "help me isolate this issue", "create a minimal
+    reproduction", "instrumentation plan for this bug", "why does this keep failing". The differentiator is the structured
+    investigation methodology (hypothesis ranking, bisection strategy, instrumentation points) — use this skill for non-obvious
+    bugs that need systematic investigation, not simple errors the model diagnoses directly. NOT for abstract reasoning or
+    problem decomposition without a specific error — the model handles general reasoning natively.'
   path: skills/debug-investigator
 - name: dependency-audit
   version: 1.0.0
@@ -113,11 +114,8 @@ skills:
   path: skills/dependency-audit
 - name: doc-condenser
   version: 1.0.0
-  description: Transform verbose technical documentation into concise, scannable specs. Use this skill when you need to condense,
-    summarize, or reformat technical docs, specs, or READMEs — including when a document is too verbose, when you want a technical
-    summary, or when working with lengthy specification documents. Triggers on phrases like "make this concise", "too verbose",
-    "condense this", "technical summary", "strip the fluff", or "reformat this spec". See assets/template.md for the standard
-    output structure.
+  description: 'DEPRECATED: The base model handles document condensation and summarization natively at high quality. This
+    skill no longer provides meaningful uplift. Retained for reference only.'
   path: skills/doc-condenser
 - name: estimate-calibrator
   version: 1.0.0
@@ -256,11 +254,8 @@ skills:
   path: skills/rag-auditor
 - name: regex-builder
   version: 1.0.0
-  description: 'Generates, explains, and tests regular expression patterns. Builds patterns from positive and negative examples,
-    breaks down each component with a readable explanation table, generates edge-case test suites, and provides usage examples
-    in Python and JavaScript. Triggers on: "regex for", "regular expression", "pattern for", "match strings like", "extract
-    from", "build regex", "create pattern", "explain this regex", "what does this regex do", "regex to match", "parse with
-    regex", "validate format". Use this skill when building, explaining, or testing a regular expression pattern.'
+  description: 'DEPRECATED: The base model generates, explains, and tests regex patterns natively with high accuracy. This
+    skill no longer provides meaningful uplift. Retained for reference only.'
   path: skills/regex-builder
 - name: remotion-video
   version: 1.0.0
@@ -287,13 +282,8 @@ skills:
   path: skills/repo-sentinel
 - name: sequential-thinking
   version: 1.0.0
-  description: 'Structured, reflective problem-solving through sequential chain-of-thought reasoning. Replaces the Sequential
-    Thinking MCP server (sequentialthinking tool). Use this skill when facing complex multi-step problems, planning and design
-    tasks, analysis that may need course correction, architectural decisions requiring trade-off evaluation, or any task where
-    the full scope is unclear initially. Triggers on: "step by step reasoning", "chain of thought", "break down problem",
-    "think through this", "structured analysis", "multi-step problem solving", "reflective reasoning", "deep analysis", "complex
-    reasoning", "hypothesis verification", "branching analysis", "trade-off evaluation". NOT for diagnosing bugs, errors,
-    stacktraces, or unexpected behavior in code — use debug-investigator instead.'
+  description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through
+    sequential chain-of-thought reasoning that replaced the Sequential Thinking MCP server.'
   path: skills/sequential-thinking
 - name: skill-evaluator
   version: 1.0.0
@@ -326,12 +316,12 @@ skills:
   path: skills/static-web-artifacts-builder
 - name: task-decomposer
   version: 1.0.0
-  description: 'Breaks down large features into implementable tasks with dependency mapping, edge case identification, test
-    strategy planning, and phased execution order. Produces task tables with parallelization flags and risk flags for each
-    phase. Triggers on: "break down this feature", "decompose", "task breakdown", "how should I implement", "implementation
-    plan", "what are the steps for", "edge cases for", "plan this feature", "implementation steps", "break this into tasks",
-    "work breakdown", "dependency map", "phases". NOT for effort estimates, PERT calculations, or confidence intervals — use
-    estimate-calibrator instead. Use this skill when a feature or project needs to be broken into actionable steps.'
+  description: 'Produces structured phased task boards from feature requests: dependency-mapped work items with parallelization
+    flags, risk flags, edge case tables, and test strategy matrices. Triggers on: "decompose this feature", "task breakdown
+    with dependencies", "phased implementation plan", "dependency map for", "break this into tasks with phases", "work breakdown
+    structure". The differentiator is the structured output format (phased tables, parallelization flags, dependency chains)
+    — use this skill when you need a formal task board, not ad-hoc decomposition the model handles natively. NOT for effort
+    estimates, PERT calculations, or confidence intervals — use estimate-calibrator instead.'
   path: skills/task-decomposer
 - name: tavily
   version: 1.0.0

--- a/skills.yaml
+++ b/skills.yaml
@@ -26,13 +26,12 @@ skills:
   path: skills/api-docs-generator
 - name: architecture-diagram
   version: 1.0.0
-  description: Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons, CSS
-    Grid nested container layout, SVG path connection overlays, and color-coded connection legends. Use when the user asks
-    to create architecture diagrams, infrastructure diagrams, system topology diagrams, network diagrams, cloud architecture
-    visuals, deployment diagrams, integration flow diagrams, or any request involving visual representation of system components,
-    their containment hierarchy, and interconnections. Triggers on terms like "architecture diagram", "infra diagram", "system
-    diagram", "topology", "deployment diagram", "network diagram", "integration architecture", or when the user provides a
-    system description and asks for a visual/diagram.
+  description: 'Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons, CSS
+    Grid nested container layout, SVG path connection overlays, and color-coded connection legends. Triggers on: "architecture
+    diagram", "infra diagram", "system diagram", "deployment diagram", "network diagram", "topology", "draw architecture",
+    "visualize architecture", "system topology", or any request for visual representation of system components, containment
+    hierarchy, and interconnections. For architecture reviews, audits, critiques, or design assessments, use architecture-reviewer
+    instead.'
   path: skills/architecture-diagram
 - name: architecture-reviewer
   version: 1.0.0
@@ -42,7 +41,8 @@ skills:
     analysis of design docs, RFCs, specs; (3) Hybrid — drift detection between intent and implementation. Triggers on: "review
     architecture", "critique design", "audit system", "evaluate codebase", "find design flaws", "assess scalability", "check
     security", "enterprise readiness", "architecture assessment", "technical due diligence", or when user provides a system
-    design document or codebase and asks for feedback or improvements.'
+    design document or codebase and asks for feedback or improvements. For architecture diagrams, visuals, or topology drawings,
+    use architecture-diagram instead.'
   path: skills/architecture-reviewer
 - name: benchmark-runner
   version: 1.0.0
@@ -74,13 +74,13 @@ skills:
 - name: concept-to-image
   version: 1.0.0
   description: 'Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG
-    image. Use this skill whenever the user wants to create a visual representation of an idea and needs an image file output
-    (PNG or SVG). This includes: infographics, concept diagrams, flowcharts, comparison charts, process visuals, educational
-    diagrams, social media graphics, data visualizations, posters, cards, badges, icons, logos sketches, or any "make me an
-    image of X" request that can be achieved with HTML/CSS/SVG rather than photographic AI generation. Also trigger when the
-    user has an existing HTML visual and wants to export/convert it to PNG or SVG. Trigger phrases include: "create an image
-    of", "make a visual", "design a graphic", "export as PNG", "save as SVG", "concept to image", "turn this into an image",
-    "screenshot this HTML", "generate an infographic", or any request combining a concept description with image output.'
+    image file. Use this skill when the user explicitly needs an image file output (PNG or SVG). This includes: concept diagrams,
+    flowcharts, comparison charts, process visuals, educational diagrams, social media graphics, data visualizations, posters,
+    cards, badges, icons, logo sketches, or any "make me an image of X" request achievable with HTML/CSS/SVG rather than photographic
+    AI generation. Also trigger when the user has an existing HTML visual and wants to export/convert it to PNG or SVG. Trigger
+    phrases: "create an image of", "export as PNG", "save as SVG", "concept to image", "turn this into an image", "screenshot
+    this HTML", "design a graphic for export". For interactive HTML visuals opened in a browser, use static-web-artifacts-builder
+    instead.'
   path: skills/concept-to-image
 - name: concept-to-video
   version: 1.1.0
@@ -95,12 +95,12 @@ skills:
   path: skills/concept-to-video
 - name: debug-investigator
   version: 1.0.0
-  description: 'Systematic debugging framework: symptom capture, evidence analysis, hypothesis generation, bisection strategy,
-    log analysis, instrumentation, and minimal reproduction design. Transforms ad-hoc debugging into structured investigation
-    with ranked hypotheses and concrete investigation plans. Triggers on: "debug this", "why is this failing", "root cause",
-    "investigate", "diagnose", "this error", "this exception", "this stacktrace", "not working", "broken", "unexpected behavior",
-    "bisect", "narrow down", "isolate the issue", "help me debug". Use this skill when confronted with a bug, error, or unexpected
-    behavior in any codebase.'
+  description: 'Hypothesis-driven debugging framework: symptom capture, evidence analysis, hypothesis ranking, bisection strategy,
+    log analysis, instrumentation, and minimal reproduction. Triggers on: "debug this", "why is this failing", "root cause",
+    "diagnose", "this error", "this exception", "this stacktrace", "not working", "broken", "unexpected behavior", "bisect",
+    "narrow down", "isolate the issue", "help me debug". Use this skill when confronted with a bug, error, or unexpected behavior
+    in code. NOT for abstract reasoning, trade-off evaluation, or general problem decomposition without a specific error —
+    use sequential-thinking instead.'
   path: skills/debug-investigator
 - name: dependency-audit
   version: 1.0.0
@@ -125,8 +125,8 @@ skills:
     and assumption documentation. Breaks work into atomic units, identifies technical and scope uncertainties, calculates
     PERT ranges, and provides confidence rationale. Triggers on: "estimate this", "how long will this take", "effort estimate",
     "time estimate", "best case worst case", "confidence interval", "sizing", "estimate effort", "how big is this", "story
-    points", "t-shirt sizing", "estimate the work", "project estimate". Use this skill when a task or project needs an effort
-    estimate with explicit uncertainty.'
+    points", "t-shirt sizing", "estimate the work", "PERT". NOT for task decomposition, implementation plans, or dependency
+    mapping — use task-decomposer instead. Use this skill when a task or project needs an effort estimate with explicit uncertainty.'
   path: skills/estimate-calibrator
 - name: filesystem
   version: 1.0.0
@@ -237,21 +237,22 @@ skills:
   path: skills/pr-review
 - name: prompt-lab
   version: 1.0.0
-  description: 'Systematic prompt engineering: analyzes existing prompts for failure modes, generates structured variants
+  description: 'Systematic LLM prompt engineering: analyzes existing prompts for failure modes, generates structured variants
     (direct, few-shot, chain-of-thought), designs evaluation rubrics with weighted criteria, and produces test case suites
-    for comparing prompt performance. Triggers on: "improve this prompt", "prompt engineering", "prompt lab", "generate prompt
-    variants", "A/B test prompts", "evaluate this prompt", "prompt failure modes", "optimize prompt", "write a better prompt",
-    "prompt design", "prompt iteration", "few-shot examples". Use this skill when designing, improving, or evaluating LLM
-    prompts.'
+    for comparing prompt performance. Triggers on: "prompt engineering", "prompt lab", "generate prompt variants", "A/B test
+    prompts", "evaluate prompt", "optimize prompt", "write a better prompt", "prompt design", "prompt iteration", "few-shot
+    examples", "chain-of-thought prompt", "prompt failure modes", "improve this prompt". Use this skill when designing, improving,
+    or evaluating LLM prompts specifically. NOT for evaluating Claude Code skills or SKILL.md files — use skill-evaluator
+    instead.'
   path: skills/prompt-lab
 - name: rag-auditor
   version: 1.0.0
   description: 'Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across retrieval and generation stages. Measures
     precision, recall, MRR for retrieval; groundedness, completeness, and hallucination rate for generation. Diagnoses failure
-    root causes and recommends chunk, retrieval, and prompt improvements. Triggers on: "audit RAG", "RAG quality", "evaluate
-    retrieval", "hallucination detection", "retrieval precision", "why is RAG failing", "RAG diagnosis", "retrieval quality",
-    "RAG evaluation", "chunk quality", "RAG pipeline review", "grounding check". Use this skill when diagnosing or evaluating
-    a RAG pipeline''s quality.'
+    root causes and recommends chunk, retrieval, and prompt improvements. Triggers on: "audit RAG pipeline", "RAG quality",
+    "evaluate RAG retrieval", "hallucination detection", "retrieval precision", "why is RAG failing", "RAG diagnosis", "retrieval
+    quality", "RAG evaluation", "chunk quality", "RAG pipeline review", "grounding check". Use this skill when diagnosing
+    or evaluating a RAG pipeline''s quality. For general architecture or system audits, use architecture-reviewer instead.'
   path: skills/rag-auditor
 - name: regex-builder
   version: 1.0.0
@@ -288,22 +289,23 @@ skills:
   version: 1.0.0
   description: 'Structured, reflective problem-solving through sequential chain-of-thought reasoning. Replaces the Sequential
     Thinking MCP server (sequentialthinking tool). Use this skill when facing complex multi-step problems, planning and design
-    tasks, analysis that may need course correction, debugging with iterative hypothesis testing, architectural decisions
-    requiring trade-off evaluation, or any task where the full scope is unclear initially. Trigger on: sequential thinking,
-    step by step reasoning, chain of thought, break down problem, think through this, structured analysis, multi-step problem
-    solving, reflective reasoning, thought process, deep analysis, complex reasoning, hypothesis verification, branching analysis,
-    revision-based thinking, dynamic problem solving.'
+    tasks, analysis that may need course correction, architectural decisions requiring trade-off evaluation, or any task where
+    the full scope is unclear initially. Triggers on: "step by step reasoning", "chain of thought", "break down problem",
+    "think through this", "structured analysis", "multi-step problem solving", "reflective reasoning", "deep analysis", "complex
+    reasoning", "hypothesis verification", "branching analysis", "trade-off evaluation". NOT for diagnosing bugs, errors,
+    stacktraces, or unexpected behavior in code — use debug-investigator instead.'
   path: skills/sequential-thinking
 - name: skill-evaluator
   version: 1.0.0
-  description: 'Evaluate Claude Code skill quality across 6 weighted dimensions: frontmatter quality, trigger coverage, structural
-    completeness, content depth, consistency and integrity, and CONTRIBUTING.md compliance. Produces scored audit reports
-    with severity-classified findings and actionable recommendations. Two modes: (1) Quick Audit — single skill, full per-dimension
-    report with weighted scoring; (2) Full Audit — all skills in repo, comparative ranking table plus per-skill summaries.
-    Triggers on: "evaluate skill", "audit skill quality", "score skill", "skill review", "check skill completeness", "rate
-    this skill", "skill quality check", "grade skill", "assess skill", "skill audit", "how good is this skill", or when a
-    user asks for feedback on a SKILL.md file. Use this skill when reviewing skills before deployment, comparing skill quality
-    across a repo, or diagnosing why a skill fails to activate on relevant queries.'
+  description: 'Evaluate Claude Code SKILL.md quality across 6 weighted dimensions: frontmatter quality, trigger coverage,
+    structural completeness, content depth, consistency and integrity, and CONTRIBUTING.md compliance. Produces scored audit
+    reports with severity-classified findings and actionable recommendations. Two modes: (1) Quick Audit — single skill, full
+    per-dimension report with weighted scoring; (2) Full Audit — all skills in repo, comparative ranking table plus per-skill
+    summaries. Triggers on: "evaluate skill", "audit skill quality", "score skill", "skill review", "check skill completeness",
+    "rate this skill", "skill quality check", "grade skill", "assess skill", "skill audit", "how good is this skill", "SKILL.md
+    feedback". Use this skill when reviewing Claude Code skills before deployment, comparing skill quality across a repo,
+    or diagnosing why a skill fails to activate on relevant queries. NOT for evaluating or improving LLM prompts — use prompt-lab
+    instead.'
   path: skills/skill-evaluator
 - name: sql-optimizer
   version: 1.0.0
@@ -315,31 +317,29 @@ skills:
   path: skills/sql-optimizer
 - name: static-web-artifacts-builder
   version: 1.0.0
-  description: 'Suite of tools for creating elaborate, self-contained static HTML artifacts — infographics, interactive diagrams,
-    architecture visuals, data dashboards, and rich visual deliverables. Use this skill when asked to create an interactive
-    HTML artifact, build a self-contained web component, generate a static HTML visualization, make an interactive diagram,
-    produce a visual infographic, or render any high-density visual as a single HTML file. Zero build toolchain — no React,
-    no Vite, no Parcel. Pure HTML5 + CSS3 (Grid/Flexbox) + inline SVG. Triggers on: "create interactive HTML", "build self-contained
-    web component", "generate static HTML visualization", "make an interactive diagram", "produce infographic", "render as
-    HTML artifact", "build a visual dashboard", "create a diagram I can open in browser".'
+  description: 'Build elaborate, self-contained static HTML artifacts opened in a browser — interactive diagrams, architecture
+    visuals, data dashboards, HTML infographics, and rich interactive deliverables. Use this skill when the output is an HTML
+    file viewed in a browser. Zero build toolchain — no React, no Vite, no Parcel. Pure HTML5 + CSS3 (Grid/Flexbox) + inline
+    SVG. Triggers on: "interactive HTML", "self-contained web component", "open in browser", "interactive diagram", "visual
+    dashboard", "HTML artifact", "HTML infographic", "interactive infographic". For image file output (PNG/SVG), use concept-to-image
+    instead.'
   path: skills/static-web-artifacts-builder
 - name: task-decomposer
   version: 1.0.0
   description: 'Breaks down large features into implementable tasks with dependency mapping, edge case identification, test
-    strategy planning, and phased execution order. Produces task tables with effort sizing, parallelization flags, and risk
-    flags for each phase. Triggers on: "break down this feature", "decompose", "task breakdown", "how should I implement",
-    "implementation plan", "what are the steps for", "edge cases for", "plan this feature", "implementation steps", "break
-    this into tasks", "work breakdown", "project breakdown". Use this skill when a feature or project needs to be broken into
-    actionable steps.'
+    strategy planning, and phased execution order. Produces task tables with parallelization flags and risk flags for each
+    phase. Triggers on: "break down this feature", "decompose", "task breakdown", "how should I implement", "implementation
+    plan", "what are the steps for", "edge cases for", "plan this feature", "implementation steps", "break this into tasks",
+    "work breakdown", "dependency map", "phases". NOT for effort estimates, PERT calculations, or confidence intervals — use
+    estimate-calibrator instead. Use this skill when a feature or project needs to be broken into actionable steps.'
   path: skills/task-decomposer
 - name: tavily
   version: 1.0.0
-  description: 'AI-optimized web search and content extraction via Tavily API. Use this skill when you need to search the
-    web for current information, recent events, technical documentation, news, or any topic requiring live internet data.
-    Triggers on: "search the web", "look this up online", "find recent information about", "search for", "google this", "web
-    search", "look up", "find current data on", "what does the web say about", "research online", "fetch web content", "extract
-    page content", "get article text", "scrape URL". Tavily returns clean, AI-ready snippets — prefer it over raw web fetch
-    for search queries. Use extract for full page content when a specific URL is already known.'
+  description: 'AI-optimized web search via Tavily API. Use this skill when no specific URL is provided and the user needs
+    to search the web for current information, recent events, technical documentation, or news. Triggers on: "search the web",
+    "look this up online", "find recent information about", "search for", "google this", "web search", "look up", "find current
+    data on", "what does the web say about", "research online". NOT for fetching a known URL — use web-fetch for that. Tavily
+    returns clean, AI-ready snippets optimized for search-first intent.'
   path: skills/tavily
 - name: test-harness
   version: 1.0.0
@@ -353,12 +353,12 @@ skills:
 - name: web-fetch
   version: 1.0.0
   description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch MCP server (fetch_html,
-    fetch_json, fetch_markdown, fetch_txt). Covers HTTP GET/POST requests, JSON API consumption with jq, HTML retrieval, markdown
-    conversion, plain text extraction, authenticated requests, redirects, cookies, and timeouts. Trigger phrases: "fetch this
-    URL", "get the page content", "download HTML", "call this API", "curl this endpoint", "grab the JSON", "fetch markdown
-    from", "retrieve web content", "hit this endpoint", "scrape this page", "read this URL", "pull data from API", "make an
-    HTTP request". Use this skill when the user provides a URL and wants its content, when consuming REST APIs, or when extracting
-    readable content from web pages.'
+    fetch_json, fetch_markdown, fetch_txt). Use this skill when a specific URL is provided and the user wants its content.
+    Covers HTTP GET/POST, JSON API consumption with jq, HTML retrieval, markdown conversion, plain text extraction, authenticated
+    requests, redirects, cookies, and timeouts. Trigger phrases: "fetch this URL", "get the page content", "download HTML",
+    "call this API", "curl this endpoint", "grab the JSON", "fetch markdown from", "retrieve web content", "hit this endpoint",
+    "scrape this page", "read this URL", "pull data from API", "make an HTTP request", "extract page content", "get article
+    text". NOT for web searches without a URL — use tavily for that.'
   path: skills/web-fetch
 - name: youtube-analysis
   version: 1.0.0

--- a/skills/adr-writer/evals/cases.yaml
+++ b/skills/adr-writer/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: adr_postgresql_over_mongodb
+    prompt: "Write an ADR for choosing PostgreSQL over MongoDB for our user service"
+    fixtures: []
+    rubric:
+      - "Output includes ADR number and title in a standard format (e.g., ADR-NNNN: Title)"
+      - "Output includes a status field (e.g., Accepted, Proposed, Deprecated)"
+      - "Output contains context, decision, and consequences sections"
+    trigger_expected: true
+
+  - id: adr_event_sourcing_order_service
+    prompt: "Document the decision to use event sourcing for our order service"
+    fixtures: []
+    rubric:
+      - "Output includes an alternatives considered section listing rejected options"
+      - "Output lists both positive and negative consequences of the decision"
+    trigger_expected: true
+
+  - id: negative_api_documentation
+    prompt: "Write documentation for our API endpoints"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for general API documentation requests"
+    trigger_expected: false
+
+  - id: negative_technical_spec
+    prompt: "Create a technical spec for the new feature"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for technical spec creation"
+    trigger_expected: false

--- a/skills/agent-builder/evals/cases.yaml
+++ b/skills/agent-builder/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: claude_agent_code_reviewer
+    prompt: "Build a Claude agent that reviews code using the Agent SDK"
+    fixtures: []
+    rubric:
+      - "Output references claude_agent_sdk or claude -p for agent invocation"
+      - "Output includes tool creation or tool registration"
+      - "Output covers authentication setup or API key configuration"
+    trigger_expected: true
+
+  - id: headless_claude_automation
+    prompt: "Create a headless Claude automation script"
+    fixtures: []
+    rubric:
+      - "Output uses claude -p CLI for non-interactive execution"
+      - "Output covers session management or conversation handling"
+    trigger_expected: true
+
+  - id: negative_openai_chatbot
+    prompt: "Build a chatbot using the OpenAI API"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for non-Claude SDK agent building"
+    trigger_expected: false
+
+  - id: negative_rest_api_endpoint
+    prompt: "Create a REST API endpoint in FastAPI"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for general coding tasks"
+    trigger_expected: false

--- a/skills/api-docs-generator/evals/cases.yaml
+++ b/skills/api-docs-generator/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: fastapi_endpoint_docs
+    prompt: "Generate API docs for this FastAPI endpoint: @app.get('/users/{id}') def get_user(id: int) -> User: ..."
+    fixtures: []
+    rubric:
+      - "Output adds response codes (e.g., 200, 404, 422)"
+      - "Output adds parameter descriptions and example values"
+      - "Output generates OpenAPI-compatible documentation"
+    trigger_expected: true
+
+  - id: audit_rest_api_docs
+    prompt: "Audit the documentation on our REST API"
+    fixtures: []
+    rubric:
+      - "Output identifies missing or incomplete descriptions"
+      - "Output checks response code coverage across endpoints"
+    trigger_expected: true
+
+  - id: negative_project_readme
+    prompt: "Write a README for my project"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for general documentation requests"
+    trigger_expected: false
+
+  - id: negative_create_endpoint
+    prompt: "Create a new API endpoint"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for API implementation tasks"
+    trigger_expected: false

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: architecture-diagram
-description: Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons, CSS Grid nested container layout, SVG path connection overlays, and color-coded connection legends. Use when the user asks to create architecture diagrams, infrastructure diagrams, system topology diagrams, network diagrams, cloud architecture visuals, deployment diagrams, integration flow diagrams, or any request involving visual representation of system components, their containment hierarchy, and interconnections. Triggers on terms like "architecture diagram", "infra diagram", "system diagram", "topology", "deployment diagram", "network diagram", "integration architecture", or when the user provides a system description and asks for a visual/diagram.
+description: >
+  Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline
+  SVG icons, CSS Grid nested container layout, SVG path connection overlays, and color-coded
+  connection legends. Triggers on: "architecture diagram", "infra diagram", "system diagram",
+  "deployment diagram", "network diagram", "topology", "draw architecture", "visualize
+  architecture", "system topology", or any request for visual representation of system
+  components, containment hierarchy, and interconnections. For architecture reviews, audits,
+  critiques, or design assessments, use architecture-reviewer instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/architecture-diagram/evals/cases.yaml
+++ b/skills/architecture-diagram/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: microservices_architecture_diagram
+    prompt: "Create an architecture diagram for our microservices: API Gateway, User Service, Order Service, PostgreSQL, Redis"
+    fixtures: []
+    rubric:
+      - "Output produces a self-contained HTML file"
+      - "Output uses SVG or CSS Grid for layout"
+      - "Output includes connection lines or arrows between components"
+    trigger_expected: true
+
+  - id: aws_deployment_diagram
+    prompt: "Draw a deployment diagram showing our AWS infrastructure"
+    fixtures: []
+    rubric:
+      - "Output shows containment hierarchy (e.g., VPC > Subnet > Instance)"
+      - "Output uses color-coded legends to distinguish component types"
+    trigger_expected: true
+
+  - id: negative_architecture_review
+    prompt: "Review the architecture of our system for flaws"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for architecture review or analysis"
+    trigger_expected: false
+
+  - id: negative_process_flowchart
+    prompt: "Create a flowchart of our checkout process"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for process flow diagrams"
+    trigger_expected: false

--- a/skills/architecture-reviewer/SKILL.md
+++ b/skills/architecture-reviewer/SKILL.md
@@ -9,7 +9,9 @@ description: >
   between intent and implementation. Triggers on: "review architecture", "critique design",
   "audit system", "evaluate codebase", "find design flaws", "assess scalability", "check
   security", "enterprise readiness", "architecture assessment", "technical due diligence",
-  or when user provides a system design document or codebase and asks for feedback or improvements.
+  or when user provides a system design document or codebase and asks for feedback or
+  improvements. For architecture diagrams, visuals, or topology drawings, use
+  architecture-diagram instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/architecture-reviewer/evals/cases.yaml
+++ b/skills/architecture-reviewer/evals/cases.yaml
@@ -1,0 +1,48 @@
+cases:
+  - id: codebase_review_request
+    prompt: "Review the architecture of this Python web application. It's a FastAPI monolith with PostgreSQL, Redis for caching, and Celery for background tasks. Team of 4, ~50K LoC, serving 10K daily active users."
+    fixtures: []
+    rubric:
+      - "asks clarifying questions before starting analysis"
+      - "evaluates all 7 dimensions: structural integrity, scalability, enterprise readiness, performance, security, operational excellence, data architecture"
+      - "produces scores on 1-5 scale per dimension"
+      - "uses severity labels S1-S5 for findings"
+      - "includes weighted overall score with letter grade"
+      - "includes prioritized recommendations in three tiers: Quick Wins, Medium-Term, Strategic"
+    trigger_expected: true
+
+  - id: document_review_mode
+    prompt: "Critique this architecture design document for our new microservices migration. We're breaking a Django monolith into 6 services connected via RabbitMQ."
+    fixtures: []
+    rubric:
+      - "activates Document review mode (Mode B)"
+      - "identifies risks in the migration approach"
+      - "evaluates whether microservices pattern fits the stated requirements"
+      - "checks for missing concerns: data consistency, service discovery, deployment strategy"
+      - "produces a scored report"
+    trigger_expected: true
+
+  - id: enterprise_readiness_focus
+    prompt: "Assess our system's enterprise readiness. We need SOC2 compliance and handle PII for 500K users."
+    fixtures: []
+    rubric:
+      - "evaluates enterprise readiness dimension in depth"
+      - "references SOC2 compliance requirements specifically"
+      - "addresses PII handling and data protection"
+      - "produces findings with severity classifications"
+      - "includes actionable compliance recommendations"
+    trigger_expected: true
+
+  - id: diagram_request
+    prompt: "Draw an architecture diagram of our microservices system."
+    fixtures: []
+    rubric:
+      - "does not activate architecture review workflow"
+    trigger_expected: false
+
+  - id: code_review_request
+    prompt: "Review my latest pull request for code quality issues."
+    fixtures: []
+    rubric:
+      - "does not activate architecture review workflow"
+    trigger_expected: false

--- a/skills/benchmark-runner/evals/cases.yaml
+++ b/skills/benchmark-runner/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: sort_algorithm_benchmark
+    prompt: "Compare the performance of quicksort vs mergesort on arrays of 10K-1M elements"
+    fixtures: []
+    rubric:
+      - "Output selects appropriate metrics such as latency, throughput, or execution time"
+      - "Output includes a comparison table or structured results"
+      - "Output captures hardware context (CPU, memory, OS)"
+    trigger_expected: true
+
+  - id: caching_implementation_benchmark
+    prompt: "Benchmark our new caching implementation against the old one"
+    fixtures: []
+    rubric:
+      - "Output designs representative test cases with varying workloads"
+      - "Output includes reproduction instructions for repeating the benchmark"
+    trigger_expected: true
+
+  - id: negative_theory_question
+    prompt: "Which sorting algorithm is theoretically fastest?"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for theoretical algorithm questions"
+    trigger_expected: false
+
+  - id: negative_optimization_task
+    prompt: "Optimize this slow function"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for code optimization tasks"
+    trigger_expected: false

--- a/skills/changelog-composer/evals/cases.yaml
+++ b/skills/changelog-composer/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: changelog_from_git_history
+    prompt: "Generate a changelog from our git history since v1.2.0"
+    fixtures: []
+    rubric:
+      - "Output classifies changes into categories (e.g., breaking, features, fixes)"
+      - "Output links to PRs or commit references"
+      - "Output filters out internal-only or housekeeping changes"
+    trigger_expected: true
+
+  - id: release_notes_v2
+    prompt: "Write release notes for version 2.0"
+    fixtures: []
+    rubric:
+      - "Output detects and highlights breaking changes"
+      - "Output produces human-readable entries suitable for end users"
+    trigger_expected: true
+
+  - id: negative_git_log
+    prompt: "Show me the git log for the past week"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for raw git history requests"
+    trigger_expected: false
+
+  - id: negative_commit_message
+    prompt: "Write a commit message for my changes"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for commit message authoring"
+    trigger_expected: false

--- a/skills/code-refiner/evals/cases.yaml
+++ b/skills/code-refiner/evals/cases.yaml
@@ -1,0 +1,45 @@
+cases:
+  - id: reduce_deep_nesting
+    prompt: >
+      Simplify this function, it has too much nesting:
+
+      def process(data):
+          if data:
+              if data.get('valid'):
+                  if data['type'] == 'A':
+                      return handle_a(data)
+                  else:
+                      return handle_b(data)
+              else:
+                  raise ValueError('invalid')
+          else:
+              raise ValueError('no data')
+    fixtures: []
+    rubric:
+      - "reduces nesting via early returns or guard clauses"
+      - "preserves exact behavior including both ValueError raises and handle_a/handle_b dispatch"
+      - "explains the refactoring approach applied"
+    trigger_expected: true
+
+  - id: cleanup_before_pr
+    prompt: "Clean up this code before I PR it"
+    fixtures: []
+    rubric:
+      - "identifies anti-patterns or code smells"
+      - "applies DRY principles to reduce duplication"
+      - "produces cleaner output with improved readability"
+    trigger_expected: true
+
+  - id: negative_debug_wrong_result
+    prompt: "Debug why this function returns the wrong result"
+    fixtures: []
+    rubric:
+      - "debugging incorrect behavior is outside code refining scope"
+    trigger_expected: false
+
+  - id: negative_add_error_handling
+    prompt: "Add error handling to this function"
+    fixtures: []
+    rubric:
+      - "adding new error handling is feature addition, not code simplification or refactoring"
+    trigger_expected: false

--- a/skills/concept-to-image/SKILL.md
+++ b/skills/concept-to-image/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: concept-to-image
 description: >
-  Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG image.
-  Use this skill whenever the user wants to create a visual representation of an idea and needs an image file output
-  (PNG or SVG). This includes: infographics, concept diagrams, flowcharts, comparison charts, process visuals,
-  educational diagrams, social media graphics, data visualizations, posters, cards, badges, icons, logos sketches,
-  or any "make me an image of X" request that can be achieved with HTML/CSS/SVG rather than photographic AI generation.
-  Also trigger when the user has an existing HTML visual and wants to export/convert it to PNG or SVG.
-  Trigger phrases include: "create an image of", "make a visual", "design a graphic", "export as PNG",
-  "save as SVG", "concept to image", "turn this into an image", "screenshot this HTML",
-  "generate an infographic", or any request combining a concept description with image output.
+  Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG image file.
+  Use this skill when the user explicitly needs an image file output (PNG or SVG). This includes: concept diagrams,
+  flowcharts, comparison charts, process visuals, educational diagrams, social media graphics, data visualizations,
+  posters, cards, badges, icons, logo sketches, or any "make me an image of X" request achievable with HTML/CSS/SVG
+  rather than photographic AI generation. Also trigger when the user has an existing HTML visual and wants to
+  export/convert it to PNG or SVG. Trigger phrases: "create an image of", "export as PNG", "save as SVG",
+  "concept to image", "turn this into an image", "screenshot this HTML", "design a graphic for export".
+  For interactive HTML visuals opened in a browser, use static-web-artifacts-builder instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/concept-to-image/evals/cases.yaml
+++ b/skills/concept-to-image/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: architecture_diagram_png
+    prompt: "Create a PNG image of a system architecture diagram showing three microservices"
+    fixtures: []
+    rubric:
+      - "produces HTML/CSS/SVG visual representation of the architecture"
+      - "exports as PNG file"
+      - "design is self-contained without external dependencies"
+    trigger_expected: true
+
+  - id: comparison_chart_svg
+    prompt: "Export this concept as an SVG: a comparison chart of React vs Vue vs Angular"
+    fixtures: []
+    rubric:
+      - "outputs SVG file format"
+      - "uses HTML/CSS rendering to produce the visual"
+    trigger_expected: true
+
+  - id: negative_interactive_dashboard
+    prompt: "Create an interactive dashboard I can open in my browser"
+    fixtures: []
+    rubric:
+      - "interactive web applications are static-web-artifacts-builder territory, not concept-to-image"
+    trigger_expected: false
+
+  - id: negative_photo_generation
+    prompt: "Generate a photo of a sunset"
+    fixtures: []
+    rubric:
+      - "photographic AI image generation is outside concept-to-image scope which uses HTML/CSS rendering"
+    trigger_expected: false

--- a/skills/concept-to-video/evals/cases.yaml
+++ b/skills/concept-to-video/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: binary_search_animation
+    prompt: "Create a video animation showing how a binary search algorithm works step by step"
+    fixtures: []
+    rubric:
+      - "uses Manim Python library for animation"
+      - "produces MP4 or GIF output"
+      - "animates the algorithm steps showing search progression"
+    trigger_expected: true
+
+  - id: data_pipeline_flow
+    prompt: "Animate a data pipeline flowing from ingestion to processing to storage"
+    fixtures: []
+    rubric:
+      - "creates a Manim scene with appropriate classes"
+      - "shows temporal flow between pipeline stages"
+    trigger_expected: true
+
+  - id: negative_branded_product_demo
+    prompt: "Create a branded product demo video with our company logo and music"
+    fixtures: []
+    rubric:
+      - "branded product demos with logos and music are remotion-video territory, not concept-to-video"
+    trigger_expected: false
+
+  - id: negative_static_infographic
+    prompt: "Make a static infographic about our tech stack"
+    fixtures: []
+    rubric:
+      - "static images are outside concept-to-video scope which produces animated video output"
+    trigger_expected: false

--- a/skills/debug-investigator/SKILL.md
+++ b/skills/debug-investigator/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: debug-investigator
 description: >
-  Systematic debugging framework: symptom capture, evidence analysis, hypothesis
-  generation, bisection strategy, log analysis, instrumentation, and minimal reproduction
-  design. Transforms ad-hoc debugging into structured investigation with ranked hypotheses
-  and concrete investigation plans.
-  Triggers on: "debug this", "why is this failing", "root cause", "investigate", "diagnose",
+  Hypothesis-driven debugging framework: symptom capture, evidence analysis, hypothesis
+  ranking, bisection strategy, log analysis, instrumentation, and minimal reproduction.
+  Triggers on: "debug this", "why is this failing", "root cause", "diagnose",
   "this error", "this exception", "this stacktrace", "not working", "broken",
   "unexpected behavior", "bisect", "narrow down", "isolate the issue", "help me debug".
-  Use this skill when confronted with a bug, error, or unexpected behavior in any codebase.
+  Use this skill when confronted with a bug, error, or unexpected behavior in code.
+  NOT for abstract reasoning, trade-off evaluation, or general problem decomposition
+  without a specific error — use sequential-thinking instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/debug-investigator/SKILL.md
+++ b/skills/debug-investigator/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: debug-investigator
 description: >
-  Hypothesis-driven debugging framework: symptom capture, evidence analysis, hypothesis
-  ranking, bisection strategy, log analysis, instrumentation, and minimal reproduction.
-  Triggers on: "debug this", "why is this failing", "root cause", "diagnose",
-  "this error", "this exception", "this stacktrace", "not working", "broken",
-  "unexpected behavior", "bisect", "narrow down", "isolate the issue", "help me debug".
-  Use this skill when confronted with a bug, error, or unexpected behavior in code.
-  NOT for abstract reasoning, trade-off evaluation, or general problem decomposition
-  without a specific error — use sequential-thinking instead.
+  Hypothesis-driven debugging methodology: ranked hypotheses with confirming/refuting tests,
+  git bisect strategy, log analysis, instrumentation point planning, and minimal reproduction
+  design. Triggers on: "debug this systematically", "root cause analysis", "bisect this bug",
+  "rank hypotheses for this error", "help me isolate this issue", "create a minimal
+  reproduction", "instrumentation plan for this bug", "why does this keep failing".
+  The differentiator is the structured investigation methodology (hypothesis ranking,
+  bisection strategy, instrumentation points) — use this skill for non-obvious bugs that
+  need systematic investigation, not simple errors the model diagnoses directly.
+  NOT for abstract reasoning or problem decomposition without a specific error — the model
+  handles general reasoning natively.
 metadata:
   version: 1.0.0
 ---
@@ -19,6 +21,11 @@ Structured debugging methodology that replaces ad-hoc exploration with hypothesi
 investigation. Captures symptoms, analyzes evidence (stacktraces, logs, state), generates
 ranked hypotheses, designs bisection strategies, identifies instrumentation points, and
 produces minimal reproductions — documenting every step so dead ends are never revisited.
+
+> **When to use this skill vs native debugging:** The base model handles straightforward
+> debugging (clear stacktraces, obvious errors) natively. Use this skill for non-obvious bugs
+> requiring systematic investigation: intermittent failures, bugs with no clear stacktrace,
+> performance regressions, or issues requiring git bisection and hypothesis ranking.
 
 ## Reference Files
 

--- a/skills/debug-investigator/evals/cases.yaml
+++ b/skills/debug-investigator/evals/cases.yaml
@@ -1,0 +1,32 @@
+cases:
+  - id: git_bisect_intermittent_bug
+    prompt: "This bug keeps appearing intermittently — help me bisect which commit introduced it"
+    fixtures: []
+    rubric:
+      - "designs git bisect strategy with good/bad commit range identification"
+      - "identifies good/bad commit range boundaries"
+      - "creates systematic investigation plan with ordered steps"
+    trigger_expected: true
+
+  - id: race_condition_minimal_repro
+    prompt: "Help me create a minimal reproduction for this race condition in our async code"
+    fixtures: []
+    rubric:
+      - "ranks hypotheses with confirming/refuting tests"
+      - "plans instrumentation points for observing async behavior"
+      - "designs minimal reproduction isolating the race condition"
+    trigger_expected: true
+
+  - id: abstract_tradeoff_reasoning
+    prompt: "Think through the trade-offs of using PostgreSQL vs MongoDB for our use case"
+    fixtures: []
+    rubric:
+      - "does not activate debug-investigator (abstract reasoning, not debugging)"
+    trigger_expected: false
+
+  - id: document_summarization
+    prompt: "Summarize this document for me"
+    fixtures: []
+    rubric:
+      - "does not activate debug-investigator (summarization, not debugging)"
+    trigger_expected: false

--- a/skills/dependency-audit/evals/cases.yaml
+++ b/skills/dependency-audit/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: security_and_license_audit
+    prompt: "Audit the dependencies in our requirements.txt for security vulnerabilities and license issues"
+    fixtures: []
+    rubric:
+      - "checks for known CVEs or security vulnerabilities"
+      - "identifies license conflicts such as GPL in an MIT-licensed project"
+      - "flags abandoned or unmaintained packages"
+    trigger_expected: true
+
+  - id: unused_duplicate_detection
+    prompt: "Check our package.json for unused or duplicate dependencies"
+    fixtures: []
+    rubric:
+      - "detects unused dependencies not referenced in source"
+      - "identifies duplicate or overlapping packages"
+    trigger_expected: true
+
+  - id: negative_install_dependencies
+    prompt: "Install these new dependencies for my project"
+    fixtures: []
+    rubric:
+      - "installing dependencies is outside audit scope"
+    trigger_expected: false
+
+  - id: negative_general_tooling_question
+    prompt: "What's the difference between npm and yarn?"
+    fixtures: []
+    rubric:
+      - "general package manager comparison is not a dependency audit"
+    trigger_expected: false

--- a/skills/doc-condenser/SKILL.md
+++ b/skills/doc-condenser/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: doc-condenser
-description: Transform verbose technical documentation into concise, scannable specs. Use this skill when you need to condense, summarize, or reformat technical docs, specs, or READMEs — including when a document is too verbose, when you want a technical summary, or when working with lengthy specification documents. Triggers on phrases like "make this concise", "too verbose", "condense this", "technical summary", "strip the fluff", or "reformat this spec". See assets/template.md for the standard output structure.
+description: "DEPRECATED: The base model handles document condensation and summarization natively at high quality. This skill no longer provides meaningful uplift. Retained for reference only."
 metadata:
   version: 1.0.0
+  status: deprecated
 ---
+
+> **DEPRECATED** — Modern Claude models condense and summarize technical documentation
+> natively with comparable quality. The output format preferences encoded here (40% length
+> cap, tables over prose, paths first) are too generic to justify skill overhead. Retained
+> for archival reference only.
 
 # Document Condenser
 

--- a/skills/doc-condenser/evals/cases.yaml
+++ b/skills/doc-condenser/evals/cases.yaml
@@ -1,0 +1,14 @@
+cases:
+  - id: condense_technical_doc
+    prompt: "Condense this technical document into a summary"
+    fixtures: []
+    rubric:
+      - "does not activate doc-condenser (deprecated, model handles natively)"
+    trigger_expected: false
+
+  - id: concise_readme
+    prompt: "Make this README more concise"
+    fixtures: []
+    rubric:
+      - "does not activate doc-condenser (deprecated, model handles natively)"
+    trigger_expected: false

--- a/skills/estimate-calibrator/SKILL.md
+++ b/skills/estimate-calibrator/SKILL.md
@@ -8,7 +8,8 @@ description: >
   Triggers on: "estimate this", "how long will this take", "effort estimate",
   "time estimate", "best case worst case", "confidence interval", "sizing",
   "estimate effort", "how big is this", "story points", "t-shirt sizing",
-  "estimate the work", "project estimate".
+  "estimate the work", "PERT".
+  NOT for task decomposition, implementation plans, or dependency mapping — use task-decomposer instead.
   Use this skill when a task or project needs an effort estimate with explicit uncertainty.
 metadata:
   version: 1.0.0

--- a/skills/estimate-calibrator/evals/cases.yaml
+++ b/skills/estimate-calibrator/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: monolith_to_microservices
+    prompt: "Estimate the effort to migrate our monolith to microservices — 3 services, ~50K LoC"
+    fixtures: []
+    rubric:
+      - "produces three-point estimate with best/likely/worst case"
+      - "identifies unknowns and assumptions"
+      - "calculates PERT range or weighted estimate"
+    trigger_expected: true
+
+  - id: oauth2_api_effort
+    prompt: "How long will it take to add OAuth2 authentication to our API?"
+    fixtures: []
+    rubric:
+      - "breaks work into atomic units or subtasks"
+      - "provides confidence interval or range-based estimate"
+    trigger_expected: true
+
+  - id: negative_task_decomposition
+    prompt: "Break this feature into implementation tasks with dependencies"
+    fixtures: []
+    rubric:
+      - "task decomposition with dependency mapping is task-decomposer territory, not estimation"
+    trigger_expected: false
+
+  - id: negative_technology_choice
+    prompt: "What technologies should I use for this project?"
+    fixtures: []
+    rubric:
+      - "technology selection is outside effort estimation scope"
+    trigger_expected: false

--- a/skills/filesystem/evals/cases.yaml
+++ b/skills/filesystem/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: find_typescript_files
+    prompt: "Find all TypeScript files in the src directory"
+    fixtures: []
+    rubric:
+      - "uses Glob tool or equivalent file search"
+      - "pattern matches *.ts files"
+      - "returns file paths"
+    trigger_expected: true
+
+  - id: show_directory_tree
+    prompt: "Show the directory tree of my project"
+    fixtures: []
+    rubric:
+      - "uses ls or tree via Bash to list directory contents"
+      - "displays hierarchical directory structure"
+    trigger_expected: true
+
+  - id: negative_code_refactor
+    prompt: "Refactor the code in this file"
+    fixtures: []
+    rubric:
+      - "code modification is outside filesystem operations scope"
+    trigger_expected: false
+
+  - id: negative_web_search
+    prompt: "Search the web for documentation"
+    fixtures: []
+    rubric:
+      - "web search is outside filesystem operations scope"
+    trigger_expected: false

--- a/skills/github/evals/cases.yaml
+++ b/skills/github/evals/cases.yaml
@@ -1,0 +1,32 @@
+cases:
+  - id: create_issue_for_bug
+    prompt: "Create a GitHub issue for the login bug we found today"
+    fixtures: []
+    rubric:
+      - "uses gh issue create command"
+      - "includes title and body flags with descriptive content"
+      - "applies appropriate labels (e.g., bug)"
+    trigger_expected: true
+
+  - id: check_ci_failing_pr
+    prompt: "Check why CI is failing on our latest PR"
+    fixtures: []
+    rubric:
+      - "uses gh run list or gh pr checks to inspect CI status"
+      - "identifies failing workflow or job"
+      - "shows error details or suggests viewing logs"
+    trigger_expected: true
+
+  - id: git_commit_message
+    prompt: "Write a git commit message for my changes"
+    fixtures: []
+    rubric:
+      - "git commit message authoring is a local git operation, not a GitHub CLI task"
+    trigger_expected: false
+
+  - id: deploy_to_production
+    prompt: "Deploy our application to production"
+    fixtures: []
+    rubric:
+      - "deployment is outside GitHub CLI operations scope"
+    trigger_expected: false

--- a/skills/gpu-optimizer/evals/cases.yaml
+++ b/skills/gpu-optimizer/evals/cases.yaml
@@ -1,0 +1,32 @@
+cases:
+  - id: pytorch_oom_rtx4090
+    prompt: "Optimize this PyTorch training loop, I keep getting OOM errors on my RTX 4090 (24GB)"
+    fixtures: []
+    rubric:
+      - "recommends mixed precision training (fp16/bf16)"
+      - "suggests gradient checkpointing to reduce VRAM usage"
+      - "addresses VRAM management (batch size reduction, memory clearing, or accumulation)"
+    trigger_expected: true
+
+  - id: xgboost_gpu_training
+    prompt: "Speed up my XGBoost training using GPU"
+    fixtures: []
+    rubric:
+      - "configures tree_method='gpu_hist' for GPU-accelerated training"
+      - "sets device parameter for GPU execution"
+      - "addresses GPU-specific tuning (max_bin, subsample, or grow_policy)"
+    trigger_expected: true
+
+  - id: sql_query_optimization
+    prompt: "Optimize this SQL query for better performance"
+    fixtures: []
+    rubric:
+      - "SQL query optimization is not a GPU optimization task"
+    trigger_expected: false
+
+  - id: cuda_environment_setup
+    prompt: "Set up a new CUDA development environment"
+    fixtures: []
+    rubric:
+      - "environment setup is outside GPU optimization scope"
+    trigger_expected: false

--- a/skills/html-presentation/evals/cases.yaml
+++ b/skills/html-presentation/evals/cases.yaml
@@ -1,0 +1,37 @@
+cases:
+  - id: outline_to_slides
+    prompt: >
+      Convert my outline into an HTML slide presentation:
+      1. Introduction
+      2. Problem Statement
+      3. Solution
+      4. Results
+      5. Conclusion
+    fixtures: []
+    rubric:
+      - "produces a self-contained HTML file"
+      - "uses Reveal.js or equivalent slide framework"
+      - "creates one slide per section from the outline"
+    trigger_expected: true
+
+  - id: dark_themed_presentation
+    prompt: "Create a dark-themed presentation from this markdown document"
+    fixtures: []
+    rubric:
+      - "applies a dark theme to the slide deck"
+      - "supports keyboard navigation between slides"
+    trigger_expected: true
+
+  - id: powerpoint_format
+    prompt: "Create a PowerPoint presentation"
+    fixtures: []
+    rubric:
+      - "PPTX format is outside HTML presentation scope"
+    trigger_expected: false
+
+  - id: blog_post_from_outline
+    prompt: "Write a blog post from this outline"
+    fixtures: []
+    rubric:
+      - "blog post authoring is not an HTML slide presentation task"
+    trigger_expected: false

--- a/skills/immune/SKILL.md
+++ b/skills/immune/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: immune
+description: >
+  Hybrid adaptive memory system with two complementary memories: Cheatsheet
+  (positive patterns injected before generation) and Immune (negative patterns
+  scanned after generation). Uses Hot/Cold tiered memory with multi-domain
+  support and auto-learning. Detects known errors via antibodies, discovers
+  new threats, and learns winning strategies over time.
+  Triggers on: "scan for errors", "immune scan", "check output quality",
+  "detect patterns", "scan content", "cheatsheet injection", "antibody scan",
+  "adaptive memory scan", "immune check", "quality scan", "pattern detection".
+  NOT for general code review or PR review — use pr-review instead.
+  NOT for security audits of repositories — use repo-sentinel instead.
+metadata:
+  version: 3.0.0
+  status: active
+  classification: tooling-wrapper
+  source: https://github.com/contactjccoaching-wq/immune
+---
+
+# Immune System v3 — Hybrid Cheatsheet + Immune
+
+You operate a hybrid adaptive system with two complementary memories:
+- **Cheatsheet** (positive patterns): domain-specific strategies injected BEFORE generation to improve output quality
+- **Immune** (negative patterns): antibodies that detect known errors and discover new threats AFTER generation
+
+Both memories use Hot/Cold tiering to keep context lean.
+
+## Input Parsing
+
+The user invokes with content to scan. Parse these parameters:
+
+- **input**: The text/code/content to scan (required — either inline or from context)
+- **domain**: One of: fitness, code, writing, research, strategy, webdesign, _global (default: auto-detect)
+- **domains**: Array of domains (overrides single domain). Example: `domains=fitness,code`
+- **constraints**: Any specific requirements the output should satisfy (optional)
+- **mode**: `full` (cheatsheet + scan, default) | `scan-only` (skip cheatsheet) | `cheatsheet-only` (return cheatsheet, no scan)
+
+<examples>
+<example>
+/immune Check this function for common pitfalls
+→ domains=["code"] (auto-detected), mode=full
+</example>
+<example>
+/immune domain=fitness Vérifie ce programme de musculation
+→ domains=["fitness"] (explicit)
+</example>
+<example>
+/immune domains=fitness,code Check this workout generator API
+→ domains=["fitness", "code"] (multi-domain)
+</example>
+<example>
+/immune
+→ scans the most recent output in the conversation
+</example>
+</examples>
+
+If no inline text is provided, scan the last substantive output in the conversation.
+
+**Domain auto-detection:** Read `config.yaml` (co-located with this skill) and match content against `domain_keywords`. If no strong match, use `["_global"]`. If single `domain` string provided, wrap in array: `domains = [domain]`.
+
+## Execution
+
+### Step 0 — Cheatsheet Injection (positive patterns)
+
+Skip this step if `mode == "scan-only"`.
+
+**0a. Load cheatsheet:**
+Read `cheatsheet_memory.json` (co-located with this skill).
+
+**0b. Filter by domains:**
+Keep strategies where ANY of the strategy's `domains` overlaps with the detected `domains`, OR strategy has `"_global"` in its domains.
+
+**0c. Classify into tiers (same logic as antibodies):**
+A strategy is HOT if ANY of:
+- `effectiveness >= 0.7`
+- `seen_count >= 3`
+- `last_seen` less than 30 days ago
+
+Everything else is COLD.
+
+**0d. Cap HOT strategies:**
+Sort by effectiveness descending, then seen_count descending.
+Keep max **15** (from `config.yaml` → `cheatsheet.max_hot`).
+
+**0e. Build cheatsheet block:**
+Format HOT strategies as XML:
+```xml
+<cheatsheet domain="{domains}">
+  <strategy id="{id}" effectiveness="{effectiveness}">
+    {pattern}
+    Example: {example}
+  </strategy>
+  ...
+</cheatsheet>
+```
+
+If there are COLD strategies, add a one-liner:
+```xml
+<cheatsheet_cold>Also consider: {comma-separated COLD pattern keywords}</cheatsheet_cold>
+```
+
+If `mode == "cheatsheet-only"`, output the cheatsheet block and stop here.
+
+Log:
+```
+[IMMUNE] Cheatsheet: {n_hot} HOT + {n_cold} COLD strategies (domains: {domains})
+```
+
+**0f. Present cheatsheet to user:**
+If running standalone (`/immune`), show the cheatsheet as context the user should apply to their next generation. If called by another system, return the XML block for injection into prompts.
+
+### Step 1 — Load & Classify Antibodies (Hot/Cold)
+
+Read `immune_memory.json` and `config.yaml` (co-located with this skill).
+
+**1a. Filter by domains:**
+Keep antibodies where ANY of the antibody's `domains` overlaps with detected `domains`, OR antibody has `"_global"` in its domains.
+
+**Backwards compatibility:** If an antibody has `"domain"` (string) instead of `"domains"` (array), treat it as `domains = [domain]`.
+
+**1b. Classify into tiers:**
+For each filtered antibody, classify as HOT if **any** of these is true:
+- `severity == "critical"`
+- `seen_count >= 3`
+- `last_seen` is less than 30 days ago (relative to today's date)
+
+Everything else is COLD.
+
+**1c. Cap HOT antibodies:**
+Sort HOT by: severity (critical > warning > info), then seen_count descending.
+Keep max **15** (from `config.yaml` → `tiers.hot.max_per_scan`).
+If more than 15 qualify as HOT, overflow goes to COLD.
+
+**1d. Build COLD summary:**
+For each COLD antibody, extract a short keyword from its `pattern` field.
+Join as comma-separated list. Example: `"SQL transactions, épicondylite, debug flags, tautologies"`
+
+Log:
+```
+[IMMUNE] Tier split: {n_hot} HOT + {n_cold} COLD / {total} total (domains: {domains})
+```
+
+### Step 2 — Scan
+
+Spawn the `immune-scan` agent (Haiku) with the following XML-structured prompt:
+
+```xml
+<scan_request>
+  <domains>{detected_domains as JSON array}</domains>
+  <task>{task description or "Scan the following content for errors and threats"}</task>
+  <constraints>{constraints or "none"}</constraints>
+
+  <content>
+{the input text/code/content to scan}
+  </content>
+
+  <hot_antibodies>
+{JSON array of HOT antibodies — full objects with id, domains, pattern, severity, correction}
+  </hot_antibodies>
+
+  <cold_summary>
+Dormant patterns (not detailed, for awareness only): {comma-separated COLD keywords}
+  </cold_summary>
+
+  <cheatsheet_applied>
+{list of strategy IDs and patterns that were injected in Step 0, or "none" if scan-only mode}
+  </cheatsheet_applied>
+</scan_request>
+```
+
+Log: `[IMMUNE] Scanning... ({n_hot} active antibodies)`
+Wait for result.
+
+If corrections applied:
+  Log: `[IMMUNE] Match {antibody_id}: {original} → {corrected}`
+If new threats detected:
+  Log: `[IMMUNE] New threat: {pattern}`
+If new strategies detected:
+  Log: `[IMMUNE] New strategy: {pattern}`
+
+### Step 3 — Update Immune Memory (with COLD deduplication)
+
+Read current `immune_memory.json`.
+
+**3a. Matched HOT antibodies:**
+For each antibody matched by the scanner, increment `seen_count` and update `last_seen` to today.
+
+**3b. New threats — deduplicate against COLD:**
+For each new threat in `new_threats_detected`:
+1. Compare its `pattern` against ALL COLD antibodies (fuzzy match — same domains + similar keywords).
+2. **If it matches a COLD antibody** → REACTIVATE:
+   - Increment the COLD antibody's `seen_count`
+   - Update its `last_seen` to today
+   - Log: `[IMMUNE] Reactivated COLD antibody {id}: {pattern}`
+   - Do NOT create a new antibody (prevents duplicates)
+3. **If no COLD match** AND `auto_add_threats` is true → CREATE new antibody:
+   - id: "AB-{next_number}"
+   - domains: from the threat's `recommended_antibody.domains` (array)
+   - pattern, severity, correction: from the threat's `recommended_antibody`
+   - seen_count: 1
+   - first_seen: today's date
+   - last_seen: today's date
+   - Log: `[IMMUNE] + New antibody {id}: {pattern}`
+
+**3c. Update stats:**
+- Increment `stats.outputs_checked`
+- Increment `stats.issues_caught` by number of corrections + new threats
+- Update `stats.antibodies_total` to current antibody count
+
+Write back to `immune_memory.json`.
+
+Log: `[IMMUNE] Memory: {total} antibodies ({n_hot} hot, {n_cold} cold) | +{new} added | Reactivated: {reactivated}`
+
+### Step 3b — Update Cheatsheet Memory (positive patterns)
+
+Skip if `mode == "scan-only"` or no `new_strategies_detected` in scan result.
+
+Read current `cheatsheet_memory.json`.
+
+**3b-i. Deduplicate:**
+For each new strategy in `new_strategies_detected`:
+1. Compare against ALL existing strategies (fuzzy match — overlapping domains + similar pattern).
+2. **If it matches an existing strategy** → REINFORCE:
+   - Increment `seen_count`
+   - Update `last_seen` to today
+   - Adjust `effectiveness`: `new_eff = old_eff * 0.8 + reported_eff * 0.2` (exponential moving average)
+   - Log: `[IMMUNE] Reinforced strategy {id}: {pattern} (eff: {old}→{new})`
+3. **If no match** AND `auto_add_strategies` is true → CREATE new strategy:
+   - id: "{prefix}-{next_number}" (prefix from `config.yaml` → `cheatsheet.id_prefix.{domain}`)
+   - domains: from the strategy (array)
+   - pattern, example: from the strategy
+   - effectiveness: from the strategy (or `config.yaml` → `cheatsheet.default_effectiveness`)
+   - seen_count: 1
+   - first_seen: today's date
+   - last_seen: today's date
+   - Log: `[IMMUNE] + New strategy {id}: {pattern}`
+
+**3b-ii. Prune low-effectiveness:**
+If any strategy has `effectiveness < config.cheatsheet.min_effectiveness` AND `seen_count >= 5`:
+- Remove it
+- Log: `[IMMUNE] - Pruned strategy {id}: {pattern} (eff: {eff})`
+
+**3b-iii. Update stats:**
+- Increment `stats.outputs_assisted`
+- Increment `stats.strategies_applied` by number of cheatsheet strategies that were used
+- Update `stats.strategies_total` to current count
+
+Write back to `cheatsheet_memory.json`.
+
+Log: `[IMMUNE] Cheatsheet: {total} strategies | +{new} added | Reinforced: {reinforced}`
+
+### Step 4 — Output
+
+**If clean:**
+```
+───
+IMMUNE v3 | domains={domains} | Status: CLEAN
+   Cheatsheet: {n_strategies} strategies applied | Antibodies: {n_hot}/{max} HOT, {n_cold} COLD
+   No issues detected
+───
+```
+
+**If corrections or threats found:**
+```
+───
+IMMUNE v3 | domains={domains} | Status: {CORRECTED|FLAGGED}
+
+Corrections Applied:
+  [AB-XXX] {pattern} → {correction}
+
+New Threats Detected:
+  [{severity}] {pattern} — {suggested_correction}
+
+Reactivated:
+  [AB-XXX] {pattern} (was COLD, now HOT)
+
+New Strategies Learned:
+  [CS-XXX] {pattern} (eff: {effectiveness})
+
+───
+Corrected Output:
+{the corrected content, formatted for the domain}
+───
+Memory: {total_ab} antibodies + {total_cs} strategies | +{new_ab} AB | +{new_cs} CS
+───
+```
+
+Then present the corrected output in a human-readable format appropriate to the domain.
+
+## Error Handling
+
+- If `immune_memory.json` does not exist: create it with `{"version": 3, "antibodies": [], "stats": {"outputs_checked": 0, "issues_caught": 0, "antibodies_total": 0}}`
+- If `cheatsheet_memory.json` does not exist: create it with `{"version": 3, "strategies": [], "stats": {"outputs_assisted": 0, "strategies_applied": 0, "strategies_total": 0}}`
+- If `immune_memory.json` has `"version": 2`: auto-migrate by converting each antibody's `"domain"` to `"domains": ["domain_value"]` and set version to 3. Write back immediately.
+- If the agent returns invalid JSON: retry once. If still invalid, report the raw output with a warning.
+- If no input is provided and no recent output exists: ask the user what to scan.
+- If all antibodies are COLD (none qualify as HOT): still send the scan with empty `hot_antibodies` array and full `cold_summary`. Haiku can still detect new threats via Phase 2.

--- a/skills/immune/agents/immune-scan.md
+++ b/skills/immune/agents/immune-scan.md
@@ -1,0 +1,109 @@
+---
+name: immune-scan
+model: haiku
+tools: []
+---
+
+<role>
+You are an adaptive immune system scanner. You detect known error patterns (antibodies) and discover new threats in any content. You also identify effective strategies (positive patterns) worth remembering. You are precise, concise, and never add commentary outside your JSON output.
+</role>
+
+<instructions>
+You receive a scan request wrapped in XML tags containing: domain(s), task, constraints, content to scan, active (HOT) antibodies with full details, a summary of dormant (COLD) patterns for awareness, and optionally a list of cheatsheet strategies that were applied during generation.
+
+Execute these phases in order:
+
+<phase name="known-antibody-scan">
+Check the content against each HOT antibody in the hot_antibodies list.
+For each antibody: if the content contains or exhibits the antibody's pattern, apply the correction.
+Be precise — only match when the pattern clearly applies. Do not force-match vague similarities.
+</phase>
+
+<phase name="new-threat-detection">
+Independently of known antibodies, analyze the content for:
+- Contradictions with stated constraints
+- Unrealistic claims or promises
+- Missing critical elements that the constraints require
+- Internal inconsistencies (part A says X, part B implies not-X)
+- Domain-specific red flags
+
+The cold_summary lists dormant patterns the system already knows about. If you detect something that clearly overlaps with a cold pattern, still report it as a new threat — the orchestrator will handle deduplication. Do not skip detection just because a cold pattern exists.
+</phase>
+
+<phase name="strategy-detection">
+Analyze the content for effective strategies and positive patterns that made the output good. Look for:
+- Domain-specific best practices that were applied well
+- Structural patterns that improve clarity or correctness
+- Techniques that address common pitfalls proactively
+- Any approach worth reusing in future outputs of this domain
+
+If cheatsheet_applied is provided, evaluate whether each applied strategy was effective in this context. Only report NEW strategies not already in the cheatsheet.
+</phase>
+
+<phase name="report">
+Produce your output as a single JSON object. No text before or after the JSON.
+</phase>
+</instructions>
+
+<output_format>
+Return ONLY this JSON structure — no markdown fences, no commentary:
+
+{
+  "scan_result": "clean|corrected|flagged",
+  "corrections_applied": [
+    {
+      "antibody_id": "AB-XXX",
+      "original": "what was in the content",
+      "corrected": "what it should be replaced with",
+      "reason": "why this antibody matched"
+    }
+  ],
+  "new_threats_detected": [
+    {
+      "pattern": "description of the detected issue",
+      "severity": "critical|warning|info",
+      "location": "where in the content this occurs",
+      "suggested_correction": "how to fix it",
+      "recommended_antibody": {
+        "domains": ["domain tag"],
+        "pattern": "generalized pattern for future detection",
+        "severity": "critical|warning|info",
+        "correction": "generalized correction"
+      }
+    }
+  ],
+  "new_strategies_detected": [
+    {
+      "pattern": "description of the effective strategy",
+      "example": "concrete example from the content",
+      "domains": ["domain tag"],
+      "effectiveness": 0.5
+    }
+  ],
+  "corrected_output": "the full corrected content (or original if clean)",
+  "scan_summary": "one-line summary of scan results"
+}
+
+Rules:
+- If clean: scan_result="clean", empty arrays, corrected_output = original content.
+- If corrections only: scan_result="corrected".
+- If new threats (with or without corrections): scan_result="flagged".
+- new_strategies_detected can be non-empty even when scan_result is "clean" — good content has good strategies.
+- effectiveness: 0.5 default for new strategies. Range 0.0-1.0.
+- Never return partial JSON. Always return the complete object.
+</output_format>
+
+<examples>
+<example>
+Input: code with `db.prepare(\`SELECT * FROM users WHERE id = '${userId}'\`)`
+Expected: corrections_applied with AB matching SQL injection, corrected to use .bind()
+</example>
+<example>
+Input: fitness program with only push exercises and no pull
+Expected: corrections_applied with AB matching push/pull imbalance
+</example>
+<example>
+Input: clean code using prepared statements, try/catch, env vars
+Expected: scan_result="clean", empty corrections, possible new_strategies_detected for "uses prepared statements for all DB queries"
+</example>
+</examples>

--- a/skills/immune/cheatsheet_memory.json
+++ b/skills/immune/cheatsheet_memory.json
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "strategies": [],
+  "stats": {
+    "outputs_assisted": 0,
+    "strategies_applied": 0,
+    "strategies_total": 0
+  }
+}

--- a/skills/immune/config.yaml
+++ b/skills/immune/config.yaml
@@ -1,0 +1,61 @@
+# ============================================================
+# Immune System — Configuration v3.0.0
+# ============================================================
+# Hybrid adaptive system: Cheatsheet (positive) + Immune (negative)
+# Two memory files: cheatsheet_memory.json + immune_memory.json
+# ============================================================
+
+immune:
+  version: "3.0.0"
+  scan_model: "haiku"
+  memory_path: "immune_memory.json"
+  cheatsheet_path: "cheatsheet_memory.json"
+  auto_add_threats: true
+  auto_add_strategies: true
+  severity_levels: [critical, warning, info]
+  domains_multi: true  # antibodies/strategies use "domains" array, not single "domain"
+
+# Tiered memory — keeps active set small for optimal Haiku performance
+# Benchmark showed sweet spot at 13-20 antibodies (F1=0.94)
+# Beyond 20, precision drops (more false positives)
+tiers:
+  hot:
+    max_per_scan: 15
+    # An antibody/strategy is HOT if ANY of these conditions is true:
+    criteria:
+      - "severity == critical"       # antibodies only
+      - "effectiveness >= 0.7"       # strategies only
+      - "seen_count >= 3"
+      - "last_seen < 30 days ago"
+  cold:
+    # COLD items are sent as a one-line topic summary (not full details)
+    summary_format: "comma-separated pattern keywords"
+    # If scanner detects something matching a COLD item → reactivate it
+    reactivation: true
+
+# Cheatsheet — positive patterns injected BEFORE generation
+cheatsheet:
+  max_hot: 15
+  # Strategy ID prefix per domain (e.g., CS-FITNESS-001)
+  id_prefix:
+    fitness: "CS-FITNESS"
+    code: "CS-CODE"
+    writing: "CS-WRITING"
+    research: "CS-RESEARCH"
+    strategy: "CS-STRATEGY"
+    webdesign: "CS-WEBDESIGN"
+    _global: "CS-GLOBAL"
+  # Default effectiveness for new strategies (0.0-1.0)
+  default_effectiveness: 0.5
+  # Strategies below this effectiveness are candidates for removal
+  min_effectiveness: 0.2
+
+# Domain hints for auto-detection
+# You can add custom domains or edit keywords to match your content
+domain_keywords:
+  code: ["function", "class", "import", "const", "let", "var", "def", "return", "async", "await", "SQL", "API", "endpoint", "worker", "fetch", "query"]
+  fitness: ["séries", "reps", "exercice", "muscle", "squat", "curl", "programme", "entraînement", "sets", "workout", "deload", "hypertrophie"]
+  writing: ["paragraphe", "article", "rédaction", "contenu", "SEO", "paragraph", "content", "blog"]
+  research: ["source", "étude", "analyse", "hypothèse", "study", "analysis", "findings"]
+  strategy: ["marché", "compétiteur", "ROI", "market", "competitor", "revenue", "pivot"]
+  webdesign: ["CSS", "HTML", "responsive", "CTA", "landing page", "UI", "UX", "layout"]

--- a/skills/immune/evals/cases.yaml
+++ b/skills/immune/evals/cases.yaml
@@ -15,7 +15,7 @@ cases:
     prompt: >
       /immune domains=fitness,code Check this workout generator API for issues:
       Programme débutant: Back squat 5x5 à 80kg for a sedentary 45-year-old.
-      const STRIPE_KEY = 'sk_live_abc123';
+      const STRIPE_KEY = 'EXAMPLE_KEY_DO_NOT_USE';
     rubric:
       - "detects heavy squat inappropriate for sedentary beginner"
       - "detects hardcoded API key in source code"

--- a/skills/immune/evals/cases.yaml
+++ b/skills/immune/evals/cases.yaml
@@ -1,0 +1,55 @@
+cases:
+  - id: sql_injection_code_scan
+    prompt: >
+      /immune Check this function for common pitfalls:
+      const userId = req.query.id;
+      const result = await db.prepare(`SELECT * FROM users WHERE id = '${userId}'`).all();
+      return Response.json(result);
+    rubric:
+      - "detects SQL injection via string concatenation"
+      - "recommends parameterized queries with .bind()"
+      - "classifies as critical severity"
+    trigger_expected: true
+
+  - id: multi_domain_scan
+    prompt: >
+      /immune domains=fitness,code Check this workout generator API for issues:
+      Programme débutant: Back squat 5x5 à 80kg for a sedentary 45-year-old.
+      const STRIPE_KEY = 'sk_live_abc123';
+    rubric:
+      - "detects heavy squat inappropriate for sedentary beginner"
+      - "detects hardcoded API key in source code"
+      - "handles multi-domain scanning (fitness + code)"
+    trigger_expected: true
+
+  - id: clean_code_no_issues
+    prompt: >
+      /immune scan-only Check this code:
+      async function getUser(id) {
+        try {
+          const stmt = db.prepare('SELECT * FROM users WHERE id = ?');
+          const user = await stmt.bind(id).first();
+          if (!user) return new Response('Not found', { status: 404 });
+          return Response.json(user);
+        } catch (err) {
+          console.error('DB error:', err);
+          return new Response('Server error', { status: 500 });
+        }
+      }
+    rubric:
+      - "reports scan_result as clean"
+      - "does not flag false positives on well-written code"
+      - "may identify positive strategies (prepared statements, error handling)"
+    trigger_expected: true
+
+  - id: general_code_review_request
+    prompt: "Review the architecture of our microservices and suggest improvements"
+    rubric:
+      - "architecture review is outside immune scan scope — use architecture-reviewer"
+    trigger_expected: false
+
+  - id: security_audit_request
+    prompt: "Run a full security audit on our public GitHub repository"
+    rubric:
+      - "repository security audits are outside immune scan scope — use repo-sentinel"
+    trigger_expected: false

--- a/skills/immune/immune_memory.json
+++ b/skills/immune/immune_memory.json
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "antibodies": [],
+  "stats": {
+    "outputs_checked": 0,
+    "issues_caught": 0,
+    "antibodies_total": 0
+  }
+}

--- a/skills/linkedin-post-style/evals/cases.yaml
+++ b/skills/linkedin-post-style/evals/cases.yaml
@@ -1,0 +1,46 @@
+cases:
+  - id: observational_post_from_notes
+    prompt: "Write a LinkedIn post about this: Google released Gemini 2.5 Pro. It scores 92% on SWE-bench. It can handle 1M token context. It's their best coding model yet."
+    fixtures: []
+    rubric:
+      - "Uses 5-act structure: hook, legend, credibility, observation, meaning"
+      - "Hook is a specific metric or fact, not an opinion"
+      - "No exclamation marks or emoji anywhere in the post"
+      - "No superlatives such as 'incredible', 'amazing', or 'game-changing'"
+      - "Withholds first-person ('I', 'my', 'me') until late in the post"
+      - "Post length is 150-300 words"
+    trigger_expected: true
+
+  - id: rewrite_existing_draft
+    prompt: "Rewrite this for LinkedIn in my style: 'Excited to announce that our team just shipped an amazing new AI feature! It's incredible how much faster developers can code now. What do you think? #AI #DevTools #Innovation'"
+    fixtures: []
+    rubric:
+      - "Removes all anti-patterns: exclamation marks, 'excited to announce', superlatives, hashtags in body, audience question"
+      - "Moves links and hashtags to comment section or omits them from the post body"
+      - "Preserves the core technical content (team shipped an AI feature that speeds up developer coding)"
+      - "Applies informed-casual voice throughout"
+    trigger_expected: true
+
+  - id: experience_post
+    prompt: "Draft a post about my experience using Cursor vs Claude Code for the past month. Cursor is good for small edits but Claude Code handles complex refactors better. I switched fully to Claude Code."
+    fixtures: []
+    rubric:
+      - "Uses early first-person ('I', 'my') consistent with experience post pattern"
+      - "No hedging qualifiers ('maybe', 'perhaps', 'I think', 'it seems')"
+      - "Contains specific observations rather than generalizations"
+      - "Ends with a meaning layer (broader implication or insight), not a call-to-action or audience question"
+    trigger_expected: true
+
+  - id: generic_writing_request
+    prompt: "Write a professional email to my manager about taking time off next week."
+    fixtures: []
+    rubric:
+      - "Does not apply LinkedIn post style rules (this is an email, not LinkedIn content)"
+    trigger_expected: false
+
+  - id: technical_blog_post
+    prompt: "Write a 2000-word technical blog post about database sharding strategies."
+    fixtures: []
+    rubric:
+      - "Does not apply LinkedIn post style rules (this is long-form blog content, not LinkedIn short-form post)"
+    trigger_expected: false

--- a/skills/manuscript-provenance/evals/cases.yaml
+++ b/skills/manuscript-provenance/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: numbers_match_scripts
+    prompt: "Check whether the numbers in our paper match the output from our analysis scripts"
+    fixtures: []
+    rubric:
+      - "cross-references manuscript values against code or script outputs"
+      - "detects hardcoded values that should come from computed results"
+      - "identifies stale or mismatched outputs"
+    trigger_expected: true
+
+  - id: latex_reproducibility
+    prompt: "Verify reproducibility of this LaTeX manuscript against our data pipeline"
+    fixtures: []
+    rubric:
+      - "traces claims to computational outputs in the pipeline"
+      - "checks pipeline completeness and identifies missing links"
+    trigger_expected: true
+
+  - id: writing_quality_review
+    prompt: "Review my paper for writing quality and structure"
+    fixtures: []
+    rubric:
+      - "writing quality review is manuscript-review territory, not provenance auditing"
+    trigger_expected: false
+
+  - id: run_analysis_scripts
+    prompt: "Run our analysis scripts and generate the results"
+    fixtures: []
+    rubric:
+      - "executing analysis pipelines is outside provenance auditing scope"
+    trigger_expected: false

--- a/skills/manuscript-review/evals/cases.yaml
+++ b/skills/manuscript-review/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: pre_submission_review
+    prompt: "Review my paper before I submit it to the conference"
+    fixtures: []
+    rubric:
+      - "produces section-level diagnostics with specific feedback"
+      - "checks citation hygiene (formatting, completeness, consistency)"
+      - "assesses overall submission readiness"
+    trigger_expected: true
+
+  - id: reference_consistency_check
+    prompt: "Check the references in my thesis chapter for consistency"
+    fixtures: []
+    rubric:
+      - "identifies citation format issues across references"
+      - "checks for missing or duplicate references"
+    trigger_expected: true
+
+  - id: numbers_from_code
+    prompt: "Verify that the numbers in my paper come from code"
+    fixtures: []
+    rubric:
+      - "numerical provenance verification is manuscript-provenance territory, not manuscript review"
+    trigger_expected: false
+
+  - id: write_introduction
+    prompt: "Write the introduction section for my paper"
+    fixtures: []
+    rubric:
+      - "writing new manuscript content is outside review scope"
+    trigger_expected: false

--- a/skills/mcp-to-skill/evals/cases.yaml
+++ b/skills/mcp-to-skill/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: convert_slack_mcp
+    prompt: "Convert our Slack MCP server into a Claude Code skill to reduce context usage"
+    fixtures: []
+    rubric:
+      - "analyzes MCP tool definitions from the Slack server"
+      - "classifies tools by replacement strategy (direct, composite, skip)"
+      - "generates a SKILL.md file with converted instructions"
+    trigger_expected: true
+
+  - id: slim_context_mcp_tools
+    prompt: "My context window is too full from MCP tools, help me slim them down"
+    fixtures: []
+    rubric:
+      - "identifies high-token-cost MCP tools"
+      - "recommends conversion to skills for the most impactful tools"
+    trigger_expected: true
+
+  - id: build_new_mcp_server
+    prompt: "Build a new MCP server from scratch"
+    fixtures: []
+    rubric:
+      - "MCP server creation is outside MCP-to-skill conversion scope"
+    trigger_expected: false
+
+  - id: general_context_question
+    prompt: "Why is my Claude conversation running out of context?"
+    fixtures: []
+    rubric:
+      - "general context window questions without MCP tools are outside conversion scope"
+    trigger_expected: false

--- a/skills/md-to-pdf/evals/cases.yaml
+++ b/skills/md-to-pdf/evals/cases.yaml
@@ -1,0 +1,54 @@
+cases:
+  - id: basic_markdown_conversion
+    prompt: "Convert this markdown file to PDF: report.md"
+    fixtures: []
+    rubric:
+      - "invokes md_to_pdf.py or equivalent conversion pipeline"
+      - "produces a .pdf output file"
+      - "uses pandoc for markdown-to-HTML conversion"
+      - "uses Playwright/Chromium for HTML-to-PDF"
+    trigger_expected: true
+
+  - id: mermaid_diagram_rendering
+    prompt: "Convert my markdown to PDF. It contains Mermaid diagrams:\n```mermaid\nflowchart LR\n  A[Start] --> B[Process] --> C[End]\n```"
+    fixtures: []
+    rubric:
+      - "detects Mermaid code blocks"
+      - "invokes mmdc (mermaid-cli) to render SVG"
+      - "replaces mermaid blocks with rendered SVG in source"
+      - "produces PDF with rendered diagram (not raw code)"
+    trigger_expected: true
+
+  - id: latex_math_rendering
+    prompt: "Make a PDF from this markdown with math equations: $E=mc^2$ and $$\\int_0^1 f(x) dx$$"
+    fixtures: []
+    rubric:
+      - "detects LaTeX math (both inline $ and display $$)"
+      - "uses KaTeX for server-side rendering"
+      - "produces PDF with rendered equations (not raw LaTeX)"
+      - "handles both inline and display modes"
+    trigger_expected: true
+
+  - id: custom_options
+    prompt: "Convert notes.md to PDF with US Letter size, landscape orientation, and page numbers."
+    fixtures: []
+    rubric:
+      - "applies --format Letter"
+      - "applies --landscape flag"
+      - "applies --header-footer for page numbers"
+      - "passes all options to the conversion script"
+    trigger_expected: true
+
+  - id: html_to_pdf_request
+    prompt: "Convert this HTML file to a PDF document."
+    fixtures: []
+    rubric:
+      - "does not trigger md-to-pdf skill (input is HTML, not markdown)"
+    trigger_expected: false
+
+  - id: pdf_editing_request
+    prompt: "Edit this PDF and change the title on page 3."
+    fixtures: []
+    rubric:
+      - "does not trigger md-to-pdf skill (editing existing PDF, not creating from markdown)"
+    trigger_expected: false

--- a/skills/migration-risk-analyzer/evals/cases.yaml
+++ b/skills/migration-risk-analyzer/evals/cases.yaml
@@ -1,0 +1,58 @@
+cases:
+  - id: alter_table_add_column_not_null
+    prompt: "Analyze this migration for risk: ALTER TABLE orders ADD COLUMN paid BOOLEAN NOT NULL DEFAULT false;"
+    fixtures: []
+    rubric:
+      - "Identifies ACCESS EXCLUSIVE lock (or equivalent heavyweight lock) on the orders table"
+      - "Estimates downtime or lock duration impact on concurrent queries"
+      - "Generates rollback script containing DROP COLUMN paid"
+      - "Flags DEFAULT false as safe non-blocking backfill on Postgres 11+ (ADD COLUMN with non-volatile DEFAULT avoids table rewrite)"
+    trigger_expected: true
+
+  - id: drop_column_irreversible
+    prompt: "Is this migration safe? ALTER TABLE users DROP COLUMN legacy_email;"
+    fixtures: []
+    rubric:
+      - "Flags the operation as IRREVERSIBLE due to permanent data loss"
+      - "Recommends backing up the column data before execution"
+      - "Does not generate a rollback script that restores data (data is unrecoverable without backup)"
+      - "Warns about dependent views, indexes, or constraints that reference legacy_email"
+    trigger_expected: true
+
+  - id: multi_operation_migration
+    prompt: >-
+      Review this migration:
+      ALTER TABLE products ADD COLUMN category_id INTEGER;
+      CREATE INDEX idx_products_category ON products(category_id);
+      ALTER TABLE products ADD CONSTRAINT fk_category FOREIGN KEY (category_id) REFERENCES categories(id);
+    fixtures: []
+    rubric:
+      - "Analyzes each of the three operations separately with individual risk assessments"
+      - "Identifies cumulative lock risk from multiple sequential ALTER TABLE and DDL statements"
+      - "Notes that CREATE INDEX blocks writes and recommends CREATE INDEX CONCURRENTLY as alternative"
+      - "Produces a per-operation risk table or structured breakdown showing lock type, duration estimate, and severity"
+    trigger_expected: true
+
+  - id: backfill_large_table
+    prompt: "Analyze risk: UPDATE users SET status = 'active' WHERE status IS NULL; -- table has 50M rows"
+    fixtures: []
+    rubric:
+      - "Flags row-level locking at scale affecting 50M rows"
+      - "Estimates long transaction duration proportional to table size"
+      - "Recommends batched updates (e.g., process N rows per transaction) instead of single bulk UPDATE"
+      - "Warns about transaction log (WAL) growth and potential replication lag"
+    trigger_expected: true
+
+  - id: general_database_question
+    prompt: "What is a database migration?"
+    fixtures: []
+    rubric:
+      - "Does not perform migration risk analysis (this is a general knowledge question)"
+    trigger_expected: false
+
+  - id: query_optimization_request
+    prompt: "This query is slow: SELECT * FROM orders WHERE created_at > '2024-01-01'"
+    fixtures: []
+    rubric:
+      - "Does not perform migration risk analysis (this is query optimization, not a schema migration)"
+    trigger_expected: false

--- a/skills/pr-review/evals/cases.yaml
+++ b/skills/pr-review/evals/cases.yaml
@@ -1,0 +1,48 @@
+cases:
+  - id: review_buggy_diff
+    prompt: "Review this diff for issues before I merge."
+    fixtures: ["fixtures/buggy_diff.patch"]
+    rubric:
+      - "identifies plaintext password comparison as CRITICAL security issue (was bcrypt, now raw comparison)"
+      - "identifies bare except with pass as silent failure"
+      - "classifies the security regression as Critical severity"
+      - "classifies silent failure as Important or Critical"
+      - "includes file:line references for both findings"
+      - "recommends reverting to bcrypt comparison"
+    trigger_expected: true
+
+  - id: review_unstaged_changes
+    prompt: "Review my changes before I commit."
+    fixtures: []
+    rubric:
+      - "uses git diff to identify changed files"
+      - "applies code review dimension at minimum"
+      - "produces severity-ranked findings (Critical/Important/Suggestion)"
+      - "includes file:line references"
+      - "acknowledges strengths if any"
+    trigger_expected: true
+
+  - id: specific_dimension_request
+    prompt: "Check my code for silent failures and error handling issues."
+    fixtures: []
+    rubric:
+      - "activates error handling dimension specifically"
+      - "loads error-handling reference"
+      - "examines try/catch/except blocks"
+      - "classifies findings by CRITICAL/HIGH/MEDIUM"
+      - "does not run unrelated dimensions (test analysis, type design)"
+    trigger_expected: true
+
+  - id: architecture_review_request
+    prompt: "Review the overall architecture of our system for scalability."
+    fixtures: []
+    rubric:
+      - "does not activate pr-review workflow (architecture-reviewer territory)"
+    trigger_expected: false
+
+  - id: test_generation_request
+    prompt: "Write tests for this function I just changed."
+    fixtures: []
+    rubric:
+      - "does not activate pr-review workflow (test-harness territory)"
+    trigger_expected: false

--- a/skills/pr-review/evals/fixtures/buggy_diff.patch
+++ b/skills/pr-review/evals/fixtures/buggy_diff.patch
@@ -1,0 +1,18 @@
+diff --git a/src/auth.py b/src/auth.py
+index 1234567..abcdefg 100644
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -10,8 +10,12 @@ def authenticate(username: str, password: str) -> bool:
+     user = db.get_user(username)
+     if user is None:
+         return False
+-    return bcrypt.checkpw(password.encode(), user.password_hash)
++    if password == user.password_hash:
++        return True
++    return False
+
++def delete_account(user_id):
++    try:
++        db.delete(user_id)
++    except:
++        pass

--- a/skills/prompt-lab/SKILL.md
+++ b/skills/prompt-lab/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: prompt-lab
 description: >
-  Systematic prompt engineering: analyzes existing prompts for failure modes, generates
-  structured variants (direct, few-shot, chain-of-thought), designs evaluation rubrics
-  with weighted criteria, and produces test case suites for comparing prompt performance.
-  Triggers on: "improve this prompt", "prompt engineering", "prompt lab",
-  "generate prompt variants", "A/B test prompts", "evaluate this prompt",
-  "prompt failure modes", "optimize prompt", "write a better prompt",
-  "prompt design", "prompt iteration", "few-shot examples".
-  Use this skill when designing, improving, or evaluating LLM prompts.
+  Systematic LLM prompt engineering: analyzes existing prompts for failure modes,
+  generates structured variants (direct, few-shot, chain-of-thought), designs evaluation
+  rubrics with weighted criteria, and produces test case suites for comparing prompt
+  performance. Triggers on: "prompt engineering", "prompt lab", "generate prompt variants",
+  "A/B test prompts", "evaluate prompt", "optimize prompt", "write a better prompt",
+  "prompt design", "prompt iteration", "few-shot examples", "chain-of-thought prompt",
+  "prompt failure modes", "improve this prompt".
+  Use this skill when designing, improving, or evaluating LLM prompts specifically.
+  NOT for evaluating Claude Code skills or SKILL.md files — use skill-evaluator instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/prompt-lab/evals/cases.yaml
+++ b/skills/prompt-lab/evals/cases.yaml
@@ -1,0 +1,51 @@
+cases:
+  # --- Positive cases ---
+
+  - id: improve_existing_prompt
+    prompt: "Improve this prompt: 'Summarize the document.' It's for Claude to summarize technical documents into 3-5 bullet points."
+    fixtures: []
+    rubric:
+      - "Identifies weaknesses in the current prompt (no output format, no length constraint, no audience specification)"
+      - "Generates 2-4 variants each testing a different hypothesis"
+      - "Each variant changes ONE variable from baseline"
+      - "Includes complete prompt text for each variant (not just descriptions)"
+      - "Designs an evaluation rubric with weighted criteria"
+    trigger_expected: true
+
+  - id: design_classification_prompt
+    prompt: "Design a prompt for GPT-4 to classify customer support tickets into categories: billing, technical, account, feature-request, other."
+    fixtures: []
+    rubric:
+      - "Generates variants including at minimum a direct instruction and a few-shot approach"
+      - "Includes concrete examples in the few-shot variant"
+      - "Designs test cases with at least one edge case (ambiguous ticket)"
+      - "Specifies success criteria (classification accuracy)"
+      - "Notes target model (GPT-4) in recommendations"
+    trigger_expected: true
+
+  - id: failure_mode_analysis
+    prompt: "Why does this prompt sometimes produce hallucinated facts? 'You are an expert. Answer the user's question about our product based on your knowledge.'"
+    fixtures: []
+    rubric:
+      - "Identifies missing grounding/context as the core failure mode"
+      - "Identifies 'based on your knowledge' as hallucination-inducing"
+      - "Recommends providing source documents or RAG context"
+      - "Generates improved variants that constrain the model to provided context"
+      - "Includes test cases specifically designed to trigger hallucination"
+    trigger_expected: true
+
+  # --- Negative cases ---
+
+  - id: skill_evaluation_request
+    prompt: "Evaluate this SKILL.md file for quality and trigger coverage."
+    fixtures: []
+    rubric:
+      - "Does NOT trigger prompt-lab skill (skill-evaluator territory, not prompt engineering)"
+    trigger_expected: false
+
+  - id: code_generation_request
+    prompt: "Write a Python script that processes CSV files."
+    fixtures: []
+    rubric:
+      - "Does NOT trigger prompt-lab skill (general coding task, not prompt engineering)"
+    trigger_expected: false

--- a/skills/rag-auditor/SKILL.md
+++ b/skills/rag-auditor/SKILL.md
@@ -5,10 +5,12 @@ description: >
   and generation stages. Measures precision, recall, MRR for retrieval; groundedness,
   completeness, and hallucination rate for generation. Diagnoses failure root causes
   and recommends chunk, retrieval, and prompt improvements.
-  Triggers on: "audit RAG", "RAG quality", "evaluate retrieval", "hallucination detection",
-  "retrieval precision", "why is RAG failing", "RAG diagnosis", "retrieval quality",
-  "RAG evaluation", "chunk quality", "RAG pipeline review", "grounding check".
+  Triggers on: "audit RAG pipeline", "RAG quality", "evaluate RAG retrieval",
+  "hallucination detection", "retrieval precision", "why is RAG failing",
+  "RAG diagnosis", "retrieval quality", "RAG evaluation", "chunk quality",
+  "RAG pipeline review", "grounding check".
   Use this skill when diagnosing or evaluating a RAG pipeline's quality.
+  For general architecture or system audits, use architecture-reviewer instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/rag-auditor/evals/cases.yaml
+++ b/skills/rag-auditor/evals/cases.yaml
@@ -1,0 +1,44 @@
+cases:
+  - id: diagnose_retrieval_failure
+    prompt: "My RAG pipeline returns irrelevant answers. Using OpenAI text-embedding-3-small, Pinecone with K=5, and GPT-4 for generation. Chunk size is 512 tokens with no overlap. What's wrong?"
+    fixtures: []
+    rubric:
+      - "identifies retrieval stage as likely failure point"
+      - "questions zero overlap chunking"
+      - "suggests increasing overlap or semantic chunking"
+      - "recommends measuring Precision@K and Recall@K"
+    trigger_expected: true
+
+  - id: diagnose_hallucination
+    prompt: "Our RAG system retrieves relevant documents but the generated answers contain facts not in the retrieved context. How do I audit this?"
+    fixtures: []
+    rubric:
+      - "identifies generation-stage failure (not retrieval)"
+      - "recommends groundedness evaluation"
+      - "suggests strengthening grounding instructions in prompt"
+      - "recommends measuring hallucination rate"
+    trigger_expected: true
+
+  - id: full_pipeline_audit
+    prompt: "Audit our RAG pipeline: 10K documents chunked at 1024 tokens, BAAI/bge-large embeddings, ChromaDB, K=10, Claude Sonnet for generation. We're getting inconsistent quality."
+    fixtures: []
+    rubric:
+      - "evaluates both retrieval AND generation stages"
+      - "recommends evaluation query design"
+      - "addresses chunk size for the embedding model"
+      - "produces structured audit approach"
+    trigger_expected: true
+
+  - id: general_architecture_audit
+    prompt: "Audit the architecture of our microservices system for scalability issues."
+    fixtures: []
+    rubric:
+      - "does not activate RAG auditor skill"
+    trigger_expected: false
+
+  - id: embedding_model_comparison
+    prompt: "Which embedding model should I use for my project?"
+    fixtures: []
+    rubric:
+      - "does not activate RAG auditor skill"
+    trigger_expected: false

--- a/skills/regex-builder/SKILL.md
+++ b/skills/regex-builder/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: regex-builder
 description: >
-  Generates, explains, and tests regular expression patterns. Builds patterns from
-  positive and negative examples, breaks down each component with a readable explanation
-  table, generates edge-case test suites, and provides usage examples in Python and
-  JavaScript.
-  Triggers on: "regex for", "regular expression", "pattern for", "match strings like",
-  "extract from", "build regex", "create pattern", "explain this regex",
-  "what does this regex do", "regex to match", "parse with regex", "validate format".
-  Use this skill when building, explaining, or testing a regular expression pattern.
+  DEPRECATED: The base model generates, explains, and tests regex patterns natively
+  with high accuracy. This skill no longer provides meaningful uplift. Retained for
+  reference only.
 metadata:
   version: 1.0.0
+  status: deprecated
 ---
+
+> **DEPRECATED** — Modern Claude models produce accurate, well-explained regex patterns
+> with edge-case test suites natively, including multi-language usage examples. The uplift
+> delta from this skill approaches zero. Retained for archival reference only.
 
 # Regex Builder
 

--- a/skills/regex-builder/evals/cases.yaml
+++ b/skills/regex-builder/evals/cases.yaml
@@ -1,0 +1,14 @@
+cases:
+  - id: build_email_regex
+    prompt: "Build a regex to match email addresses"
+    fixtures: []
+    rubric:
+      - "does not activate regex-builder (deprecated, model handles natively)"
+    trigger_expected: false
+
+  - id: explain_regex_pattern
+    prompt: "Explain what this regex does: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+    fixtures: []
+    rubric:
+      - "does not activate regex-builder (deprecated, model handles natively)"
+    trigger_expected: false

--- a/skills/remotion-video/evals/cases.yaml
+++ b/skills/remotion-video/evals/cases.yaml
@@ -1,0 +1,36 @@
+cases:
+  - id: branded_product_launch_video
+    prompt: >
+      Create a Remotion video for our product launch with our brand colors (#1A1A2E, #E94560),
+      logo at assets/logo.png, and background music from assets/launch-track.mp3.
+    fixtures: []
+    rubric:
+      - "sets up Remotion React project with composition and video entry point"
+      - "uses TailwindCSS or styled-components for styling with specified brand colors"
+      - "includes audio sync via Remotion Audio component with the background music file"
+    trigger_expected: true
+
+  - id: data_driven_revenue_video
+    prompt: >
+      Generate a data-driven video showing monthly revenue growth from this CSV data.
+      The video should animate bar charts with labeled axes and smooth transitions.
+    fixtures: []
+    rubric:
+      - "creates React composition with data input props for CSV-sourced revenue data"
+      - "animates chart or data visualization using Remotion interpolate/spring"
+      - "produces renderable video via Remotion CLI or renderMedia"
+    trigger_expected: true
+
+  - id: negative_math_proof_animation
+    prompt: "Animate a math proof step by step showing the derivation of Euler's identity"
+    fixtures: []
+    rubric:
+      - "mathematical proof animation is concept-to-video/Manim territory, not Remotion"
+    trigger_expected: false
+
+  - id: negative_static_product_image
+    prompt: "Create a static image of our product on a white background for the website hero section"
+    fixtures: []
+    rubric:
+      - "static image generation is not a video task"
+    trigger_expected: false

--- a/skills/repo-sentinel/evals/cases.yaml
+++ b/skills/repo-sentinel/evals/cases.yaml
@@ -1,0 +1,54 @@
+cases:
+  - id: detect_hardcoded_api_key
+    prompt: "Audit this file before pushing:\n```python\nAPI_KEY = 'sk-live-abc123def456ghi789'\nresponse = requests.get(url, headers={'Authorization': f'Bearer {API_KEY}'})\n```"
+    fixtures: []
+    rubric:
+      - "classifies as CRITICAL severity"
+      - "identifies hardcoded credential"
+      - "recommends environment variable"
+      - "recommends credential rotation"
+    trigger_expected: true
+
+  - id: detect_internal_url_in_docs
+    prompt: "Review this README before making the repo public:\n## Setup\nSee https://wiki.internal.corp/auth-setup for authentication details.\nContact john.smith@company.com for access."
+    fixtures: []
+    rubric:
+      - "flags internal URL as HIGH"
+      - "flags personal email/name as MEDIUM"
+      - "recommends removing internal references"
+      - "recommends generic contact"
+    trigger_expected: true
+
+  - id: detect_env_file_tracked
+    prompt: "Is this repo safe to push? git ls-files shows .env and .env.production are tracked."
+    fixtures: []
+    rubric:
+      - "flags .env files as CRITICAL"
+      - "recommends git rm --cached"
+      - "recommends adding to .gitignore"
+      - "warns about history scrubbing if already pushed"
+    trigger_expected: true
+
+  - id: pre_oss_audit_request
+    prompt: "We want to open source this repo. Run a security audit."
+    fixtures: []
+    rubric:
+      - "triggers full audit mode (not fast-path)"
+      - "covers multiple attack surfaces"
+      - "checks for LICENSE file"
+      - "checks for SECURITY.md"
+    trigger_expected: true
+
+  - id: general_security_question
+    prompt: "What are the OWASP top 10 vulnerabilities?"
+    fixtures: []
+    rubric:
+      - "does not trigger repo-sentinel skill"
+    trigger_expected: false
+
+  - id: code_review_request
+    prompt: "Review this function for bugs and code quality issues."
+    fixtures: []
+    rubric:
+      - "does not trigger repo-sentinel skill"
+    trigger_expected: false

--- a/skills/repo-sentinel/evals/cases.yaml
+++ b/skills/repo-sentinel/evals/cases.yaml
@@ -1,6 +1,6 @@
 cases:
   - id: detect_hardcoded_api_key
-    prompt: "Audit this file before pushing:\n```python\nAPI_KEY = 'sk-live-abc123def456ghi789'\nresponse = requests.get(url, headers={'Authorization': f'Bearer {API_KEY}'})\n```"
+    prompt: "Audit this file before pushing:\n```python\nAPI_KEY = 'EXAMPLE_KEY_DO_NOT_USE'\nresponse = requests.get(url, headers={'Authorization': f'Bearer {API_KEY}'})\n```"
     fixtures: []
     rubric:
       - "classifies as CRITICAL severity"

--- a/skills/sequential-thinking/SKILL.md
+++ b/skills/sequential-thinking/SKILL.md
@@ -4,12 +4,14 @@ description: >
   Structured, reflective problem-solving through sequential chain-of-thought reasoning.
   Replaces the Sequential Thinking MCP server (sequentialthinking tool). Use this skill
   when facing complex multi-step problems, planning and design tasks, analysis that may
-  need course correction, debugging with iterative hypothesis testing, architectural
-  decisions requiring trade-off evaluation, or any task where the full scope is unclear
-  initially. Trigger on: sequential thinking, step by step reasoning, chain of thought,
-  break down problem, think through this, structured analysis, multi-step problem solving,
-  reflective reasoning, thought process, deep analysis, complex reasoning, hypothesis
-  verification, branching analysis, revision-based thinking, dynamic problem solving.
+  need course correction, architectural decisions requiring trade-off evaluation, or any
+  task where the full scope is unclear initially.
+  Triggers on: "step by step reasoning", "chain of thought", "break down problem",
+  "think through this", "structured analysis", "multi-step problem solving",
+  "reflective reasoning", "deep analysis", "complex reasoning", "hypothesis verification",
+  "branching analysis", "trade-off evaluation".
+  NOT for diagnosing bugs, errors, stacktraces, or unexpected behavior in code — use
+  debug-investigator instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/sequential-thinking/SKILL.md
+++ b/skills/sequential-thinking/SKILL.md
@@ -1,20 +1,17 @@
 ---
 name: sequential-thinking
 description: >
-  Structured, reflective problem-solving through sequential chain-of-thought reasoning.
-  Replaces the Sequential Thinking MCP server (sequentialthinking tool). Use this skill
-  when facing complex multi-step problems, planning and design tasks, analysis that may
-  need course correction, architectural decisions requiring trade-off evaluation, or any
-  task where the full scope is unclear initially.
-  Triggers on: "step by step reasoning", "chain of thought", "break down problem",
-  "think through this", "structured analysis", "multi-step problem solving",
-  "reflective reasoning", "deep analysis", "complex reasoning", "hypothesis verification",
-  "branching analysis", "trade-off evaluation".
-  NOT for diagnosing bugs, errors, stacktraces, or unexpected behavior in code — use
-  debug-investigator instead.
+  DEPRECATED: Use the model's native extended thinking instead. Structured, reflective
+  problem-solving through sequential chain-of-thought reasoning that replaced the
+  Sequential Thinking MCP server.
 metadata:
   version: 1.0.0
+  status: deprecated
 ---
+
+> **DEPRECATED** — Sonnet 4 and Opus 4 handle structured chain-of-thought natively,
+> including revision, branching, and scope adjustment. This skill no longer provides
+> meaningful uplift over the base model. Retained for reference only.
 
 # Sequential Thinking
 

--- a/skills/sequential-thinking/evals/cases.yaml
+++ b/skills/sequential-thinking/evals/cases.yaml
@@ -1,0 +1,14 @@
+cases:
+  - id: step_by_step_thinking
+    prompt: "Think through this problem step by step"
+    fixtures: []
+    rubric:
+      - "does not activate sequential-thinking (deprecated, model handles natively)"
+    trigger_expected: false
+
+  - id: sequential_breakdown
+    prompt: "Break down this complex analysis into sequential steps"
+    fixtures: []
+    rubric:
+      - "does not activate sequential-thinking (deprecated, model handles natively)"
+    trigger_expected: false

--- a/skills/skill-evaluator/SKILL.md
+++ b/skills/skill-evaluator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-evaluator
 description: >
-  Evaluate Claude Code skill quality across 6 weighted dimensions: frontmatter quality,
+  Evaluate Claude Code SKILL.md quality across 6 weighted dimensions: frontmatter quality,
   trigger coverage, structural completeness, content depth, consistency and integrity,
   and CONTRIBUTING.md compliance. Produces scored audit reports with severity-classified
   findings and actionable recommendations. Two modes: (1) Quick Audit — single skill,
@@ -9,9 +9,10 @@ description: >
   comparative ranking table plus per-skill summaries. Triggers on: "evaluate skill",
   "audit skill quality", "score skill", "skill review", "check skill completeness",
   "rate this skill", "skill quality check", "grade skill", "assess skill", "skill audit",
-  "how good is this skill", or when a user asks for feedback on a SKILL.md file. Use this
-  skill when reviewing skills before deployment, comparing skill quality across a repo,
-  or diagnosing why a skill fails to activate on relevant queries.
+  "how good is this skill", "SKILL.md feedback". Use this skill when reviewing Claude Code
+  skills before deployment, comparing skill quality across a repo, or diagnosing why a
+  skill fails to activate on relevant queries.
+  NOT for evaluating or improving LLM prompts — use prompt-lab instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/skill-evaluator/evals/cases.yaml
+++ b/skills/skill-evaluator/evals/cases.yaml
@@ -1,0 +1,32 @@
+cases:
+  - id: evaluate_single_skill
+    prompt: "Evaluate the quality of the sql-optimizer SKILL.md"
+    fixtures: []
+    rubric:
+      - "scores across defined dimensions including frontmatter quality and trigger coverage"
+      - "produces severity-classified findings (critical, warning, info)"
+      - "gives actionable recommendations for improvement"
+    trigger_expected: true
+
+  - id: audit_all_skills
+    prompt: "Run a full audit across all skills in this repo and rank them by quality"
+    fixtures: []
+    rubric:
+      - "produces comparative ranking table across all skills"
+      - "includes per-skill summaries with scores"
+      - "identifies lowest-scoring skills with specific deficiencies"
+    trigger_expected: true
+
+  - id: negative_prompt_improvement
+    prompt: "Improve this LLM prompt for better classification accuracy: 'Classify the sentiment of the following text'"
+    fixtures: []
+    rubric:
+      - "prompt engineering is prompt-lab territory, not skill evaluation"
+    trigger_expected: false
+
+  - id: negative_skill_creation
+    prompt: "Write a new skill for database optimization from scratch"
+    fixtures: []
+    rubric:
+      - "skill creation is outside skill evaluation scope"
+    trigger_expected: false

--- a/skills/sql-optimizer/evals/cases.yaml
+++ b/skills/sql-optimizer/evals/cases.yaml
@@ -1,0 +1,64 @@
+cases:
+  - id: missing_index_on_filter
+    prompt: >
+      Optimize this query, table has 5M rows:
+      SELECT * FROM orders WHERE customer_email = 'user@example.com' AND status = 'pending';
+    fixtures: []
+    rubric:
+      - "identifies missing index on filter columns (customer_email, status)"
+      - "recommends composite index on (customer_email, status)"
+      - "flags SELECT * as anti-pattern"
+      - "suggests selecting specific columns instead of SELECT *"
+    trigger_expected: true
+
+  - id: n_plus_one_pattern
+    prompt: >
+      This is slow in our Django app:
+      for user in User.objects.all():
+          orders = Order.objects.filter(user_id=user.id)
+          print(f'{user.name}: {orders.count()}')
+    fixtures: []
+    rubric:
+      - "identifies N+1 query pattern"
+      - "recommends select_related or prefetch_related"
+      - "suggests single query with JOIN or subquery"
+      - "explains why N+1 causes N additional database roundtrips"
+    trigger_expected: true
+
+  - id: suboptimal_join_with_explain
+    prompt: >
+      Why is this slow? PostgreSQL EXPLAIN shows Seq Scan on products (cost=0.00..45000.00 rows=1000000):
+      SELECT p.name, c.name FROM products p JOIN categories c ON p.category_id = c.id WHERE p.price > 100 ORDER BY p.created_at DESC LIMIT 20;
+    fixtures: []
+    rubric:
+      - "interprets EXPLAIN output identifying Seq Scan as full table scan"
+      - "recommends index on products(price) or products(created_at)"
+      - "considers composite or covering index"
+      - "explains cost numbers from EXPLAIN output"
+    trigger_expected: true
+
+  - id: function_on_indexed_column
+    prompt: >
+      This query ignores my index on users.email:
+      SELECT * FROM users WHERE UPPER(email) = 'USER@EXAMPLE.COM';
+    fixtures: []
+    rubric:
+      - "identifies function on indexed column prevents index use"
+      - "recommends expression index (CREATE INDEX ON users(UPPER(email)))"
+      - "suggests application-level normalization as alternative"
+      - "explains why the optimizer cannot use the existing index when a function wraps the column"
+    trigger_expected: true
+
+  - id: migration_risk_question
+    prompt: "Is this ALTER TABLE safe to run in production?"
+    fixtures: []
+    rubric:
+      - "migration risk analysis is outside query optimization scope"
+    trigger_expected: false
+
+  - id: database_design_question
+    prompt: "How should I design the schema for a multi-tenant SaaS application?"
+    fixtures: []
+    rubric:
+      - "schema design is outside query optimization scope"
+    trigger_expected: false

--- a/skills/static-web-artifacts-builder/SKILL.md
+++ b/skills/static-web-artifacts-builder/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: static-web-artifacts-builder
 description: >
-  Suite of tools for creating elaborate, self-contained static HTML artifacts — infographics,
-  interactive diagrams, architecture visuals, data dashboards, and rich visual deliverables.
-  Use this skill when asked to create an interactive HTML artifact, build a self-contained web
-  component, generate a static HTML visualization, make an interactive diagram, produce a
-  visual infographic, or render any high-density visual as a single HTML file. Zero build
-  toolchain — no React, no Vite, no Parcel. Pure HTML5 + CSS3 (Grid/Flexbox) + inline SVG.
-  Triggers on: "create interactive HTML", "build self-contained web component", "generate
-  static HTML visualization", "make an interactive diagram", "produce infographic", "render
-  as HTML artifact", "build a visual dashboard", "create a diagram I can open in browser".
+  Build elaborate, self-contained static HTML artifacts opened in a browser — interactive diagrams,
+  architecture visuals, data dashboards, HTML infographics, and rich interactive deliverables.
+  Use this skill when the output is an HTML file viewed in a browser. Zero build toolchain — no
+  React, no Vite, no Parcel. Pure HTML5 + CSS3 (Grid/Flexbox) + inline SVG. Triggers on:
+  "interactive HTML", "self-contained web component", "open in browser", "interactive diagram",
+  "visual dashboard", "HTML artifact", "HTML infographic", "interactive infographic".
+  For image file output (PNG/SVG), use concept-to-image instead.
 metadata:
   version: 1.0.0
 ---

--- a/skills/static-web-artifacts-builder/evals/cases.yaml
+++ b/skills/static-web-artifacts-builder/evals/cases.yaml
@@ -1,0 +1,35 @@
+cases:
+  - id: metrics_dashboard_html
+    prompt: >
+      Create an interactive HTML dashboard showing our system metrics (CPU, memory, disk usage)
+      that I can open directly in a browser.
+    fixtures: []
+    rubric:
+      - "produces a self-contained HTML file with no external dependencies"
+      - "uses HTML5, CSS3, and inline SVG or Canvas for visualizations"
+      - "requires no build toolchain — opens directly in a browser"
+    trigger_expected: true
+
+  - id: interactive_data_flow_diagram
+    prompt: >
+      Build an interactive diagram of our data flow from ingestion through processing to storage
+      that I can open in my browser.
+    fixtures: []
+    rubric:
+      - "creates interactive elements with hover, click, or drag behavior via JS"
+      - "uses pure HTML/CSS/JS without framework dependencies"
+    trigger_expected: true
+
+  - id: negative_png_export
+    prompt: "Export this chart as a PNG image file"
+    fixtures: []
+    rubric:
+      - "PNG image export is concept-to-image territory, not static web artifact"
+    trigger_expected: false
+
+  - id: negative_react_app
+    prompt: "Build a React web application with routing, state management, and API integration"
+    fixtures: []
+    rubric:
+      - "full React application is outside static web artifact scope"
+    trigger_expected: false

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -3,11 +3,12 @@ name: task-decomposer
 description: >
   Breaks down large features into implementable tasks with dependency mapping, edge case
   identification, test strategy planning, and phased execution order. Produces task tables
-  with effort sizing, parallelization flags, and risk flags for each phase.
+  with parallelization flags and risk flags for each phase.
   Triggers on: "break down this feature", "decompose", "task breakdown",
   "how should I implement", "implementation plan", "what are the steps for",
   "edge cases for", "plan this feature", "implementation steps",
-  "break this into tasks", "work breakdown", "project breakdown".
+  "break this into tasks", "work breakdown", "dependency map", "phases".
+  NOT for effort estimates, PERT calculations, or confidence intervals — use estimate-calibrator instead.
   Use this skill when a feature or project needs to be broken into actionable steps.
 metadata:
   version: 1.0.0

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: task-decomposer
 description: >
-  Breaks down large features into implementable tasks with dependency mapping, edge case
-  identification, test strategy planning, and phased execution order. Produces task tables
-  with parallelization flags and risk flags for each phase.
-  Triggers on: "break down this feature", "decompose", "task breakdown",
-  "how should I implement", "implementation plan", "what are the steps for",
-  "edge cases for", "plan this feature", "implementation steps",
-  "break this into tasks", "work breakdown", "dependency map", "phases".
-  NOT for effort estimates, PERT calculations, or confidence intervals — use estimate-calibrator instead.
-  Use this skill when a feature or project needs to be broken into actionable steps.
+  Produces structured phased task boards from feature requests: dependency-mapped work items
+  with parallelization flags, risk flags, edge case tables, and test strategy matrices.
+  Triggers on: "decompose this feature", "task breakdown with dependencies", "phased
+  implementation plan", "dependency map for", "break this into tasks with phases",
+  "work breakdown structure". The differentiator is the structured output format (phased
+  tables, parallelization flags, dependency chains) — use this skill when you need a
+  formal task board, not ad-hoc decomposition the model handles natively.
+  NOT for effort estimates, PERT calculations, or confidence intervals — use
+  estimate-calibrator instead.
 metadata:
   version: 1.0.0
 ---
@@ -20,6 +20,12 @@ Transforms ambiguous feature requests into concrete, implementable task sequence
 identifies acceptance criteria, decomposes into phased work items with effort sizing,
 maps dependencies and parallelization, enumerates edge cases, plans testing, and flags
 risks — producing a ready-to-execute task board.
+
+> **When to use this skill vs native decomposition:** The base model decomposes features
+> well in an ad-hoc format. Use this skill specifically when you need the structured output:
+> phased task tables with dependency mapping, parallelization flags, risk flags, and
+> integrated test strategy. If you just need a quick list of steps, ask directly without
+> invoking this skill.
 
 ## Reference Files
 

--- a/skills/task-decomposer/evals/cases.yaml
+++ b/skills/task-decomposer/evals/cases.yaml
@@ -1,0 +1,36 @@
+cases:
+  - id: decompose_realtime_notifications
+    prompt: >
+      Decompose this feature into phased tasks with dependencies:
+      Add real-time notifications to our chat app using WebSockets.
+    fixtures: []
+    rubric:
+      - "produces phased task tables with clear ordering"
+      - "includes dependency mapping between tasks"
+      - "includes parallelization flags indicating which tasks can run concurrently"
+    trigger_expected: true
+
+  - id: wbs_oauth2_migration
+    prompt: >
+      Create a work breakdown structure for migrating our auth system from session-based
+      to OAuth2 with PKCE flow.
+    fixtures: []
+    rubric:
+      - "identifies edge cases such as token refresh, session migration, and backward compatibility"
+      - "includes risk flags for high-impact subtasks"
+      - "maps test strategy per phase or task group"
+    trigger_expected: true
+
+  - id: negative_time_estimate
+    prompt: "How long will this feature take to build? Give me a time estimate for adding search."
+    fixtures: []
+    rubric:
+      - "time estimation is estimate-calibrator territory, not task decomposition"
+    trigger_expected: false
+
+  - id: negative_code_review
+    prompt: "Review this pull request code for bugs and security issues"
+    fixtures: []
+    rubric:
+      - "code review is outside task decomposition scope"
+    trigger_expected: false

--- a/skills/tavily/SKILL.md
+++ b/skills/tavily/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: tavily
 description: >
-  AI-optimized web search and content extraction via Tavily API. Use this skill when you need
-  to search the web for current information, recent events, technical documentation, news, or
-  any topic requiring live internet data. Triggers on: "search the web", "look this up online",
-  "find recent information about", "search for", "google this", "web search", "look up", "find
-  current data on", "what does the web say about", "research online", "fetch web content",
-  "extract page content", "get article text", "scrape URL". Tavily returns clean, AI-ready
-  snippets — prefer it over raw web fetch for search queries. Use extract for full page content
-  when a specific URL is already known.
+  AI-optimized web search via Tavily API. Use this skill when no specific URL is provided
+  and the user needs to search the web for current information, recent events, technical
+  documentation, or news. Triggers on: "search the web", "look this up online", "find
+  recent information about", "search for", "google this", "web search", "look up", "find
+  current data on", "what does the web say about", "research online". NOT for fetching a
+  known URL — use web-fetch for that. Tavily returns clean, AI-ready snippets optimized
+  for search-first intent.
 metadata:
   version: 1.0.0
 ---

--- a/skills/tavily/evals/cases.yaml
+++ b/skills/tavily/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: search_api_pricing
+    prompt: "Search the web for the latest Claude API pricing and rate limits"
+    fixtures: []
+    rubric:
+      - "uses Tavily search API to perform the web search"
+      - "returns AI-ready snippets with relevant pricing information"
+      - "handles search-first intent without requiring a specific URL"
+    trigger_expected: true
+
+  - id: search_react_best_practices
+    prompt: "Find recent information about React Server Components best practices and patterns"
+    fixtures: []
+    rubric:
+      - "performs web search via Tavily for current information"
+      - "returns relevant results with source attribution"
+    trigger_expected: true
+
+  - id: negative_url_fetch
+    prompt: "Fetch the content from https://docs.anthropic.com/en/api/getting-started"
+    fixtures: []
+    rubric:
+      - "direct URL fetching is web-fetch territory, not web search"
+    trigger_expected: false
+
+  - id: negative_local_file
+    prompt: "Read the contents of /etc/hosts for me"
+    fixtures: []
+    rubric:
+      - "local filesystem operations are outside web search scope"
+    trigger_expected: false

--- a/skills/test-harness/evals/cases.yaml
+++ b/skills/test-harness/evals/cases.yaml
@@ -1,0 +1,48 @@
+cases:
+  - id: generate_tests_for_function
+    prompt: "Write pytest tests for the calculate_discount function in sample_module.py"
+    fixtures: ["fixtures/sample_module.py"]
+    rubric:
+      - "generates test for happy path (valid price and percentage)"
+      - "generates boundary tests (0% discount, 100% discount, price of 0)"
+      - "generates error tests (negative price raises ValueError, percentage > 100 raises ValueError)"
+      - "uses pytest.raises for exception testing"
+      - "uses pytest.mark.parametrize for boundary cases"
+    trigger_expected: true
+
+  - id: generate_tests_for_module
+    prompt: "Generate a comprehensive test suite for fixtures/sample_module.py"
+    fixtures: ["fixtures/sample_module.py"]
+    rubric:
+      - "generates tests for BOTH functions (calculate_discount and find_duplicates)"
+      - "tests find_duplicates with empty list"
+      - "tests find_duplicates with no duplicates"
+      - "tests find_duplicates with multiple duplicates"
+      - "preserves duplicate order in assertions"
+      - "uses concrete test data (not placeholders)"
+    trigger_expected: true
+
+  - id: mock_strategy_request
+    prompt: "Write tests for a function that calls an external API. The function is: def fetch_user(user_id: str) -> dict: response = requests.get(f'https://api.example.com/users/{user_id}'); response.raise_for_status(); return response.json()"
+    fixtures: []
+    rubric:
+      - "mocks requests.get at the module import boundary"
+      - "tests happy path with mocked JSON response"
+      - "tests error case (HTTP 404 raises)"
+      - "asserts mock was called with correct URL"
+      - "does not make real HTTP requests"
+    trigger_expected: true
+
+  - id: run_existing_tests
+    prompt: "Run the tests in tests/ and tell me what fails."
+    fixtures: []
+    rubric:
+      - "does not trigger test-harness skill (test execution, not test generation)"
+    trigger_expected: false
+
+  - id: e2e_test_request
+    prompt: "Write Playwright end-to-end tests for our web application login flow."
+    fixtures: []
+    rubric:
+      - "does not trigger test-harness skill (E2E/browser tests, not unit/integration pytest tests)"
+    trigger_expected: false

--- a/skills/test-harness/evals/fixtures/sample_module.py
+++ b/skills/test-harness/evals/fixtures/sample_module.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+def calculate_discount(price: float, percentage: float) -> float:
+    """Apply a percentage discount to a price.
+
+    Args:
+        price: Original price (must be >= 0)
+        percentage: Discount percentage (0-100)
+
+    Returns:
+        Discounted price
+
+    Raises:
+        ValueError: If price is negative or percentage is out of range
+    """
+    if price < 0:
+        raise ValueError("Price must be non-negative")
+    if not 0 <= percentage <= 100:
+        raise ValueError("Percentage must be between 0 and 100")
+    return round(price * (1 - percentage / 100), 2)
+
+
+def find_duplicates(items: list[str]) -> list[str]:
+    """Return items that appear more than once, in order of first duplicate occurrence."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for item in items:
+        if item in seen and item not in duplicates:
+            duplicates.append(item)
+        seen.add(item)
+    return duplicates

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -2,15 +2,15 @@
 name: web-fetch
 description: >
   Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch
-  MCP server (fetch_html, fetch_json, fetch_markdown, fetch_txt). Covers HTTP
-  GET/POST requests, JSON API consumption with jq, HTML retrieval, markdown
-  conversion, plain text extraction, authenticated requests, redirects, cookies,
-  and timeouts. Trigger phrases: "fetch this URL", "get the page content",
-  "download HTML", "call this API", "curl this endpoint", "grab the JSON",
-  "fetch markdown from", "retrieve web content", "hit this endpoint", "scrape this
-  page", "read this URL", "pull data from API", "make an HTTP request". Use this
-  skill when the user provides a URL and wants its content, when consuming REST
-  APIs, or when extracting readable content from web pages.
+  MCP server (fetch_html, fetch_json, fetch_markdown, fetch_txt). Use this skill when
+  a specific URL is provided and the user wants its content. Covers HTTP GET/POST,
+  JSON API consumption with jq, HTML retrieval, markdown conversion, plain text
+  extraction, authenticated requests, redirects, cookies, and timeouts. Trigger
+  phrases: "fetch this URL", "get the page content", "download HTML", "call this
+  API", "curl this endpoint", "grab the JSON", "fetch markdown from", "retrieve web
+  content", "hit this endpoint", "scrape this page", "read this URL", "pull data
+  from API", "make an HTTP request", "extract page content", "get article text". NOT
+  for web searches without a URL — use tavily for that.
 metadata:
   version: 1.0.0
 ---

--- a/skills/web-fetch/evals/cases.yaml
+++ b/skills/web-fetch/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: fetch_github_api_json
+    prompt: "Fetch the content from https://api.github.com/repos/anthropics/claude-code and show me the repo details"
+    fixtures: []
+    rubric:
+      - "uses curl or WebFetch to retrieve the URL"
+      - "makes HTTP GET request to the specified endpoint"
+      - "parses and presents the JSON response"
+    trigger_expected: true
+
+  - id: fetch_html_extract_content
+    prompt: "Download the HTML from https://example.com and extract the main content"
+    fixtures: []
+    rubric:
+      - "retrieves full page content from the URL"
+      - "supports HTML content extraction from the response"
+    trigger_expected: true
+
+  - id: negative_web_search
+    prompt: "Search the web for information about Rust async patterns and best practices"
+    fixtures: []
+    rubric:
+      - "open-ended web search is tavily territory, not direct URL fetching"
+    trigger_expected: false
+
+  - id: negative_scraping_script
+    prompt: "Create a Python web scraping script using BeautifulSoup to crawl product pages"
+    fixtures: []
+    rubric:
+      - "code generation for scraping is outside content fetching scope"
+    trigger_expected: false

--- a/skills/youtube-analysis/evals/cases.yaml
+++ b/skills/youtube-analysis/evals/cases.yaml
@@ -1,0 +1,31 @@
+cases:
+  - id: youtube_video_concept_analysis
+    prompt: "Analyze this YouTube video and give me the key concepts: https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    fixtures: []
+    rubric:
+      - "extracts transcript via youtube-transcript-api"
+      - "produces structured concept analysis"
+      - "includes multi-level summary (overview, detailed, key concepts)"
+    trigger_expected: true
+
+  - id: youtube_tech_talk_takeaways
+    prompt: "Summarize the key takeaways from this tech talk: https://youtu.be/abc123"
+    fixtures: []
+    rubric:
+      - "identifies actionable takeaways from video content"
+      - "produces structured output with clear sections"
+    trigger_expected: true
+
+  - id: vimeo_video_request
+    prompt: "Watch this Vimeo video and summarize it"
+    fixtures: []
+    rubric:
+      - "does not activate youtube-analysis (not a YouTube URL)"
+    trigger_expected: false
+
+  - id: video_creation_request
+    prompt: "Create a video about binary search"
+    fixtures: []
+    rubric:
+      - "does not activate youtube-analysis (video creation, not analysis)"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

Full modernisation of the praxis-skills catalog across 6 phases — resolving trigger collisions, deprecating low-value skills, achieving 100% eval coverage, and adding CI infrastructure. Also introduces the immune skill (v3.0.0) from an external repo.

**23 commits** | **67 files changed** | **+2,402 / -170 lines** | **39 → 40 skills**

## Changes by Phase

### Phase 1 — Trigger Collision Resolution

Disambiguated 7 overlapping skill pairs so each skill owns exclusive trigger territory with negative disambiguation lines:

| Collision Pair | Resolution |
|---|---|
| architecture-diagram ↔ architecture-reviewer | Diagram owns visual/topology; reviewer owns audit/critique |
| rag-auditor ↔ architecture-reviewer | RAG-qualified all rag-auditor triggers |
| estimate-calibrator ↔ task-decomposer | Estimator owns PERT/sizing; decomposer owns phases/dependencies |
| prompt-lab ↔ skill-evaluator | Prompt-lab owns prompt engineering; skill-evaluator owns SKILL.md evaluation |
| concept-to-image ↔ static-web-artifacts-builder | Image owns PNG/SVG output; builder owns interactive HTML |
| tavily ↔ web-fetch | Tavily owns search-first (no URL); web-fetch owns URL-first |
| debug-investigator ↔ sequential-thinking | Debug owns error/stacktrace; sequential-thinking owns abstract reasoning |

**14 SKILL.md files** updated.

### Phase 2 — Uplift Delta Assessment

Evaluated 5 obsolescence-risk skills against base model capability:

| Skill | Action | Rationale |
|---|---|---|
| sequential-thinking | **Deprecated** | Base model handles chain-of-thought natively |
| doc-condenser | **Deprecated** | Base model handles summarization natively |
| regex-builder | **Deprecated** | Base model generates regex at equivalent quality |
| task-decomposer | **Narrowed** | Value only in structured output format |
| debug-investigator | **Narrowed** | Value in hypothesis/bisection methodology only |

### Phase 3–4 — Priority Eval Authoring (Top 10)

Created detailed eval cases for the 10 highest-value skills with domain-specific rubrics:

- migration-risk-analyzer (6 cases), repo-sentinel (6), rag-auditor (5), linkedin-post-style (5), sql-optimizer (6)
- md-to-pdf (6), architecture-reviewer (5), prompt-lab (6), test-harness (5 + fixture), pr-review (5 + fixture)

**54 total cases** across 10 skills, with 2 fixture files for realistic test inputs.

### Phase 5 — CI Infrastructure

| Component | Purpose |
|---|---|
| `scripts/validate_evals.py` | Schema validator — required fields, types, duplicate IDs, positive/negative case minimums, deprecated skill handling |
| `.github/workflows/skill-evals.yml` | PR gate (manifest sync + eval schema validation) + weekly Monday cron for model drift detection |
| `.pre-commit-config.yaml` | Local hook to auto-regenerate `skills.yaml` on skill file changes |

### Phase 6 — Remaining 29 Skills: Full Eval Coverage

Scaffold evals for all remaining skills grouped by domain:
- **Developer tooling** (7): code-refiner, debug-investigator, agent-builder, mcp-to-skill, skill-evaluator, benchmark-runner, github
- **Content & media** (6): concept-to-image, concept-to-video, remotion-video, html-presentation, static-web-artifacts-builder, youtube-analysis
- **Infrastructure & ops** (6): dependency-audit, gpu-optimizer, filesystem, tavily, web-fetch, estimate-calibrator
- **Documentation & review** (6): adr-writer, api-docs-generator, changelog-composer, manuscript-provenance, manuscript-review, architecture-diagram
- **Deprecated & remaining** (4): doc-condenser (0+2), regex-builder (0+2), sequential-thinking (0+2), task-decomposer (2+2)

Deprecated skills enforce 0 positive + 2 negative cases (validator updated accordingly).

### New Skill — immune v3.0.0

Imported from [contactjccoaching-wq/immune](https://github.com/contactjccoaching-wq/immune). Hybrid adaptive memory system:
- **Cheatsheet** (positive patterns): domain strategies injected before generation
- **Immune** (negative patterns): antibodies that detect errors after generation
- Hot/Cold tiered memory, multi-domain support, auto-learning, COLD reactivation
- Includes Haiku scanner agent, config, empty memory stores, and eval cases

## Final State

- **40/40 skills** have eval coverage (100%)
- **~165 total eval cases** across all skills
- **3 skills deprecated**, 2 narrowed, 7 collision pairs resolved, 1 new skill added
- **CI pipeline** validates schema + manifest on every PR and weekly
- **Pre-commit hook** auto-regenerates manifest on skill file changes
- **65 existing tests** still passing

## Test Plan

- [x] `uv run python scripts/validate_evals.py` — 40 eval files pass
- [x] `uv run python scripts/generate_manifest.py` — manifest in sync (40 skills)
- [x] `uv run python -m pytest tests/ -v` — 65 tests pass
- [x] Deprecated skills correctly enforce 0 positive cases
- [x] `.gitignore` tracks `evals/cases.yaml` while ignoring `evals/results/`
- [ ] CI workflow runs on this PR (manifest sync + eval validation)