### PR TITLE
feat(skills): add to-markdown skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 42](https://img.shields.io/badge/skills-42-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 43](https://img.shields.io/badge/skills-43-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -30,6 +30,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | [tavily](skills/tavily/)                         | AI-optimized web search and content extraction via Tavily API with structured output parsing                                                |
 | [test-harness](skills/test-harness/)             | Comprehensive pytest suite generation — happy path, edge cases, error conditions, fixtures, mocks, async, parametrized tests                |
 | [debug-investigator](skills/debug-investigator/) | Systematic debugging framework — hypothesis-driven investigation with bisection, log analysis, instrumentation, and minimal reproduction    |
+| [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub       |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                       |
 
 ### Research & Analysis

--- a/skills.yaml
+++ b/skills.yaml
@@ -361,6 +361,16 @@ skills:
     test", "test coverage for", "write a test file". Use this skill when given a Python function, class, or module and asked
     to produce tests.'
   path: skills/test-harness
+- name: to-markdown
+  version: 1.0.0
+  description: 'Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX), Excel (XLSX), PowerPoint (PPTX), HTML,
+    images (EXIF + OCR), audio (transcription), CSV, JSON, XML, YouTube URLs, EPubs, and more. Output is optimised for LLM
+    pipelines, knowledge bases, and document ingestion workflows. Use this skill whenever the user wants to: convert a file
+    to markdown, extract text from a document, scrape a URL to markdown, turn a PDF into readable text, "get the content of
+    this file", ingest documents for RAG, prepare files for an LLM, or says "convert to md / markdown". Trigger on: "convert
+    to markdown", "extract text from PDF", "turn this into markdown", "scrape this URL", "file to md", "document ingestion",
+    "read this PDF", "get contents of", "parse this document", "ingest for RAG".'
+  path: skills/to-markdown
 - name: web-fetch
   version: 1.1.0
   description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch MCP server (fetch_html,

--- a/skills/to-markdown/SKILL.md
+++ b/skills/to-markdown/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: to-markdown
+description: >
+  Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX), Excel
+  (XLSX), PowerPoint (PPTX), HTML, images (EXIF + OCR), audio (transcription),
+  CSV, JSON, XML, YouTube URLs, EPubs, and more. Output is optimised for LLM
+  pipelines, knowledge bases, and document ingestion workflows.
+  Use this skill whenever the user wants to: convert a file to markdown,
+  extract text from a document, scrape a URL to markdown, turn a PDF into
+  readable text, "get the content of this file", ingest documents for RAG,
+  prepare files for an LLM, or says "convert to md / markdown".
+  Trigger on: "convert to markdown", "extract text from PDF", "turn this into
+  markdown", "scrape this URL", "file to md", "document ingestion", "read this
+  PDF", "get contents of", "parse this document", "ingest for RAG".
+metadata:
+  version: 1.0.0
+---
+
+# To Markdown
+
+Convert any file or URL to clean Markdown using [MarkItDown](https://github.com/microsoft/markitdown) as the conversion engine, with a lightweight fetch layer for URLs.
+
+## Reference Files
+
+| File                    | Purpose                                               |
+| ----------------------- | ----------------------------------------------------- |
+| `references/formats.md` | Per-format handling notes, internal engines, known gaps |
+| `references/fetch.md`   | URL fetch layer: trafilatura + Playwright strategies   |
+| `references/install.md` | Dependency install guide for all variants              |
+
+## Decision Tree
+
+Determine the input type before touching any tool:
+
+```text
+Input type?
+  Local file path        -> markitdown directly
+  URL
+    YouTube URL          -> markitdown directly (transcript extraction built-in)
+    Static page          -> trafilatura fetch -> markitdown on HTML result
+    JS-rendered / auth   -> Playwright fetch -> markitdown on result
+  Pasted HTML string     -> markitdown directly on string
+```
+
+Do not use `web_fetch` or `WebFetch` for URLs — route through the fetch layer described in `references/fetch.md` to preserve the conversion pipeline.
+
+## Core Conversion Workflow
+
+### Step 1: Ensure dependencies
+
+```bash
+uv pip show markitdown || uv pip install 'markitdown[all]' trafilatura
+```
+
+See `references/install.md` for selective installs and full dependency table.
+
+### Step 2: Convert
+
+```python
+from markitdown import MarkItDown
+
+md = MarkItDown(enable_plugins=False)
+result = md.convert("path/to/file.pdf")
+print(result.text_content)
+```
+
+### Step 3: Workflow
+
+1. Detect input type (file path, URL, raw HTML).
+2. If URL, run fetch layer first (see `references/fetch.md`).
+3. Run markitdown conversion on the local file or fetched content.
+4. Post-process if needed (strip boilerplate, trim to main content).
+5. Write output or return inline per output conventions below.
+
+## Output Conventions
+
+| Context                     | Output behaviour                                         |
+| --------------------------- | -------------------------------------------------------- |
+| Single file, user wants file | Write `<input_stem>.md` to same directory               |
+| Single file, inline request | Return Markdown in conversation                          |
+| Batch (multiple files)      | Write each to `<stem>.md`, summarise what was produced   |
+| URL                         | Write `<slug>.md` to current directory or return inline  |
+| Piped into another workflow | Return `result.text_content` string only                 |
+
+Default: "convert this file" -> write a file. "Read this" or "what does this say" -> return inline.
+
+### Output Example
+
+**Source** (two-column PDF with a table):
+
+```text
+Annual Report 2024                    Financial Highlights
+Revenue grew 12% year-over-year...    | Metric   | 2023  | 2024  |
+                                      | Revenue  | $4.2B | $4.7B |
+                                      | EBITDA   | $1.1B | $1.3B |
+```
+
+**Converted Markdown**:
+
+```markdown
+# Annual Report 2024
+
+Revenue grew 12% year-over-year...
+
+## Financial Highlights
+
+| Metric  | 2023  | 2024  |
+| ------- | ----- | ----- |
+| Revenue | $4.2B | $4.7B |
+| EBITDA  | $1.1B | $1.3B |
+```
+
+Multi-column layouts merge into linear flow. Tables are preserved as Markdown tables. Headings are inferred from font size/weight.
+
+## LLM Image Description (opt-in)
+
+Markitdown supports an `llm_client` for image description in PPTX and image files. **Never enable by default** — it incurs cost, latency, and unexpected API calls. Prompt the user first: "This file contains images. Do you want me to use Claude to describe them? This will make additional API calls."
+
+```python
+import anthropic
+from markitdown import MarkItDown
+
+client = anthropic.Anthropic()
+md = MarkItDown(llm_client=client, llm_model="claude-sonnet-4-20250514")
+result = md.convert("presentation.pptx")
+```
+
+## Error Handling
+
+| Severity     | Condition                                  | Action                                                                 |
+| ------------ | ------------------------------------------ | ---------------------------------------------------------------------- |
+| **Terminal** | Unsupported format (no converter exists)   | Report to user immediately; do not retry                               |
+| **Terminal** | Password-protected Office file             | Report to user; no programmatic workaround                             |
+| **Terminal** | File not found / path invalid              | Report exact path; ask user to verify                                  |
+| **Recover**  | Empty output from PDF                      | Likely scanned — escalate to OCR path in `references/formats.md`       |
+| **Recover**  | Missing optional dependency (e.g. playwright) | Install the dependency, then retry the conversion                   |
+| **Recover**  | URL fetch returns paywall page             | Report fetch limitation; do not retry or attempt bypass                 |
+| **Recover**  | trafilatura returns empty                  | Escalate to Playwright fetch strategy per `references/fetch.md`        |
+
+```python
+result = md.convert(path)
+if not result.text_content.strip():
+    raise ValueError(f"No text extracted from {path}. See references/formats.md for OCR options.")
+```
+
+Never silently return empty Markdown. Surface the failure with the severity and a pointer to the relevant reference file.
+
+## Known Gaps and Escalation
+
+- **HTML fidelity**: markitdown uses `html2text` internally — complex layouts lose structure. For high-fidelity HTML conversion where DOM structure matters, suggest Turndown via Node subprocess.
+- **Hard paywalls**: The fetch layer returns the regwall page, not the content. This is a fetch limitation, not a conversion problem.
+- **Scanned PDFs** (image-only, no text layer): markitdown returns near-empty output. Escalate to OCR workflow (Azure Document Intelligence or Tesseract). See `references/formats.md`.
+- **Protected Office files**: Password-protected DOCX/XLSX will fail. Inform the user.
+
+## Calibration Rules
+
+1. Converted output must contain at least 10 words per page of source document. Below this threshold, treat as empty extraction and escalate per the error handling table.
+2. Tables in the source must appear as Markdown tables in the output — if a table is present in the original but missing in the conversion, flag it to the user.
+3. Heading hierarchy from the source document must be preserved (H1 > H2 > H3). Flat output with no headings from a structured document indicates a conversion quality issue.
+4. For URL conversions, output must not contain navigation elements, cookie banners, or footer boilerplate. If present, re-run through trafilatura with `include_tables=True` to strip boilerplate.
+5. Multi-sheet XLSX must produce one clearly labeled section per sheet. Missing sheets indicate a partial conversion — report which sheets were extracted.
+
+## Limitations
+
+- No paywall bypass. Document it, don't attempt it.
+- No Turndown integration built-in. Different runtime (Node.js).
+- No scheduled/batch crawling. One conversion per invocation.
+- No output format other than Markdown.
+- Auto-generated YouTube captions may contain errors for technical terms.
+- Scanned PDFs require external OCR — markitdown alone returns empty output.

--- a/skills/to-markdown/evals/cases.yaml
+++ b/skills/to-markdown/evals/cases.yaml
@@ -1,0 +1,77 @@
+cases:
+  - id: convert_pdf_to_markdown
+    prompt: "Convert this PDF to markdown: /tmp/report.pdf"
+    fixtures: []
+    rubric:
+      - "uses markitdown to convert the PDF"
+      - "outputs a .md file or returns markdown content"
+    trigger_expected: true
+
+  - id: extract_text_from_docx
+    prompt: "Extract the text from my Word document at ~/docs/proposal.docx"
+    fixtures: []
+    rubric:
+      - "uses markitdown to convert the DOCX"
+      - "returns readable markdown content"
+    trigger_expected: true
+
+  - id: scrape_url_to_markdown
+    prompt: "Scrape this URL and give me the content as markdown: https://example.com/article"
+    fixtures: []
+    rubric:
+      - "uses trafilatura or fetch layer for URL content"
+      - "converts fetched content to markdown via markitdown"
+    trigger_expected: true
+
+  - id: convert_excel_spreadsheet
+    prompt: "Turn this spreadsheet into markdown tables: data.xlsx"
+    fixtures: []
+    rubric:
+      - "uses markitdown to convert XLSX"
+      - "produces markdown tables from sheet data"
+    trigger_expected: true
+
+  - id: ingest_documents_for_rag
+    prompt: "I need to ingest these PDFs for my RAG pipeline, convert them all to markdown"
+    fixtures: []
+    rubric:
+      - "uses markitdown for batch PDF conversion"
+      - "writes individual .md files for each input"
+    trigger_expected: true
+
+  - id: read_pdf_contents
+    prompt: "What does this PDF say? /tmp/notes.pdf"
+    fixtures: []
+    rubric:
+      - "uses markitdown to extract text"
+      - "returns content inline rather than writing a file"
+    trigger_expected: true
+
+  - id: convert_pptx_to_markdown
+    prompt: "Convert my presentation slides.pptx to markdown"
+    fixtures: []
+    rubric:
+      - "uses markitdown to convert PPTX"
+      - "includes slide content and speaker notes"
+    trigger_expected: true
+
+  - id: generic_summarize_article
+    prompt: "Summarize the key points of this article for me"
+    fixtures: []
+    rubric:
+      - "does not activate to-markdown (no file or URL provided, this is a summarization request)"
+    trigger_expected: false
+
+  - id: write_markdown_document
+    prompt: "Write me a markdown document about Python best practices"
+    fixtures: []
+    rubric:
+      - "does not activate to-markdown (creating markdown content, not converting a file)"
+    trigger_expected: false
+
+  - id: convert_markdown_to_pdf
+    prompt: "Convert this markdown file to PDF"
+    fixtures: []
+    rubric:
+      - "does not activate to-markdown (opposite direction: markdown to PDF, not to markdown)"
+    trigger_expected: false

--- a/skills/to-markdown/references/fetch.md
+++ b/skills/to-markdown/references/fetch.md
@@ -1,0 +1,77 @@
+# URL Fetch Layer
+
+Three strategies in escalating order of complexity. Use the simplest that works.
+
+## Strategy 1: trafilatura (default for static pages)
+
+```python
+import trafilatura
+
+def fetch_url(url: str) -> str:
+    downloaded = trafilatura.fetch_url(url)
+    if not downloaded:
+        raise ValueError(f"Could not fetch {url}")
+    text = trafilatura.extract(downloaded, include_tables=True, include_links=True)
+    if not text:
+        raise ValueError(f"No content extracted from {url}")
+    return text
+```
+
+Returns clean article text with boilerplate stripped. Pass the result to `markitdown.convert_stream()` or write to a temp `.html` file then convert.
+
+Best for: news articles, blog posts, documentation pages, any static HTML.
+
+## Strategy 2: Playwright (JS-rendered pages)
+
+Use when trafilatura returns empty or the page requires JavaScript (SPAs, dashboards, login-gated content with session access).
+
+```python
+from playwright.sync_api import sync_playwright
+
+def fetch_js_page(url: str) -> str:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url, wait_until="networkidle")
+        html = page.content()
+        browser.close()
+    return html
+```
+
+Pass the returned HTML to markitdown for conversion.
+
+Install:
+
+```bash
+uv pip install playwright && playwright install chromium
+```
+
+## Strategy 3: Authenticated session (user-managed)
+
+Not automated by this skill. The pattern: user provides cookies or session storage, inject into Playwright browser context.
+
+```python
+context = browser.new_context(storage_state="auth.json")
+```
+
+Out of scope for general use. Point to [Playwright authentication docs](https://playwright.dev/python/docs/auth) if the user needs this.
+
+## Selection Logic
+
+```text
+URL received
+  Is YouTube URL?           -> skip fetch, markitdown handles directly
+  Try trafilatura fetch
+    Content extracted?      -> use it
+    Empty/failed?           -> try Playwright
+      Playwright succeeds?  -> use it
+      Still empty?          -> report failure to user
+```
+
+## Paywall Handling
+
+**This skill does not bypass paywalls.** Both trafilatura and Playwright return the regwall/paywall page for paywalled content. This is a fetch-layer limitation — no conversion tool solves it.
+
+When the fetched content looks like a paywall page (short content, login prompts, subscription CTAs), report this clearly to the user:
+- "The page returned a paywall. The conversion contains the paywall page, not the article."
+- Do not retry or attempt workarounds.

--- a/skills/to-markdown/references/formats.md
+++ b/skills/to-markdown/references/formats.md
@@ -1,0 +1,84 @@
+# Format-Specific Handling
+
+Per-format conversion details, internal engines, known issues, and workarounds.
+
+## Format Table
+
+| Format          | Engine (internal)       | Known Issues                                      | Workaround                                      |
+| --------------- | ----------------------- | ------------------------------------------------- | ----------------------------------------------- |
+| PDF (text)      | pdfminer                | Multi-column layouts merge columns                | Acceptable for LLM use                          |
+| PDF (scanned)   | pdfminer                | Returns empty — no text layer                     | OCR: Azure DocIntel or Tesseract (see below)    |
+| DOCX            | python-docx             | Embedded images lost                              | Use LLM client for image descriptions           |
+| PPTX            | python-pptx             | Speaker notes included (useful for LLMs)          | Filter with `---NOTES---` marker if needed      |
+| XLSX / XLS      | openpyxl / xlrd         | Each sheet becomes a Markdown table               | Works well                                      |
+| HTML            | html2text               | Complex layouts lose structure                    | Use Turndown for fidelity-critical cases        |
+| Images          | EXIF + optional OCR     | No OCR without Azure DocIntel                     | Pass `docintel_endpoint` for OCR                |
+| Audio           | speech transcription    | Requires `[audio-transcription]` extra            | `uv pip install 'markitdown[audio-transcription]'` |
+| YouTube         | transcript API          | Only works if captions available                  | Returns empty if no captions                    |
+| CSV / JSON / XML | built-in               | Converts to Markdown tables/structure             | Clean, reliable                                 |
+| EPub            | built-in                | Large EPubs may be slow                           | Works for most cases                            |
+
+## Scanned PDF — OCR Escalation Path
+
+When markitdown returns empty or near-empty output from a PDF, the file is likely scanned (image-only, no text layer).
+
+### Option 1: Azure Document Intelligence
+
+```python
+from markitdown import MarkItDown
+
+md = MarkItDown(docintel_endpoint="https://<resource>.cognitiveservices.azure.com/")
+result = md.convert("scanned.pdf")
+```
+
+Requires an Azure AI Document Intelligence resource. Set the endpoint and key via environment variables or pass directly.
+
+### Option 2: Tesseract (local OCR)
+
+```bash
+# Install Tesseract
+brew install tesseract  # macOS
+# apt install tesseract-ocr  # Linux
+
+# Extract images from PDF, then OCR
+uv pip install pdf2image pytesseract
+```
+
+```python
+from pdf2image import convert_from_path
+import pytesseract
+
+images = convert_from_path("scanned.pdf")
+text = "\n\n".join(pytesseract.image_to_string(img) for img in images)
+```
+
+This is a fallback outside markitdown's pipeline. Use when Azure DocIntel is unavailable.
+
+## PPTX Speaker Notes
+
+Markitdown includes speaker notes by default, separated by `---NOTES---` markers. For LLM ingestion this is typically desirable. To strip notes:
+
+```python
+import re
+
+cleaned = re.sub(r"---NOTES---.*?(?=^#|\Z)", "", result.text_content, flags=re.DOTALL | re.MULTILINE)
+```
+
+## DOCX with Embedded Images
+
+Images in DOCX files are not extracted by default. To get image descriptions, enable the LLM client (see SKILL.md "LLM Image Description" section). Without it, images are silently skipped.
+
+## HTML Fidelity
+
+markitdown uses `html2text` which handles standard article content well but loses structure on:
+- Nested tables (common in email templates)
+- CSS-dependent layouts (grid, flexbox)
+- Interactive elements (forms, JS-rendered content)
+
+For high-fidelity HTML-to-Markdown conversion where DOM structure matters, use Turndown via Node subprocess:
+
+```bash
+npx turndown-cli input.html -o output.md
+```
+
+This is out of scope for this skill — mention it as an alternative when html2text output is insufficient.

--- a/skills/to-markdown/references/install.md
+++ b/skills/to-markdown/references/install.md
@@ -1,0 +1,42 @@
+# Dependency Installation
+
+## Prerequisites
+
+- Python 3.10+. Verify: `python --version`
+- `uv` package manager.
+
+## Check Before Installing
+
+```bash
+uv pip show markitdown
+```
+
+Avoid redundant installs.
+
+## Install Table
+
+| Use case                    | Install command                                                        |
+| --------------------------- | ---------------------------------------------------------------------- |
+| Everything (recommended)    | `uv pip install 'markitdown[all]'`                                     |
+| PDF only                    | `uv pip install 'markitdown[pdf]'`                                     |
+| Office docs                 | `uv pip install 'markitdown[docx,pptx,xlsx]'`                          |
+| Audio transcription         | `uv pip install 'markitdown[audio-transcription]'`                     |
+| Azure Document Intelligence | `uv pip install 'markitdown[az-doc-intel]'`                            |
+| URL fetching (static)       | `uv pip install trafilatura`                                           |
+| URL fetching (JS-rendered)  | `uv pip install playwright && playwright install chromium`             |
+| LLM image description       | `uv pip install anthropic`                                             |
+
+## Recommended First Install
+
+```bash
+uv pip install 'markitdown[all]' trafilatura
+```
+
+This covers all file formats and static URL fetching. Add Playwright only if JS-rendered pages are needed.
+
+## Verification
+
+```bash
+python -c "from markitdown import MarkItDown; print('markitdown OK')"
+python -c "import trafilatura; print('trafilatura OK')"
+```


### PR DESCRIPTION
## Summary

New skill that converts any file or URL to clean Markdown using [MarkItDown](https://github.com/microsoft/markitdown) as the conversion engine, with a trafilatura + Playwright fetch layer for URLs.

### Supported formats

PDF, DOCX, XLSX, PPTX, HTML, images (EXIF + OCR), audio (transcription), CSV, JSON, XML, YouTube URLs, EPubs.

### Skill structure

| File | Purpose |
|------|---------|
| `skills/to-markdown/SKILL.md` (170 lines) | Decision tree, conversion workflow, output conventions, error severity table, calibration rules, output example |
| `skills/to-markdown/references/formats.md` | Per-format engines, known issues, OCR escalation path (Azure DocIntel / Tesseract) |
| `skills/to-markdown/references/fetch.md` | Three-strategy URL fetch layer: trafilatura (static) -> Playwright (JS-rendered) -> authenticated session (user-managed) |
| `skills/to-markdown/references/install.md` | Dependency install table with `uv` commands for selective and full installs |
| `skills/to-markdown/evals/cases.yaml` | 7 positive + 3 negative trigger evaluation cases |

### Key design decisions

- **Decision tree routing**: Local files go directly to markitdown; URLs route through a fetch layer first; YouTube URLs bypass fetch (markitdown handles transcripts natively). Prevents the common failure of using `WebFetch` for URLs.
- **Error severity classification**: Terminal errors (unsupported format, password-protected files) vs recoverable errors (missing optional dependency, empty PDF output). Gives Claude a triage framework instead of one-size-fits-all error handling.
- **LLM image description is opt-in only**: Never enabled by default due to cost/latency. User must explicitly consent before additional API calls are made.
- **Calibration rules**: 5 quantitative quality gates — minimum words per page, table preservation, heading hierarchy, boilerplate detection, multi-sheet completeness.
- **Output conventions**: File vs inline output determined by user intent ("convert this" -> file, "read this" -> inline).

### Project-level updates

- `skills.yaml`: Regenerated manifest (42 -> 43 skills)
- `README.md`: Added to-markdown to Development & Tooling catalog, bumped skill count badge to 43

### Skill evaluator score

Evaluated against the 6-dimension rubric:

| Dimension | Score |
|-----------|-------|
| D1: Frontmatter Quality | 5/5 |
| D2: Trigger Coverage | 5/5 |
| D3: Structural Completeness | 5/5 |
| D4: Content Depth | 5/5 |
| D5: Consistency & Integrity | 5/5 |
| D6: CONTRIBUTING Compliance | 5/5 |

**Overall: 100% — Exemplary** (after addressing all findings from initial 91.6% evaluation)

## Test plan

- [x] `python scripts/validate_evals.py` — 43 eval files validated
- [x] `python scripts/generate_manifest.py` — manifest in sync (43 skills)
- [x] `python -m pytest tests/ -q` — 65 tests pass
- [ ] Install skill via `claude --add-dir skills/to-markdown` and test trigger activation
- [ ] Convert a local PDF and verify output quality against calibration rules
- [ ] Convert a static URL via trafilatura path and verify boilerplate stripping