### PR TITLE
feat: add humanize skill with cross-skill integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 43](https://img.shields.io/badge/skills-43-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 44](https://img.shields.io/badge/skills-44-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -96,6 +96,7 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 
 | Skill                                              | Description                                                                                                                                                         |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [humanize](skills/humanize/)                       | Detect and remove AI-generated writing patterns — 24 lexical patterns + 12 statistical signals, 6 domain profiles, 5-phase pipeline with semantic preservation |
 | [linkedin-post-style](skills/linkedin-post-style/) | Write LinkedIn posts in a specific technical voice with visual companion support — carousels via md-to-pdf, images via concept-to-image, video via concept-to-video |
 
 ### Deprecated

--- a/skills.yaml
+++ b/skills.yaml
@@ -165,6 +165,15 @@ skills:
     minimal, corporate, hacker terminal). Consider asking the user for clarification on theme, navigation direction, and content
     structure if not already specified.
   path: skills/html-presentation
+- name: humanize
+  version: 1.0.0
+  description: Detect and remove AI-generated writing patterns from text while preserving semantic meaning and factual accuracy.
+    Rewrites text to sound natural, varied, and human-authored across domains including academic, technical, blog, professional,
+    and social media writing. Use this skill when the user asks to "humanize text", "make this sound human", "remove AI patterns",
+    "rewrite to sound natural", "make this less AI", "de-slop this", "clean up AI writing", "make this not sound like ChatGPT",
+    or provides AI-generated text and asks for a natural rewrite. Also trigger when reviewing drafts for AI tells, checking
+    if text sounds AI-generated, or requesting a "human pass" on content.
+  path: skills/humanize
 - name: immune
   version: 1.0.0
   description: 'Hybrid adaptive memory system with two complementary memories: Cheatsheet (positive patterns injected before

--- a/skills.yaml
+++ b/skills.yaml
@@ -184,7 +184,7 @@ skills:
     code review or PR review — use pr-review instead. NOT for security audits of repositories — use repo-sentinel instead.'
   path: skills/immune
 - name: linkedin-post-style
-  version: 1.1.0
+  version: 1.2.0
   description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and precise.
     Use this skill whenever the user asks to write, draft, rewrite, review, improve, or refine a LinkedIn post, social media
     post, tech commentary, or any public-facing short-form writing about technology, AI, software engineering, or developer
@@ -203,7 +203,7 @@ skills:
     against scripts", "provenance audit", or any request to verify that manuscript content traces back to computational outputs.'
   path: skills/manuscript-provenance
 - name: manuscript-review
-  version: 1.1.0
+  version: 1.2.0
   description: Systematic pre-publication manuscript audit producing a structured refactoring report with section-level diagnostics,
     citation hygiene analysis, and submission-readiness assessment. Use this skill whenever the user uploads a manuscript,
     paper, thesis chapter, journal submission, or conference paper and asks for review, feedback, editing, refactoring, pre-submission

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: humanize
+description: >
+  Detect and remove AI-generated writing patterns from text while preserving semantic meaning
+  and factual accuracy. Rewrites text to sound natural, varied, and human-authored across domains
+  including academic, technical, blog, professional, and social media writing. Use this skill when
+  the user asks to "humanize text", "make this sound human", "remove AI patterns", "rewrite to
+  sound natural", "make this less AI", "de-slop this", "clean up AI writing", "make this not
+  sound like ChatGPT", or provides AI-generated text and asks for a natural rewrite. Also trigger
+  when reviewing drafts for AI tells, checking if text sounds AI-generated, or requesting a
+  "human pass" on content.
+metadata:
+  version: 1.0.0
+---
+
+# Humanize: AI Pattern Detection and Removal
+
+Remove AI-generated writing patterns from text. Produce natural, human-sounding output that preserves meaning.
+
+This is not a generic rewriter. It targets specific, documented AI-writing patterns catalogued by Wikipedia's WikiProject AI Cleanup from thousands of observed instances.
+
+## Workflow
+
+Five phases. Each phase has a clear input, transformation, and output. Do not skip phases.
+
+### Phase 1: Detection Scan
+
+Read the input text. Load `references/detection-patterns.md`. Scan for two categories of signals:
+
+**A. Lexical patterns** (the 24 catalogued AI-writing patterns):
+
+| Category | Patterns | Priority |
+|----------|----------|----------|
+| Content inflation | Significance puffing, notability claims, superficial -ing analyses, promotional language, vague attributions, formulaic challenges sections | HIGH — loudest AI tells |
+| Vocabulary | AI-frequency words, copula avoidance, filler phrases, excessive hedging | HIGH — statistically detectable |
+| Structure | Rule of three, negative parallelisms, elegant variation, false ranges, inline-header lists | MEDIUM — structural fingerprints |
+| Style | Em dash overuse, boldface overuse, title case headings, emoji decoration, curly quotes | MEDIUM — formatting tells |
+| Communication | Chatbot artifacts, knowledge-cutoff disclaimers, sycophantic tone, generic conclusions | LOW — obvious, usually caught by author |
+
+**B. Statistical regularity signals** (see `references/statistical-signals.md`):
+
+| Signal | What to look for |
+|--------|-----------------|
+| Sentence length uniformity | Sentences clustering within a narrow word-count range |
+| Low clause density variation | Every sentence has the same number of clauses |
+| Flat information density | Every sentence carries roughly the same amount of detail |
+| High-frequency phrase templates | Stock collocations and common bigrams/trigrams dominating the text |
+| Excessive transition markers | Formal connectives appearing more than 8 per 1,000 words |
+| Structural symmetry | Paragraphs and sentences following balanced, mirror-like patterns |
+| Uniform inter-sentence cohesion | Every sentence tightly follows the previous with no topic shifts or digressions |
+| Generic function word usage | Connectors and prepositions used in textbook-standard distribution with no personal tendencies |
+
+Output a detection report using the detection report template (see Output Format).
+
+**Instance severity rating:**
+
+| Severity | Criteria |
+|----------|----------|
+| HIGH | 3+ patterns co-occurring in a single paragraph, or any paragraph saturated with AI vocabulary (5+ signal words) |
+| MEDIUM | 1-2 patterns in a paragraph, or a statistical signal present across 3+ consecutive sentences |
+| LOW | Isolated single instance of any pattern, or a borderline statistical signal |
+
+### Phase 2: Structural Rewrite
+
+Transform document structure to break AI-typical organization:
+
+- Convert uniform paragraph lengths to varied blocks
+- Merge or split sentences to break rhythmic uniformity
+- Reorder clauses where meaning permits
+- Convert formulaic list structures to narrative where appropriate
+- Remove tripartite constructions unless the content genuinely has three parts
+
+Do not change factual content. Do not add information. Do not remove cited sources, data, or technical terms.
+
+### Phase 3: Vocabulary and Style Pass
+
+Apply pattern-specific rewrites from the detection report:
+
+- Replace AI-frequency vocabulary with natural alternatives
+- Restore simple copulas (is/are/has) where the text uses elaborate substitutes
+- Remove filler phrases and excessive hedging
+- Cut promotional language and significance inflation
+- Replace vague attributions with specific ones (or remove if no source exists)
+
+Load the appropriate style profile from `references/style-guide.md` based on the target domain. Apply domain-specific voice calibration.
+
+### Phase 4: Entropy and Variation
+
+Human writing has burstiness — irregular rhythm, varied sentence lengths, uneven information density. AI text is statistically smooth. This phase breaks that smoothness.
+
+Load `references/statistical-signals.md` for target ranges. Apply:
+
+- **Sentence length variance**: mix short declarative with longer explanatory. Target visible variance across any 5-sentence window.
+- **Clause density variation**: alternate simple sentences (one clause) with compound/complex (2-3 clauses). Do not settle on a uniform clause count.
+- **Information density variation**: let some sentences carry heavy detail while others are light — a summary statement, a reaction, a pivot. Uniform density reads as generated.
+- **Phrase template breaking**: replace stock collocations with specific phrasings. "Play a role in" -> name the specific action. "In terms of" -> delete or restructure.
+- **Inter-sentence cohesion variation**: not every sentence should tightly follow the previous. Allow small topic expansions, brief asides, or contextual jumps that a thinking human would make.
+- **Function word personalization**: vary connector usage. Use "but" in one place, "still" in another, nothing in a third. Do not default to the same conjunction pattern throughout.
+- **Paragraph length variance**: mix single-sentence paragraphs with 4-5 sentence blocks.
+- **Controlled imperfection**: fragments at impact positions, parenthetical asides, concessive turns. Sparingly — seasoning, not structure.
+
+### Phase 5: Validation and Output
+
+Two checks before delivering:
+
+**Semantic check:** Compare rewrite against original. Every factual claim, data point, argument, and technical term in the original must be present in the rewrite. If anything was lost, restore it.
+
+**Self-audit:** Ask internally: "What still sounds AI-generated about this text?" If residual patterns remain, fix them. One pass only — do not loop indefinitely.
+
+Output the final text followed by a brief changes summary.
+
+## Output Format
+
+### Full Rewrite / Targeted Fix / Style Shift
+
+```
+[Humanized text]
+
+---
+Changes: [2-4 bullet summary of what was changed and why]
+Patterns detected: [list of pattern numbers/names found]
+Domain: [detected or specified domain]
+```
+
+For short texts (under 100 words), skip the changes summary unless the user requests it.
+
+### Detection Only
+
+```
+## Detection Report
+
+**Domain:** [detected or specified]
+**Overall severity:** [HIGH / MEDIUM / LOW]
+**Patterns found:** [count]
+
+### Findings
+
+| Location | Pattern | Severity | Evidence |
+|----------|---------|----------|----------|
+| Para 1 | #7 AI vocabulary | HIGH | "delve", "intricate", "pivotal" in same sentence |
+| Para 2 | #8 Copula avoidance | MEDIUM | "serves as" instead of "is" |
+| Para 1-4 | Sentence length uniformity | MEDIUM | All sentences 18-22 words, SD < 3 |
+| ... | ... | ... | ... |
+
+### Statistical Signals
+
+| Signal | Status | Detail |
+|--------|--------|--------|
+| Sentence length variance | FLAG | SD ~3 words (human typical: 7-15) |
+| Transition frequency | OK | 5 per 1,000 words |
+| ... | ... | ... |
+
+### Summary
+[1-2 sentences: overall assessment and highest-priority patterns to fix first]
+```
+
+## Reference Files
+
+| File | Purpose | Load When |
+|------|---------|-----------|
+| `references/detection-patterns.md` | 24 AI-writing patterns with examples | Always (Phase 1) |
+| `references/statistical-signals.md` | 12 statistical regularity signals with target ranges | Phase 1 (scan) and Phase 4 (targets) |
+| `references/style-guide.md` | Domain-specific voice profiles and calibration rules | Phase 3 (match to domain) |
+| `references/transformation-rules.md` | Structural rewrite strategies and entropy techniques | Phase 2 and Phase 4 |
+| `examples/academic.md` | Before/after pairs for academic writing | When domain is academic |
+| `examples/blog.md` | Before/after pairs for blog/casual writing | When domain is blog or social |
+| `examples/professional.md` | Before/after pairs for professional/business writing | When domain is professional |
+
+## Domain Detection
+
+If the user does not specify a domain, infer from:
+
+1. Vocabulary density and jargon type
+2. Citation patterns
+3. Sentence complexity
+4. Register (formal/informal markers)
+
+Default to **professional** if ambiguous.
+
+Supported domains: `academic`, `technical`, `blog`, `social`, `professional`, `marketing`
+
+## Behavioral Constraints
+
+1. **Never fabricate.** Do not add facts, citations, quotes, statistics, or claims not in the original.
+2. **Never remove data.** Numbers, dates, names, URLs, and cited sources must survive the rewrite.
+3. **Preserve argument structure.** If the original makes points A, B, C in that order with that logic, the rewrite must preserve the logical flow.
+4. **Do not over-humanize.** Some text is meant to be neutral and informational. A technical specification does not need personality. Match the appropriate register.
+5. **Respect code blocks and structured data.** Do not humanize code, tables, JSON, YAML, or any structured/machine-readable content. Pass these through unchanged.
+6. **One pass through the pipeline.** Do not run the 5-phase pipeline recursively. If the output still has tells after Phase 5, note them in the changes summary rather than looping.
+
+## Scope Modes
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **Full rewrite** | "humanize this", "rewrite naturally" | Run all 5 phases |
+| **Detection only** | "check for AI patterns", "does this sound AI" | Run Phase 1 only, output detection report |
+| **Targeted fix** | "fix the AI-sounding parts", "just clean up the obvious stuff" | Run Phase 1, then apply fixes only to HIGH-priority patterns |
+| **Style shift** | "make this more casual/academic/professional" | Run Phases 3-4 with specified domain profile |
+
+## Error Handling
+
+| Problem | Cause | Resolution |
+|---------|-------|------------|
+| Input under 20 words | Insufficient signal for pattern detection | Report: "Text too short for reliable pattern detection." Apply vocabulary fixes only (Phase 3) if obvious patterns are present. Skip statistical signal analysis. |
+| Input is entirely code/structured data | No prose to humanize | Report: "Input is structured data — no humanization applicable." Return input unchanged. |
+| Mixed human + AI text | Partial AI generation or human-edited AI output | Run Phase 1 on full text. Flag only paragraphs/sections with detected patterns. Apply Phases 2-4 selectively to flagged sections. Leave clean sections untouched. |
+| Domain ambiguous after detection | Input mixes registers (e.g., academic citations in a blog post) | Default to **professional**. Note the ambiguity in the output: "Domain defaulted to professional — specify if another profile is preferred." |
+| Semantic drift detected in Phase 5 | Rewrite altered meaning during structural/vocabulary changes | Restore the drifted factual claim from the original. Do not re-run the full pipeline. Note the restoration in the changes summary. |
+| Input contains fabricated citations | Original text has hallucinated sources | Not detectable — this skill humanizes style, not factual accuracy. Pass through unchanged. Note in limitations if the user asks about accuracy. |
+| All patterns are LOW severity | Text is mostly human-written with minor tells | In targeted fix mode, report findings but recommend no changes. In full rewrite mode, apply light-touch fixes only — do not over-edit clean text. |
+
+## Integration Point
+
+Other writing skills can import `references/detection-patterns.md` as a pattern library for their own anti-pattern sweeps. The detection patterns are the shared asset; the pipeline is this skill's domain.
+
+## Limitations
+
+- Cannot verify factual accuracy of the original text. Garbage in, humanized garbage out.
+- Effectiveness depends on input length. Very short texts (under 20 words) have insufficient signal for pattern detection.
+- Style profiles are guidelines, not voice cloning. The output will sound natural but will not match a specific author's voice without additional calibration.
+- Does not interact with external AI-detection APIs. Assessment is heuristic, not benchmark-verified.

--- a/skills/humanize/evals/cases.yaml
+++ b/skills/humanize/evals/cases.yaml
@@ -1,0 +1,91 @@
+cases:
+  # Positive cases (trigger_expected: true)
+  - id: humanize_ai_text
+    prompt: "Humanize this text: 'In today's rapidly evolving landscape, AI has emerged as a transformative force, fostering innovation and enhancing productivity across industries.'"
+    fixtures: []
+    rubric:
+      - "detects AI-writing patterns including significance inflation and AI-frequency vocabulary"
+      - "rewrites to remove detected patterns"
+      - "preserves the core meaning about AI affecting multiple industries"
+      - "output sounds natural and human-written"
+    trigger_expected: true
+
+  - id: make_sound_human
+    prompt: "Make this sound more human and natural: 'Additionally, it is important to note that the implementation showcases our commitment to leveraging cutting-edge solutions for enhanced operational efficiency.'"
+    fixtures: []
+    rubric:
+      - "removes filler phrases like 'it is important to note'"
+      - "removes AI vocabulary like 'showcases', 'leveraging', 'enhanced'"
+      - "replaces promotional language with specific claims"
+      - "result is shorter and more direct"
+    trigger_expected: true
+
+  - id: detect_ai_patterns_only
+    prompt: "Check this paragraph for AI writing patterns, don't rewrite it yet: 'The event serves as a vibrant testament to the community's enduring commitment to fostering cultural exchange and enhancing social cohesion.'"
+    fixtures: []
+    rubric:
+      - "identifies specific patterns by name or number"
+      - "does not rewrite the text unless asked"
+      - "reports copula avoidance, significance inflation, AI vocabulary, and promotional language"
+    trigger_expected: true
+
+  - id: rewrite_academic_naturally
+    prompt: "This abstract sounds too AI-generated. Rewrite it for an academic audience: 'This groundbreaking study delves into the intricate interplay between climate change and agricultural yields, underscoring the pivotal role of adaptive strategies in ensuring food security.'"
+    fixtures: []
+    rubric:
+      - "applies academic style profile"
+      - "removes promotional language like 'groundbreaking'"
+      - "removes AI vocabulary like 'delves', 'intricate', 'interplay', 'pivotal', 'underscoring'"
+      - "preserves the academic register and topic"
+    trigger_expected: true
+
+  - id: deslop_blog_post
+    prompt: "De-slop this blog intro, it reads like ChatGPT wrote it: 'Welcome to this comprehensive guide! In this article, we'll explore the fascinating world of container orchestration. Whether you're a seasoned DevOps engineer or just starting your journey, this guide will equip you with valuable insights. Let's dive in!'"
+    fixtures: []
+    rubric:
+      - "removes chatbot artifacts like 'Welcome to', 'Let's dive in!'"
+      - "removes false range 'seasoned engineer or just starting'"
+      - "removes AI vocabulary like 'comprehensive', 'fascinating', 'valuable insights'"
+      - "produces a direct, blog-appropriate introduction"
+    trigger_expected: true
+
+  # Negative cases (trigger_expected: false)
+  - id: translate_text
+    prompt: "Translate this paragraph from English to Spanish."
+    fixtures: []
+    rubric:
+      - "does not activate humanization workflow"
+      - "translation is a different task from humanization"
+    trigger_expected: false
+
+  - id: write_from_scratch
+    prompt: "Write me a blog post about Kubernetes best practices."
+    fixtures: []
+    rubric:
+      - "does not activate humanization workflow"
+      - "content generation from scratch is not humanization"
+    trigger_expected: false
+
+  - id: grammar_check
+    prompt: "Check this text for grammar and spelling errors."
+    fixtures: []
+    rubric:
+      - "does not activate humanization workflow"
+      - "grammar checking is different from AI pattern detection"
+    trigger_expected: false
+
+  - id: code_review
+    prompt: "Review this Python function for bugs and suggest improvements."
+    fixtures: []
+    rubric:
+      - "does not activate humanization workflow"
+      - "code review is unrelated to text humanization"
+    trigger_expected: false
+
+  - id: summarize_document
+    prompt: "Summarize this 10-page report into 3 bullet points."
+    fixtures: []
+    rubric:
+      - "does not activate humanization workflow"
+      - "summarization is a different text transformation"
+    trigger_expected: false

--- a/skills/humanize/examples/academic.md
+++ b/skills/humanize/examples/academic.md
@@ -1,0 +1,35 @@
+# Academic Writing — Before/After Examples
+
+## Example 1: Research Summary
+
+**Before (AI-generated):**
+> This groundbreaking study delves into the intricate interplay between urbanization and biodiversity loss, highlighting the crucial role that green infrastructure plays in fostering ecological resilience. The findings underscore the enduring significance of urban planning in shaping sustainable futures. Additionally, the research showcases how nature-based solutions can enhance ecosystem services, contributing to a vibrant and resilient urban landscape.
+
+**After (humanized):**
+> This study examines how urbanization affects biodiversity, focusing on the role of green infrastructure in maintaining ecological function. The findings suggest that targeted urban planning decisions — specifically green corridors and retention ponds — correlate with higher species counts in adjacent areas. Nature-based solutions improved three measured ecosystem services: stormwater absorption, pollination rates, and ambient temperature regulation.
+
+**Patterns removed:** Significance inflation (1), AI vocabulary — "delve", "intricate", "interplay", "crucial", "fostering", "enduring", "vibrant", "landscape" (7), superficial -ing phrases (3), promotional language — "groundbreaking" (4).
+
+---
+
+## Example 2: Literature Review Paragraph
+
+**Before (AI-generated):**
+> The evolving landscape of machine learning research has witnessed a pivotal shift toward transformer architectures. Several studies have highlighted the key role these models play in advancing natural language processing. Experts argue that attention mechanisms serve as the foundation for modern NLP systems, underscoring their valuable contribution to the field. Despite challenges related to computational cost, these innovations continue to garner significant interest from the research community.
+
+**After (humanized):**
+> Transformer architectures have become the dominant approach in NLP research since Vaswani et al. (2017). Attention mechanisms replaced recurrent processing as the core component in language models, with BERT (Devlin et al., 2019) and GPT-2 (Radford et al., 2019) demonstrating state-of-the-art results across benchmark tasks. The primary limitation is computational cost: training GPT-3 required an estimated $4.6M in compute (Li et al., 2020), restricting replication to well-funded labs.
+
+**Patterns removed:** Significance inflation — "evolving landscape", "pivotal shift" (1), vague attributions — "Several studies", "Experts argue" (5), AI vocabulary — "key role", "underscoring", "valuable", "garner" (7), copula avoidance — "serve as" (8), formulaic challenges (6).
+
+---
+
+## Example 3: Methods Description
+
+**Before (AI-generated):**
+> In order to achieve robust and reliable results, a comprehensive survey methodology was employed. The survey instrument was designed to capture a wide range of participant perspectives, ensuring that diverse viewpoints were represented. It is important to note that the sample size of 450 participants provides sufficient statistical power for the analyses conducted.
+
+**After (humanized):**
+> We surveyed 450 participants using a stratified random sample drawn from the university's enrollment database. The survey included 32 Likert-scale items and 4 open-ended questions, administered online via Qualtrics between March and May 2024. The sample size exceeds the minimum of 385 required for 95% confidence at 5% margin of error (Cochran, 1977).
+
+**Patterns removed:** Filler phrases — "In order to", "It is important to note that" (22), promotional language — "robust and reliable", "comprehensive" (4), vague language replaced with specifics throughout.

--- a/skills/humanize/examples/blog.md
+++ b/skills/humanize/examples/blog.md
@@ -1,0 +1,43 @@
+# Blog Writing — Before/After Examples
+
+## Example 1: Tech Commentary
+
+**Before (AI-generated):**
+> In today's rapidly evolving technological landscape, AI-assisted coding tools have emerged as a transformative force in software development. These groundbreaking innovations are reshaping how developers ideate, iterate, and deliver solutions. It's not just about autocomplete; it's about unlocking creativity at scale, fostering collaboration, and enhancing productivity. The future of coding looks incredibly promising, and exciting times lie ahead for the developer community.
+
+**After (humanized):**
+> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
+
+> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
+
+> The productivity claims are slippery. GitHub says Copilot users "accept 30% of suggestions," but acceptance isn't correctness. If you don't have tests, you're guessing.
+
+**Patterns removed:** Significance inflation — "rapidly evolving technological landscape", "transformative force" (1), promotional — "groundbreaking", "incredibly promising" (4), negative parallelism — "It's not just about X; it's about Y" (9), rule of three — "ideate, iterate, and deliver" and "collaboration, and enhancing" (10), generic positive conclusion — "exciting times lie ahead" (24), AI vocabulary — "fostering", "enhancing" (7).
+
+---
+
+## Example 2: Product Review
+
+**Before (AI-generated):**
+> I recently had the opportunity to explore the latest iteration of this remarkable product. The device boasts an impressive array of features, including a stunning display, enhanced battery life, and a powerful processor. The user experience has been significantly improved, showcasing the manufacturer's commitment to innovation and excellence. Overall, this represents a significant step forward for the industry.
+
+**After (humanized):**
+> I've been using the new model for two weeks. The screen is noticeably better — brighter outdoors and the colors look less washed out than the previous version. Battery gets me through a full day now, which it didn't before.
+
+> The processor upgrade is harder to feel in daily use. Apps open maybe a half-second faster. I notice it in video editing but not much else.
+
+> It's a solid upgrade if you're on a two-year-old model. If you bought last year's version, probably not worth it.
+
+**Patterns removed:** Promotional language — "remarkable", "impressive", "stunning", "powerful", "excellence" (4), copula avoidance — "boasts" (8), rule of three — "display, battery life, and processor" (10), superficial -ing — "showcasing" (3), generic conclusion — "significant step forward for the industry" (24), AI vocabulary — "enhanced", "commitment to" (7).
+
+---
+
+## Example 3: Tutorial Introduction
+
+**Before (AI-generated):**
+> Welcome to this comprehensive guide on setting up a Python development environment! In this tutorial, we'll delve into the intricacies of virtual environments, package management, and IDE configuration. Whether you're a seasoned developer or just starting your coding journey, this guide will equip you with the essential knowledge to streamline your workflow and enhance your productivity. Let's dive in!
+
+**After (humanized):**
+> This guide covers setting up a Python dev environment from scratch: virtual environments, package management with uv, and VS Code configuration. Takes about 20 minutes. Assumes you have Python 3.12+ installed.
+
+**Patterns removed:** Chatbot artifacts — "Welcome to", "Let's dive in!" (19), AI vocabulary — "delve", "intricacies", "comprehensive", "essential", "enhance" (7), promotional — "streamline your workflow and enhance your productivity" (4), false range — "seasoned developer or just starting your coding journey" (12).

--- a/skills/humanize/examples/professional.md
+++ b/skills/humanize/examples/professional.md
@@ -1,0 +1,45 @@
+# Professional Writing — Before/After Examples
+
+## Example 1: Status Update Email
+
+**Before (AI-generated):**
+> I hope this email finds you well! I wanted to provide you with a comprehensive update on the project's progress. The team has been working diligently to ensure that all deliverables are aligned with the strategic objectives. We've made significant strides in several key areas, and I'm excited to share that we're on track to meet our ambitious targets. Please don't hesitate to reach out if you have any questions or concerns.
+
+**After (humanized):**
+> Quick update on Project Atlas.
+
+> We finished the API integration on Thursday — two days ahead of schedule. Load testing starts Monday. The only open risk is the third-party auth provider, which hasn't confirmed their sandbox availability for next week. I'll escalate if we don't hear back by Wednesday.
+
+> Next milestone: staging deployment on March 20.
+
+**Patterns removed:** Chatbot artifacts — "I hope this email finds you well!", "Please don't hesitate to reach out" (19), filler — "I wanted to provide you with a comprehensive update" (22), promotional — "significant strides", "ambitious targets" (4), AI vocabulary — "aligned with", "key areas" (7), vague language replaced with specific dates, names, and status.
+
+---
+
+## Example 2: Project Proposal Paragraph
+
+**Before (AI-generated):**
+> This innovative initiative serves as a testament to our organization's commitment to leveraging cutting-edge technology for enhanced operational efficiency. By implementing this groundbreaking solution, we can foster a culture of continuous improvement while ensuring seamless integration with existing systems. The proposed framework will play a pivotal role in driving sustainable growth and delivering valuable insights to key stakeholders.
+
+**After (humanized):**
+> The proposal is to replace the current batch-processing pipeline with a streaming architecture using Apache Kafka. This reduces data latency from 4 hours to under 30 seconds for the three dashboards the operations team uses daily. Integration with the existing PostgreSQL warehouse requires a Kafka Connect sink, estimated at 2 weeks of engineering time.
+
+**Patterns removed:** Significance inflation — "testament to", "pivotal role" (1), promotional — "innovative", "cutting-edge", "groundbreaking" (4), AI vocabulary — "fostering", "ensuring", "enhanced", "valuable", "key stakeholders" (7), copula avoidance — "serves as" (8), superficial -ing — "leveraging", "ensuring", "driving", "delivering" (3).
+
+---
+
+## Example 3: Meeting Notes Summary
+
+**Before (AI-generated):**
+> The meeting served as a productive forum for discussing several critical issues. Key takeaways include the need to align cross-functional teams on the strategic roadmap. Additionally, it was noted that stakeholder engagement plays a crucial role in ensuring project success. The team highlighted the importance of maintaining open communication channels and fostering collaboration across departments.
+
+**After (humanized):**
+> Three decisions from today's meeting:
+
+> 1. Design and engineering will sync weekly starting Thursday (Sarah owns the invite).
+> 2. The Q3 roadmap review moves to April 5 — Tom needs the updated capacity numbers from each team lead by March 28.
+> 3. Client demos stay biweekly. No change.
+
+> Open item: nobody has confirmed who owns the data migration spec. Flagged for resolution by EOD Friday.
+
+**Patterns removed:** Copula avoidance — "served as" (8), AI vocabulary — "critical", "crucial", "key takeaways", "align", "fostering", "highlighted" (7), vague attributions — "it was noted" (5), filler — "Additionally" (22), superficial -ing — "ensuring", "maintaining", "fostering" (3). Replaced abstract summary with specific decisions, owners, and dates.

--- a/skills/humanize/references/detection-patterns.md
+++ b/skills/humanize/references/detection-patterns.md
@@ -1,0 +1,275 @@
+# AI Writing Detection Patterns
+
+Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. Last synced: 2025-01.
+
+24 patterns organized by detection priority. Each pattern includes signal words, the problem it creates, and a before/after example.
+
+---
+
+## HIGH Priority — Content Inflation
+
+### Pattern 1: Significance and Legacy Inflation
+
+**Signal words:** stands/serves as, is a testament/reminder, vital/significant/crucial/pivotal/key role/moment, underscores/highlights importance, reflects broader, symbolizing ongoing/enduring/lasting, setting the stage, marking/shaping, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
+
+Before:
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
+
+After:
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+### Pattern 2: Notability and Media Emphasis
+
+**Signal words:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** Hits readers over the head with claims of notability without context.
+
+Before:
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+After:
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+### Pattern 3: Superficial -ing Analyses
+
+**Signal words:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** Tacks present participle phrases onto sentences to add fake depth.
+
+Before:
+> The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
+
+After:
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+### Pattern 4: Promotional Language
+
+**Signal words:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
+
+Before:
+> Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+After:
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+### Pattern 5: Vague Attributions
+
+**Signal words:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications
+
+**Problem:** Attributes opinions to vague authorities without specific sources.
+
+Before:
+> Experts believe it plays a crucial role in the regional ecosystem.
+
+After:
+> The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+### Pattern 6: Formulaic Challenges Sections
+
+**Signal words:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
+
+Before:
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
+
+After:
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
+
+---
+
+## HIGH Priority — Vocabulary
+
+### Pattern 7: AI-Frequency Vocabulary
+
+**Overused words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
+
+Before:
+> Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
+
+After:
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
+
+### Pattern 8: Copula Avoidance
+
+**Signal words:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
+
+Before:
+> Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+After:
+> Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
+
+### Pattern 22: Filler Phrases
+
+Common substitutions:
+- "In order to achieve this goal" -> "To achieve this"
+- "Due to the fact that" -> "Because"
+- "At this point in time" -> "Now"
+- "In the event that" -> "If"
+- "has the ability to" -> "can"
+- "It is important to note that" -> (delete, state the fact directly)
+
+### Pattern 23: Excessive Hedging
+
+**Problem:** Over-qualifying every statement.
+
+Before:
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+After:
+> The policy may affect outcomes.
+
+---
+
+## MEDIUM Priority — Structure
+
+### Pattern 9: Negative Parallelisms
+
+**Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
+
+Before:
+> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
+
+After:
+> The heavy beat adds to the aggressive tone.
+
+### Pattern 10: Rule of Three
+
+**Problem:** Forces ideas into groups of three to appear comprehensive.
+
+Before:
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+After:
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### Pattern 11: Elegant Variation (Synonym Cycling)
+
+**Problem:** Excessive synonym substitution driven by repetition-penalty.
+
+Before:
+> The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
+
+After:
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### Pattern 12: False Ranges
+
+**Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
+
+Before:
+> Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
+
+After:
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### Pattern 15: Inline-Header Vertical Lists
+
+**Problem:** Lists where items start with bolded headers followed by colons.
+
+Before:
+> - **User Experience:** The UX has been significantly improved.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+After:
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+## MEDIUM Priority — Style
+
+### Pattern 13: Em Dash Overuse
+
+**Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
+
+Before:
+> The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
+
+After:
+> The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
+
+**Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
+
+### Pattern 14: Boldface Overuse
+
+**Problem:** Mechanical emphasis on phrases.
+
+Before:
+> It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
+
+After:
+> It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
+
+### Pattern 16: Title Case in Headings
+
+Before: `## Strategic Negotiations And Global Partnerships`
+After: `## Strategic negotiations and global partnerships`
+
+### Pattern 17: Emoji Decoration
+
+**Problem:** Decorating headings or bullet points with emoji.
+
+Before:
+> - :rocket: **Launch Phase:** The product launches in Q3
+> - :bulb: **Key Insight:** Users prefer simplicity
+
+After:
+> The product launches in Q3. User research showed a preference for simplicity.
+
+### Pattern 18: Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes instead of straight quotes. Not all AI models do this, but it is a tell when present.
+
+Fix: Replace all curly quotes with straight quotes.
+
+---
+
+## LOW Priority — Communication Artifacts
+
+### Pattern 19: Collaborative Communication Artifacts
+
+**Signal words:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Chatbot conversation artifacts left in published text.
+
+Before:
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+After:
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### Pattern 20: Knowledge-Cutoff Disclaimers
+
+**Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
+
+Before:
+> While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+After:
+> The company was founded in 1994, according to its registration documents.
+
+### Pattern 21: Sycophantic Tone
+
+Before:
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point.
+
+After:
+> The economic factors you mentioned are relevant here.
+
+### Pattern 24: Generic Positive Conclusions
+
+Before:
+> The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+After:
+> The company plans to open two more locations next year.

--- a/skills/humanize/references/statistical-signals.md
+++ b/skills/humanize/references/statistical-signals.md
@@ -1,0 +1,72 @@
+# Statistical Signals of AI-Generated Text
+
+12 distributional signals used by AI-text detection systems. These measure structural regularity, predictability, and distributional patterns that differ between machine-generated and human-written text.
+
+Claude cannot compute most of these metrics numerically. Instead, use the **target behaviors** column during Phase 4 to produce text that falls within human-typical ranges.
+
+---
+
+## Signal Reference Table
+
+| # | Signal | What detectors measure | Human-typical range | AI-typical pattern | Target behavior during rewrite |
+|---|--------|----------------------|--------------------|--------------------|-------------------------------|
+| 1 | Perplexity | How predictable text is to a language model | Higher, variable | Lower, uniform | Use specific/concrete words over high-frequency generic ones. Prefer "the auth module crashed" over "the system encountered an error" |
+| 2 | Burstiness | Variance in token predictability across a passage | High variance | Low variance | Alternate between predictable phrasings and unexpected expressions. Let some sentences be plain, others surprising |
+| 3 | Sentence length variance | Standard deviation of words per sentence | SD 7-15 words | Narrow SD | Mix sentences from 3-8 words to 20-30 words within paragraphs. No three consecutive sentences within 5 words of each other |
+| 4 | Token probability distribution | Distribution of word likelihood scores | Long tail of low-probability tokens | Clustered mid-to-high probability | Include specific nouns, unusual adjectives, domain jargon, and concrete details that a generic model would not predict |
+| 5 | Type-token ratio | Unique words / total words | 0.45-0.65 | Often lower (repetitive) | Maintain vocabulary breadth through restructuring (pronouns, sentence merging), not synonym cycling |
+| 6 | N-gram frequency | Distribution of common word sequences | More rare bigrams/trigrams | Heavy reliance on stock phrases | Break phrase templates: "plays a role in" -> name the action. "In terms of" -> delete. "It is worth noting" -> delete |
+| 7 | Sentence entropy | Information density per sentence | Moderate to high, variable | Moderate but uniform | Vary density: some sentences carry 3-4 facts, others carry one reaction or pivot. Do not distribute information evenly |
+| 8 | Function word distribution | Usage patterns of the/and/but/because/however | Personalized, consistent per author | Standardized, textbook-like | Develop preferences within a piece: favor "but" over "however", use "still" or "and yet" instead of always defaulting to the same connector |
+| 9 | Clause density | Average clauses per sentence | 1.2-2.5, varied | More uniform | Mix simple sentences (one clause) with compound-complex (2-3 clauses). Do not write 10 consecutive simple sentences or 10 consecutive complex ones |
+| 10 | Semantic similarity between sentences | Cosine similarity of adjacent sentence embeddings | 0.3-0.6 | Often higher (tightly related) | Allow topic micro-shifts: a brief aside, a contextual expansion, a perspective shift. Not every sentence must directly continue the previous one |
+| 11 | Transition phrase frequency | Discourse markers per 1,000 words | 3-8 | Often higher | Remove 60-80% of formal transitions. Replace half with nothing, the rest with short conjunctions (but, so, still) or paragraph breaks |
+| 12 | Structural symmetry | Uniformity of sentence/paragraph/clause patterns | High irregularity | Balanced, mirror-like | Break symmetry: unequal paragraph lengths, varied sentence openings, mixed clause structures. Avoid A-B-A-B patterns |
+
+---
+
+## Applying Signals by Phase
+
+### Phase 1 (Detection): What to scan for
+
+Assess the input text for these regularity indicators:
+
+- **Sentence length uniformity**: Are most sentences within a 5-word range of each other? Flag if yes.
+- **Clause density uniformity**: Does every sentence have the same structure (all simple, or all compound)? Flag if yes.
+- **Transition overuse**: Count formal transitions (however, furthermore, additionally, moreover, in addition, therefore, consequently, nevertheless). Flag if above ~8 per 1,000 words.
+- **Phrase template density**: Are stock collocations repeated? ("plays a role", "it is important to note", "in terms of", "serves as a", "a wide range of"). Flag clusters.
+- **Structural symmetry**: Are paragraphs roughly equal length? Do sentences follow predictable patterns? Flag visible uniformity.
+- **Inter-sentence tightness**: Does every sentence directly continue the previous with no shifts, asides, or expansions? Flag if the text reads as a single unbroken logical chain.
+
+### Phase 4 (Entropy): What to target
+
+Use the human-typical ranges as guidelines, not formulas:
+
+**Sentence-level targets:**
+- In any 5-sentence window: at least one under 8 words, at least one over 20 words
+- No three consecutive sentences with the same clause structure
+- At least one sentence per paragraph that shifts density (heavy detail -> light reaction, or vice versa)
+
+**Paragraph-level targets:**
+- Visible length variation across paragraphs (some 1-2 sentences, some 4-6)
+- At least one paragraph break that is not preceded by a transition phrase
+
+**Document-level targets:**
+- 2-3 small topic micro-shifts or asides per 500 words (brief digressions that a thinking human would include)
+- Function word preferences should be roughly consistent within the piece (if you use "but" early, don't switch to "however" later without reason)
+- Formal transition count under 8 per 1,000 words
+
+---
+
+## Signals Claude Cannot Directly Compute
+
+These require language model inference or embedding computation that is not available during skill execution:
+
+| Signal | Why it's not computable | Proxy behavior |
+|--------|------------------------|----------------|
+| Perplexity (absolute score) | Requires running a reference LM on the output | Use specific, concrete, domain-appropriate vocabulary instead of generic high-frequency words |
+| Token probability distribution | Requires token-level probability access | Include proper nouns, precise numbers, domain jargon — tokens a model would assign low probability |
+| Semantic similarity (cosine) | Requires sentence embeddings | Introduce visible topic variation: asides, perspective shifts, contextual jumps |
+| N-gram rarity scores | Requires corpus frequency data | Break stock phrases, use fresh constructions, avoid "plays a role in / wide range of / it is important" templates |
+
+The proxy behaviors achieve the same *effect* on detector scores without requiring numerical computation.

--- a/skills/humanize/references/style-guide.md
+++ b/skills/humanize/references/style-guide.md
@@ -1,0 +1,127 @@
+# Domain Style Profiles
+
+Voice calibration rules per writing domain. Apply the matching profile during Phase 3 (Vocabulary and Style Pass).
+
+---
+
+## Academic
+
+**Register:** Formal, measured, evidence-based.
+**Audience:** Researchers, reviewers, graduate students.
+
+Rules:
+- Maintain hedging where epistemically appropriate ("suggests" vs. "proves") — but remove *excessive* hedging (Pattern 23)
+- Preserve citation structure and in-text references exactly
+- Passive voice is acceptable where convention demands it (methods sections)
+- Do not inject personality or first-person unless the original uses it
+- Avoid contractions
+- Replace AI-inflated significance claims with measured statements: "This study examines..." not "This groundbreaking study delves into..."
+- Technical jargon is expected — do not simplify domain-specific terms
+- Sentence length: longer is acceptable, but vary within paragraphs
+
+**Preserve:** Citation formats, section headings (Introduction/Methods/Results/Discussion), figure/table references, statistical notation.
+
+**Target tells to fix:** Significance inflation (Pattern 1), AI vocabulary (Pattern 7), formulaic challenges/future-work sections (Pattern 6), vague attributions (Pattern 5).
+
+---
+
+## Technical
+
+**Register:** Precise, direct, information-dense.
+**Audience:** Engineers, developers, technical practitioners.
+
+Rules:
+- Clarity over style — if a sentence is clear but boring, leave it
+- Code blocks, terminal output, config snippets pass through unchanged
+- Numbered steps and bullet lists are natural in technical writing — do not convert all lists to prose
+- Contractions are fine
+- First person ("I configured...", "we deployed...") is natural in technical blogs and docs
+- Replace promotional language with specifics: "blazing fast" -> "handles 10K requests/second"
+- Remove all chatbot artifacts aggressively (Pattern 19)
+
+**Preserve:** Code blocks, command-line examples, version numbers, API endpoints, configuration values, error messages.
+
+**Target tells to fix:** Promotional language (Pattern 4), copula avoidance (Pattern 8), AI vocabulary (Pattern 7), inline-header lists (Pattern 15).
+
+---
+
+## Blog
+
+**Register:** Conversational, opinionated, personal.
+**Audience:** General readers, tech-curious non-specialists.
+
+Rules:
+- First person is expected and natural
+- Contractions, fragments, rhetorical questions all allowed
+- Opinions and reactions are good — "I genuinely don't know how to feel about this"
+- Humor and asides are human signals — preserve or introduce where natural
+- Vary rhythm aggressively: short punchy sentences mixed with longer explanatory ones
+- Analogies should be concrete and from everyday life
+- Remove ALL promotional language — blog readers detect it instantly
+- Remove significance inflation — readers came for the author's perspective, not Wikipedia-style importance claims
+
+**Preserve:** Personal anecdotes, named sources, specific experiences, the author's apparent opinions.
+
+**Target tells to fix:** All HIGH priority patterns, plus structural patterns (Rule of Three, Negative Parallelisms).
+
+---
+
+## Social
+
+**Register:** Casual, compressed, direct.
+**Audience:** Reddit, Twitter/X, forum users.
+
+Rules:
+- Extremely short paragraphs (1-3 sentences)
+- Fragments and incomplete sentences are natural
+- Slang and informal language acceptable
+- No hedging — social media writing is assertive
+- No significance inflation — users will mock it
+- Remove ALL chatbot artifacts — these are the most obvious tell on social platforms
+- Contractions mandatory — "do not" reads as AI on Reddit
+- Lowercase acceptable for casual tone
+- Swearing is fine if the original contains it
+
+**Preserve:** Links, usernames/handles, quoted text, platform-specific formatting.
+
+**Target tells to fix:** Communication artifacts (Pattern 19-21), hedging (Pattern 23), filler (Pattern 22), promotional language (Pattern 4).
+
+---
+
+## Professional
+
+**Register:** Clear, neutral, competent. Business correspondence tone.
+**Audience:** Colleagues, clients, stakeholders.
+
+Rules:
+- Polite but not sycophantic — remove "I hope this finds you well" only if it reads as filler
+- Contractions acceptable in internal communication, avoid in external/formal
+- No promotional language unless the context is genuinely marketing
+- Action items and next steps should be clear and direct
+- Remove AI vocabulary but preserve business terminology where standard
+- Moderate formality — neither stiff nor casual
+- First person is natural ("I'll follow up on...", "We reviewed...")
+
+**Preserve:** Names, dates, action items, deadlines, project references, organizational terminology.
+
+**Target tells to fix:** Sycophantic tone (Pattern 21), filler phrases (Pattern 22), AI vocabulary (Pattern 7), generic conclusions (Pattern 24).
+
+---
+
+## Marketing
+
+**Register:** Persuasive but authentic. Benefits-focused.
+**Audience:** Potential customers, users, decision-makers.
+
+Rules:
+- Some promotional language is expected — but it must be specific, not generic
+- "Blazing fast" is AI slop; "loads in 0.3 seconds" is marketing with substance
+- Remove vague superlatives, keep specific claims
+- Social proof should cite real numbers or real customers, not "industry experts agree"
+- CTA (call to action) is expected — do not remove it, but make it specific
+- Bullet lists and feature comparisons are natural format for marketing
+- Remove AI tells that undermine trust: chatbot artifacts, hedging, generic conclusions
+
+**Preserve:** Product names, feature lists, pricing, CTAs, testimonials (if sourced), comparison data.
+
+**Target tells to fix:** Vague attributions (Pattern 5), generic positive conclusions (Pattern 24), AI vocabulary (Pattern 7), significance inflation (Pattern 1).

--- a/skills/humanize/references/transformation-rules.md
+++ b/skills/humanize/references/transformation-rules.md
@@ -1,0 +1,182 @@
+# Transformation Rules
+
+Structural rewrite strategies (Phase 2) and entropy techniques (Phase 4).
+
+---
+
+## Structural Transformations
+
+### Paragraph Restructuring
+
+AI text tends toward uniform paragraph length (3-5 sentences each, roughly equal). Human writing varies.
+
+Techniques:
+- Split a long paragraph into a short declarative statement + a longer elaboration paragraph
+- Merge two related short paragraphs into one cohesive block
+- Allow single-sentence paragraphs at impact positions (conclusions, transitions, revelations)
+- Break the "topic sentence + support + conclusion" template — not every paragraph needs all three
+
+### Sentence Merging and Splitting
+
+AI produces uniform sentence length. Target: visible variance.
+
+- Merge two short related sentences: "The system is fast. It handles 10K requests." -> "The system handles 10K requests per second."
+- Split compound sentences where the conjunction adds no meaning: "The team reviewed the code and they found three bugs" -> "The team reviewed the code. Three bugs."
+- Introduce subordinate clauses where they reduce total word count: "X happened. This was because of Y." -> "X happened because of Y."
+
+### List-to-Narrative Conversion
+
+Not all lists should become narrative. Convert when:
+- The list has 3 items and reads as Rule of Three (Pattern 10)
+- The list items are complete sentences disguised as bullets
+- The list has inline bold headers (Pattern 15)
+
+Keep lists when:
+- Items are genuinely parallel (feature comparisons, step-by-step instructions)
+- Items are short noun phrases or values
+- The context is technical documentation
+
+### Clause Reordering
+
+AI follows predictable clause order: setup -> detail -> significance. Human writing varies:
+
+- Lead with the specific detail, then provide context: "Three bugs in the auth module — the team found them during Friday's review."
+- Start with a consequence, then explain: "The deployment failed. The config file was missing a required field."
+- Bury the attribution mid-sentence: "The river supports, according to a 2019 CAS survey, several endemic fish species."
+
+---
+
+## Entropy and Variation Techniques
+
+These techniques target the statistical regularity signals documented in `statistical-signals.md`. The goal: produce text that falls within human-typical distributional ranges.
+
+### Sentence Length Variance (Signal 3)
+
+Target distribution across any 5-sentence window:
+- At least one sentence under 8 words
+- At least one sentence over 20 words
+- No three consecutive sentences within 5 words of each other in length
+
+Human-typical SD: 7-15 words. This is a guideline, not a formula. The goal is visible variance, not mechanical alternation.
+
+### Clause Density Variation (Signal 9)
+
+Human writing mixes simple, compound, and complex sentences. Human-typical range: 1.2-2.5 clauses per sentence, varied.
+
+- Do not write 5 consecutive simple sentences (all one clause)
+- Do not write 5 consecutive complex sentences (all 2-3 clauses)
+- Mix: "The deployment failed." (simple) + "The config file was missing a required field, which the CI pipeline should have caught but didn't because the validation step was skipped." (complex)
+- Subordinate clauses add density naturally: "because", "although", "which", "where", "when"
+
+### Information Density Variation (Signal 7)
+
+AI distributes information evenly — every sentence carries roughly the same load. Human writing varies:
+
+- **Heavy sentences**: pack 3-4 facts or details: "The survey covered 450 participants across 12 departments, ran from March to May, and used both Likert-scale and open-ended questions."
+- **Light sentences**: carry one reaction, pivot, or summary: "That's a lot of data." or "The results were mixed."
+- Alternate heavy and light within paragraphs. Do not let every sentence carry the same information weight.
+
+### Syntactic Variation
+
+Rotate sentence openings across a paragraph. Avoid:
+- Three sentences starting with "The [noun]..."
+- Two consecutive sentences starting with the same word
+- Subject-verb-object in every sentence
+
+Introduce:
+- Occasional inverted structures: "Gone is the assumption that..."
+- Adverbial openers: "By Friday, the team had..."
+- Participial openers (sparingly — avoid creating Pattern 3): "Having reviewed the data, the team concluded..."
+- Prepositional openers: "In the auth module, three bugs surfaced."
+
+### Lexical Diversity (Signal 5)
+
+Target type-token ratio: 0.45-0.65. Replace repeated words through restructuring, not synonym cycling (Pattern 11).
+
+- If "system" appears 5 times in a paragraph, restructure so 2-3 instances become pronouns or are eliminated through sentence merging
+- Domain-specific terms should NOT be varied — "API" stays "API", not "interface" then "endpoint" then "service boundary"
+- Common verbs (is, has, does, makes, gets) are invisible to readers — repeating them is fine
+
+### Phrase Template Breaking (Signal 6)
+
+AI text relies on stock collocations — high-frequency bigrams and trigrams that detectors measure via n-gram rarity scores.
+
+Common templates to break:
+- "plays a role in" -> name the specific action
+- "a wide range of" -> specify the range or delete
+- "in terms of" -> delete, restructure the sentence
+- "it is worth noting that" -> state the fact directly
+- "serves as a" -> use "is"
+- "has the potential to" -> "can" or "might"
+- "in the context of" -> "in" or "for" or delete
+
+The goal is not to avoid all common phrases — just to prevent them from dominating. A few stock phrases in 500 words is normal. A dozen is a signal.
+
+### Inter-Sentence Cohesion Variation (Signal 10)
+
+AI text produces tightly chained sentences where each directly continues the previous. Human-typical cosine similarity between adjacent sentences: 0.3-0.6.
+
+Introduce:
+- **Topic micro-shifts**: "The API handled authentication well. On the deployment side, things were rougher." (shift from feature to infrastructure)
+- **Brief asides**: "The team shipped on Friday — not the best day for a deploy, but deadlines."
+- **Perspective pivots**: "The metrics looked good. Whether they'll hold under real traffic is a different question."
+- **Contextual expansions**: after a specific claim, briefly widen scope before returning
+
+Target: 2-3 small topic shifts or asides per 500 words.
+
+### Function Word Personalization (Signal 8)
+
+AI uses connectors and prepositions in standardized distributions. Human authors show consistent but personalized patterns.
+
+Within a single piece:
+- Pick preferred connectors and use them consistently: if you use "but" early, don't switch to "however" without reason
+- Vary connector type: "but", "still", "and yet", "though" — not the same one every time
+- Allow some sentences to connect with no explicit marker at all
+- Avoid defaulting to the most formal option ("furthermore", "moreover", "additionally") — these are the strongest transition-frequency signals
+
+### Controlled Imperfection (Signal 2 — Burstiness)
+
+Human writing alternates between predictable and unexpected. This burstiness is one of the strongest statistical differentiators.
+
+- Occasional fragments: "Not ideal." or "Three bugs. All in auth."
+- Parenthetical asides: "The team (all six of them) reviewed the code."
+- Self-corrections: "The system is fast — well, fast enough."
+- Concessive turns: "Granted, the sample size is small."
+- Unexpected specificity: "The meeting ran 47 minutes" (not "about an hour")
+
+Use sparingly. One fragment per 500 words maximum. These are seasoning, not structure.
+
+### Transition Reduction (Signal 11)
+
+AI overuses transitions: "Additionally", "Furthermore", "Moreover", "In conclusion", "However". Human-typical range: 3-8 formal transitions per 1,000 words.
+
+Human writing uses:
+- No transition (just start the next thought)
+- Short conjunctions: "But", "And", "So", "Still"
+- Paragraph breaks as implicit transitions
+- Semantic connection (the ideas themselves connect, no signpost needed)
+
+Target: remove 60-80% of formal transitional phrases. Replace half with nothing. Replace the rest with short conjunctions or restructured sentences.
+
+### Structural Symmetry Breaking (Signal 12)
+
+AI produces balanced, mirror-like structures. Human writing is irregular.
+
+- Vary paragraph lengths visibly: some 1-2 sentences, some 4-6
+- Do not alternate short-long-short-long in a predictable pattern
+- Allow one paragraph to be noticeably longer than its neighbors
+- Break any A-B-A-B or A-B-C-A-B-C patterns in list or argument structures
+
+---
+
+## Preservation Checklist
+
+Before delivering the rewrite, verify:
+
+- [ ] Every factual claim in the original is present in the rewrite
+- [ ] All numbers, dates, and proper nouns are unchanged
+- [ ] Citations and references are intact (format may change, content must not)
+- [ ] Code blocks, tables, and structured data are untouched
+- [ ] The argument flows in the same logical order (unless reordering was explicitly requested)
+- [ ] Technical terminology is preserved — no simplification of domain terms
+- [ ] URLs, file paths, and identifiers are exact

--- a/skills/linkedin-post-style/SKILL.md
+++ b/skills/linkedin-post-style/SKILL.md
@@ -11,7 +11,7 @@ description: >
   md-to-pdf with Mermaid diagrams), custom images (via concept-to-image), or animations (via
   concept-to-video).
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # LinkedIn Post Style Guide
@@ -156,6 +156,19 @@ When the user provides raw content, notes, or an existing draft:
 9. **Cut pass**: Remove every sentence that doesn't earn its place. If removing it doesn't hurt, remove it.
 10. **Rhythm check**: Read aloud. Long/short alternation? Does it breathe?
 11. **Anti-pattern sweep**: Zero violations against the hard blocks list.
+12. **AI-pattern sweep**: Load `../humanize/references/detection-patterns.md` and check for residual AI tells. Specifically scan for:
+    - Copula avoidance (#8) — this voice uses "is/are" directly
+    - AI-frequency vocabulary (#7) — "delve", "crucial", "landscape", "foster", "underscore"
+    - Filler phrases (#22) — the cut pass should have caught these
+    - Sycophantic tone (#21) — hard-blocked already but verify
+    - Significance inflation (#1) — antithetical to this voice's restraint
+    - Promotional language (#4) — "groundbreaking", "stunning", "vibrant"
+    - Generic positive conclusions (#24) — the meaning layer must be specific, not upbeat filler
+
+    **Skip patterns that conflict with this voice:**
+    - Rule of three (#10) — credibility spikes use deliberate triads
+    - Em dash (#13) — this voice uses them sparingly but intentionally
+    - Negative parallelism (#9) — "Here is what it's good at / Here is what it doesn't do" is a signature construction
 
 ## Edge Cases
 

--- a/skills/manuscript-review/SKILL.md
+++ b/skills/manuscript-review/SKILL.md
@@ -13,7 +13,7 @@ description: >
   requests like "check my references" or "does the abstract work" — the full
   diagnostic surfaces issues across all facets even when only one was asked about.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Manuscript Review Skill
@@ -161,6 +161,30 @@ checklist sections. Work systematically — for each checkpoint:
 - Clarity and precision (marketing language advisory for arXiv)
 - Abbreviation hygiene (first-use expansion, consistency)
 - Mathematical typesetting consistency
+
+**Pass 7b — AI-Pattern Detection (advisory)**
+
+Scan prose sections for residual AI-writing patterns using detection rules
+from `../humanize/references/detection-patterns.md`. Academic manuscripts
+drafted or polished with AI assistants often retain detectable tells.
+
+Focus on patterns relevant to academic writing:
+- Significance inflation (#1) — "pivotal", "groundbreaking", "paradigm shift"
+- AI-frequency vocabulary (#7) — "delve", "landscape", "tapestry", "underscore"
+- Copula avoidance (#8) — "serves as" instead of "is"
+- Vague attributions (#5) — "experts argue", "studies have shown" without citations
+- Filler phrases (#22) — "it is important to note that"
+- Excessive hedging (#23) — beyond what epistemically appropriate hedging requires
+
+Skip patterns that are acceptable in academic prose:
+- Passive voice — standard in methods sections
+- Formal transitions — "Furthermore", "Moreover" are conventional in academic writing
+- Title case headings — journal style may require it
+
+This pass is MEDIUM priority. Flag findings but do not over-correct —
+academic conventions overlap with some AI patterns. Severity: report
+individual instances as LOW, flag clusters of 3+ patterns in a single
+paragraph as MEDIUM.
 
 **Pass 8 — Best Practices & Reproducibility (Checklist §16, §17, §18, §19)**
 


### PR DESCRIPTION
## Summary

Add a new **humanize** skill for detecting and removing AI-generated writing patterns from text, plus integrate its detection pattern library into two existing writing skills.

### New skill: `humanize` (v1.0.0)

A 5-phase pipeline for transforming AI-generated text into natural, human-sounding writing while preserving semantic meaning and factual accuracy.

**Architecture:**
- **SKILL.md** — Core control layer with 5-phase workflow (Detection → Structural Rewrite → Vocabulary/Style → Entropy/Variation → Validation), 4 scope modes (full rewrite, detection only, targeted fix, style shift), domain detection across 6 domains, instance-level severity rating, error handling table, and behavioral constraints
- **references/detection-patterns.md** — 24 catalogued AI-writing patterns from Wikipedia's WikiProject AI Cleanup, organized by priority (HIGH/MEDIUM/LOW) with signal words and before/after examples
- **references/statistical-signals.md** — 12 distributional features used by AI-text detectors (perplexity, burstiness, sentence length variance, type-token ratio, clause density, semantic similarity, etc.) mapped to actionable proxy behaviors Claude can target during rewriting
- **references/style-guide.md** — 6 domain voice profiles (academic, technical, blog, social, professional, marketing) with register rules, target patterns, and preservation requirements
- **references/transformation-rules.md** — Structural rewrite strategies and entropy techniques covering sentence/clause/paragraph restructuring, phrase template breaking, inter-sentence cohesion variation, function word personalization, and controlled imperfection
- **examples/** — Before/after pairs for academic, blog, and professional domains with annotated pattern numbers
- **evals/cases.yaml** — 5 positive triggers + 5 negative triggers

**Design decisions:**
- Detection patterns live in `references/` as a shared library importable by other writing skills (design-time integration, not runtime chaining)
- Statistical signals that Claude cannot compute (perplexity, embeddings) are mapped to proxy writing behaviors that achieve the same effect on detector scores
- Progressive loading: SKILL.md is ~220 lines; reference files load conditionally per phase and domain
- Skill-evaluator score: 100% (Exemplary) across all 6 dimensions

### Cross-skill integration

**linkedin-post-style** (v1.1.0 → v1.2.0):
- Added step 12 (AI-pattern sweep) to the post composition process
- Selectively imports 7 detection patterns: copula avoidance, AI vocabulary, filler phrases, sycophantic tone, significance inflation, promotional language, generic conclusions
- Explicitly skips 3 patterns that conflict with this voice: rule of three (credibility spikes), em dashes (intentional), negative parallelisms (signature construction)

**manuscript-review** (v1.1.0 → v1.2.0):
- Added Pass 7b (AI-Pattern Detection) to the 13-pass audit workflow
- Targets 6 patterns relevant to academic writing: significance inflation, AI vocabulary, copula avoidance, vague attributions, filler phrases, excessive hedging
- Skips patterns acceptable in academic prose: passive voice, formal transitions, title case headings
- Advisory priority with cluster-based severity escalation

### Other changes
- README: badge count 43 → 44, humanize added to Writing catalog section
- skills.yaml: regenerated with humanize (44 skills) and version bumps

## Test plan

- [x] `uv run scripts/generate_manifest.py` — 44 skills generated
- [x] `uv run scripts/validate_evals.py` — all 44 eval files pass
- [x] `uv run pytest tests/` — 65 tests pass
- [x] Skill-evaluator audit: 100% (Exemplary)
- [ ] Manual: install humanize skill and test full rewrite on AI-generated text
- [ ] Manual: install linkedin-post-style and verify step 12 fires without conflicting with voice
- [ ] Manual: install manuscript-review and verify Pass 7b detects AI patterns in academic prose