### PR TITLE
feat(concept-to-image): add design philosophy and visual pattern library

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -72,7 +72,7 @@ skills:
     code smells.'
   path: skills/code-refiner
 - name: concept-to-image
-  version: 1.1.0
+  version: 1.2.0
   description: 'Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG
     image file. Use this skill when the user explicitly needs an image file output (PNG or SVG). This includes: concept diagrams,
     flowcharts, comparison charts, process visuals, educational diagrams, social media graphics, data visualizations, posters,

--- a/skills/concept-to-image/SKILL.md
+++ b/skills/concept-to-image/SKILL.md
@@ -10,7 +10,7 @@ description: >
   "concept to image", "turn this into an image", "screenshot this HTML", "design a graphic for export".
   For interactive HTML visuals opened in a browser, use static-web-artifacts-builder instead.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Concept to Image

--- a/skills/concept-to-image/references/design-guide.md
+++ b/skills/concept-to-image/references/design-guide.md
@@ -2,6 +2,30 @@
 
 Patterns and principles for creating high-quality visuals that don't look AI-generated.
 
+## Core philosophy
+
+### Argue, don't display
+
+A visual should make an argument — showing relationships, causality, and flow that text alone can't express. A diagram that just labels boxes is formatted text, not a visual.
+
+**The isomorphism test**: If you removed all text, would the structure alone communicate the concept? If not, the visual design isn't carrying its weight. Redesign until the shapes mirror the meaning.
+
+### Multi-zoom architecture
+
+Comprehensive visuals operate at three levels simultaneously:
+
+1. **Summary flow** — Simplified overview showing the full pipeline at a glance (top or bottom of canvas)
+2. **Section boundaries** — Labeled regions that group related components into visual "rooms"
+3. **Detail inside sections** — Concrete examples, data formats, code snippets — where the educational value lives
+
+Simple concept cards need only level 1. Technical architecture diagrams need all three.
+
+### Container discipline
+
+Default to no container. Add shapes/boxes only when they carry meaning — grouping, connection endpoints, or semantic shape (decision diamond, etc.). Typography (font size, weight, color) creates hierarchy without boxes.
+
+**The container test**: For each boxed element, ask "Would this work as free-floating text with proper styling?" If yes, remove the box.
+
 ## Layout principles
 
 ### Asymmetry over symmetry
@@ -77,7 +101,21 @@ Keep icons simple — 24×24 or 32×32 viewBox. Single-color, using `currentColo
 
 Linear gradients for backgrounds. Radial gradients for spotlight effects. Use SVG `<pattern>` for subtle textures (dots, lines, crosshatch) that add depth without noise.
 
-## Layout patterns by visual type
+## Visual pattern library
+
+Match the concept's behavior to the right visual structure. Each major concept in a multi-concept visual should use a **different** pattern — no uniform grids.
+
+| If the concept...            | Pattern                  | HTML/SVG approach                                      |
+| ---------------------------- | ------------------------ | ------------------------------------------------------ |
+| Spawns multiple outputs      | **Fan-out** (radial)     | Central element + SVG arrows radiating to targets      |
+| Combines inputs into one     | **Convergence** (funnel) | Multiple sources + SVG arrows merging to single target |
+| Has hierarchy/nesting        | **Tree**                 | Nested containers or SVG lines + positioned labels     |
+| Is a sequence of steps       | **Timeline**             | SVG line + dots + labels along the axis                |
+| Loops or improves            | **Spiral / Cycle**       | SVG arrows forming a closed loop                       |
+| Transforms input to output   | **Assembly line**        | Before → process → after with clear visual contrast    |
+| Compares two things          | **Side-by-side**         | CSS Grid parallel columns with visual differentiation  |
+| Separates into phases        | **Gap / Break**          | Whitespace or dashed SVG line between sections         |
+| Is an abstract state/context | **Cloud**                | Overlapping SVG ellipses with varied sizes             |
 
 ### Flowchart / Pipeline
 
@@ -114,6 +152,19 @@ Linear gradients for backgrounds. Radial gradients for spotlight effects. Use SV
 - All positioning via SVG `transform`, `x`, `y` attributes
 - Groups (`<g>`) for logical sections
 - Best for: icons, badges, logos, technical diagrams
+
+### Evidence artifacts (for technical diagrams)
+
+When diagramming real systems, include concrete proof — not just labeled boxes:
+
+| Artifact type      | When to use                         | Rendering approach                           |
+| ------------------ | ----------------------------------- | -------------------------------------------- |
+| Code snippets      | APIs, integrations, implementations | Dark `<pre>` block with syntax-colored spans |
+| Data/JSON examples | Schemas, payloads, formats          | Monospace text in a styled container         |
+| UI mockups         | Showing actual output               | Nested HTML elements mimicking real UI       |
+| Real input content | Showing what goes IN to a system    | Container with sample content visible        |
+
+These raise a diagram from "labeled architecture" to "educational artifact."
 
 ## Anti-patterns (the "AI slop" checklist)
 

--- a/skills/concept-to-image/references/design-guide.md
+++ b/skills/concept-to-image/references/design-guide.md
@@ -179,6 +179,9 @@ Avoid all of these:
 7. **Over-decoration** — Borders, shadows, gradients AND rounded corners on one element
 8. **Low density** — Fill the canvas. 70%+ content-to-whitespace ratio
 9. **Orphaned labels** — Every text element should be visually connected to what it describes
+10. **Displaying instead of arguing** — Boxes with labels connected by arrows. If the structure doesn't mirror the concept's behavior, it's just formatted text
+11. **Uniform visual patterns** — Every concept rendered the same way (all rectangles, all cards). Vary patterns per concept
+12. **Abstract when concrete is available** — Labeling a box "API Response" instead of showing the actual JSON shape. Use evidence artifacts for technical diagrams
 
 ## Pre-export checklist
 
@@ -190,3 +193,6 @@ Before running `render_to_image.py`:
 - [ ] Colors have sufficient contrast
 - [ ] Layout doesn't overflow `.canvas` bounds
 - [ ] If SVG export desired: content is inside a root `<svg>` within `.canvas`
+- [ ] Isomorphism test: structure communicates without reading text
+- [ ] Each major concept uses a distinct visual pattern (no uniform grid)
+- [ ] Technical diagrams include at least one evidence artifact


### PR DESCRIPTION
## Summary

Enhances the concept-to-image skill's design guide with a design philosophy layer ported from the [excalidraw-diagram-skill](https://github.com/coleam00/excalidraw-diagram-skill) approach. The philosophy is adapted to work with the existing HTML/CSS/SVG rendering pipeline — no changes to the rendering engine, dependencies, or SKILL.md workflow.

### Motivation

The current design guide is purely tactical (asymmetry, color ratios, font scales). It tells the agent *how to style* but not *what to express*. This produces serviceable output for cards and infographics, but architectural/flow diagrams default to uniform boxes-and-arrows layouts.

Analysis of the excalidraw-diagram-skill ([full analysis context](https://github.com/coleam00/excalidraw-diagram-skill)) confirmed that:
- Its **design philosophy** (argue-not-display, isomorphism test, container discipline) is excellent and format-agnostic
- Its **rendering approach** (manual Excalidraw JSON coordinate layout) is inferior to CSS layout for LLM output
- Porting the philosophy into the existing HTML/CSS/SVG pipeline captures the value without the drawbacks

### What changed

**Commit 1 — Core content enhancement** (`design-guide.md`)
- **Core philosophy section** with three principles:
  - *Argue, don't display* — visuals should show relationships text can't, not just label boxes
  - *Multi-zoom architecture* — three simultaneous detail levels (summary → sections → detail)
  - *Container discipline* — default to no container; typography creates hierarchy without boxes
- **Visual pattern library** — replaces the flat "Layout patterns by visual type" heading with a concept-to-pattern mapping table (9 patterns: fan-out, convergence, tree, timeline, spiral/cycle, assembly line, side-by-side, gap/break, cloud)
- **Evidence artifacts subsection** — guidance for embedding concrete proof (code snippets, JSON examples, UI mockups) in technical diagrams via `<pre>` blocks and styled containers

**Commit 2 — Quality gates** (`design-guide.md`)
- 3 new anti-patterns: displaying-instead-of-arguing, uniform visual patterns, abstract-when-concrete
- 3 new pre-export checklist items: isomorphism test, pattern variety check, evidence artifact requirement

**Commit 3 — Housekeeping**
- Version bump 1.1.0 → 1.2.0 in `SKILL.md`
- Regenerated `skills.yaml` manifest

### What did NOT change

- No changes to `SKILL.md` workflow, triggers, or description (beyond version)
- No changes to `render_to_image.py` or `assets/template.html`
- No new dependencies
- No changes to README (catalog description remains accurate)

## Expected impact

| Area | Before | After |
|------|--------|-------|
| Diagram quality | Uniform boxes-and-arrows | Pattern-matched to concept behavior |
| Design process | Jump straight to CSS | Concept → pattern mapping → then CSS |
| Technical diagrams | Labeled boxes | Evidence artifacts with real data shapes |
| Container usage | Over-boxed text | Typography-first, containers only when meaningful |
| Complex visuals | Flat detail level | Multi-zoom: summary + sections + detail |

## Test plan

- [x] `uv run pytest tests/` — 65 passed, 0 failures
- [x] `uv run scripts/generate_manifest.py` — regenerated with version 1.2.0
- [ ] Manual validation: generate a concept-to-image diagram with the updated skill and verify pattern variety in output