### PR TITLE
feat: template sync infrastructure, cross-reference fix, and 5 new generalized skills

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: sync-templates
+        name: Sync shared templates to skills
+        entry: python scripts/sync_templates.py
+        language: python
+        pass_filenames: false
+        files: ^(_templates/|skills/.*/references/)
+
       - id: generate-manifest
         name: Regenerate skills.yaml
         entry: python scripts/generate_manifest.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,50 @@ uv run scripts/generate_manifest.py
 - Skill names: kebab-case, maximum 64 characters
 - Directory name must match the `name` field in frontmatter
 
+## Self-Containment
+
+Skills must be standalone packages. Every file a skill references must live within its own directory.
+
+**Blocked:**
+- `../other-skill/references/file.md` — cross-skill path references
+- Absolute paths to files outside the skill directory
+- References to files that only exist in other skills
+
+**Why:** Skills are distributed individually via `npx skills add` and `.skill` archives. Cross-skill references break when a skill is installed without its dependency. The skill-evaluator flags this as a CRITICAL D5 finding.
+
+**Shared content:** If multiple skills need the same reference file, use the template sync system (see below). Each skill gets its own physical copy, managed by `scripts/sync_templates.py`.
+
+## Shared Templates
+
+The `_templates/` directory holds reference files shared across multiple skills. The sync system copies templates into each consuming skill's `references/` directory.
+
+**How it works:**
+
+1. Source files live in `_templates/` (e.g., `_templates/detection-patterns.md`)
+2. `scripts/sync_templates.py` defines which skills consume each template via `TEMPLATE_CONSUMERS`
+3. Running the script copies templates to `skills/{consumer}/references/{template}`
+4. A pre-commit hook runs sync automatically when templates or references change
+
+**To add a shared template:**
+
+1. Create the file in `_templates/`
+2. Add the template name and consumer list to `TEMPLATE_CONSUMERS` in `scripts/sync_templates.py`
+3. Run `uv run python scripts/sync_templates.py` to populate copies
+4. Commit both the template and the synced copies
+
+**To use an existing template in a new skill:**
+
+1. Add your skill name to the consumer list in `scripts/sync_templates.py`
+2. Run `uv run python scripts/sync_templates.py`
+3. Reference the file as `references/{template}` in your SKILL.md (local path, not `../`)
+
+Current templates:
+
+| Template | Consumers | Purpose |
+|----------|-----------|---------|
+| `detection-patterns.md` | humanize, linkedin-post-style, manuscript-review | AI writing detection patterns |
+| `project-detection.md` | ship-workflow, plan-review, qa-systematic | Stack-agnostic project detection |
+
 ## Description Rules
 
 - Maximum 1024 characters (sweet spot: 200-800 characters)
@@ -104,6 +148,44 @@ The evaluator scores 6 dimensions:
 
 Skills scoring below 70% need improvement before review. Skills with CRITICAL findings (missing frontmatter, name mismatch) are automatically rejected.
 
+## Eval Cases
+
+Every skill must have eval cases in `skills/<name>/evals/cases.yaml`. These define trigger accuracy — does the skill activate on the right queries and stay silent on the wrong ones?
+
+**Schema:**
+
+```yaml
+cases:
+  - id: unique_snake_case_id
+    prompt: "What the user would type"
+    fixtures: []
+    rubric:
+      - "Expected behavior point 1"
+      - "Expected behavior point 2"
+    trigger_expected: true  # or false
+```
+
+**Requirements:**
+
+| Skill Status | Positive Cases (trigger_expected: true) | Negative Cases (trigger_expected: false) |
+|-------------|----------------------------------------|------------------------------------------|
+| Active | 1+ (recommended: 2+) | 2+ |
+| Deprecated | 0 (must be zero) | 2+ |
+
+**Guidelines:**
+- Positive cases should use natural language a real user would type
+- Negative cases should test plausible but incorrect triggers (adjacent tasks the skill should NOT handle)
+- Each case needs a unique `id` (snake_case)
+- Rubric items describe what a correct response looks like, not implementation details
+
+**Validation:**
+
+```bash
+uv run python scripts/validate_evals.py
+```
+
+CI runs this on every PR. Skills without valid evals will fail the pipeline.
+
 ## Testing Locally
 
 Point Claude Code at the skill directory:
@@ -134,6 +216,10 @@ Before opening a PR, confirm:
 - [ ] No angle brackets or pushy language in description
 - [ ] No secrets, credentials, or internal URLs in any file
 - [ ] Tested locally with Claude Code
-- [ ] All file references in `SKILL.md` resolve to existing files
+- [ ] All file references in `SKILL.md` resolve to existing files within the skill directory
+- [ ] No cross-skill references (`../other-skill/`) — skill is fully self-contained
+- [ ] Eval cases exist in `evals/cases.yaml` with 1+ positive and 2+ negative triggers
+- [ ] Evals pass: `uv run python scripts/validate_evals.py`
+- [ ] Templates synced (if using shared templates): `uv run python scripts/sync_templates.py`
 - [ ] Skill evaluator score is 70% or above (paste the scorecard in your PR)
 - [ ] No CRITICAL or HIGH findings from skill evaluator

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # praxis-skills
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 44](https://img.shields.io/badge/skills-44-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![skills: 49](https://img.shields.io/badge/skills-49-informational)](skills/) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 
 Curated, production-grade skills for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -49,11 +49,14 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | [architecture-reviewer](skills/architecture-reviewer/) | Architecture reviews across 7 scored dimensions — structural integrity, scalability, security, performance, enterprise readiness, operations, data |
 | [code-refiner](skills/code-refiner/)                   | Deep code simplification and refactoring — structural complexity analysis, anti-pattern detection, idiomatic rewrites across Python, Go, TS, Rust  |
 | [pr-review](skills/pr-review/)                         | Diff-based PR review across 5 dimensions — code quality, test coverage, silent failures, type design, comment quality with severity-ranked output  |
+| [pre-landing-review](skills/pre-landing-review/)       | Gate-oriented safety audit with two-pass severity triage — CRITICAL (SQL, races, trust) blocks landing, INFORMATIONAL is advisory                  |
+| [plan-review](skills/plan-review/)                     | Pre-implementation plan audit stress-testing scope, assumptions, risks, and failure modes with product and engineering lenses                       |
 | [manuscript-review](skills/manuscript-review/)         | Pre-publication manuscript audit with 24 diagnostic dimensions, citation hygiene, and cross-element coherence                                      |
 | [manuscript-provenance](skills/manuscript-provenance/) | Computational provenance audit verifying every number, table, and figure in a manuscript traces back to code                                       |
 | [repo-sentinel](skills/repo-sentinel/)                 | Security audit and enforcement for public repos — 12 attack surfaces, pre-release readiness, history scrubbing, CI gates                           |
 | [skill-evaluator](skills/skill-evaluator/)             | Evaluate skill quality across 6 weighted dimensions — frontmatter, triggers, structure, depth, consistency, compliance                             |
 | [dependency-audit](skills/dependency-audit/)           | Dependency risk assessment — license compliance, maintenance health scoring, CVE detection, bloat identification, supply chain analysis            |
+| [qa-systematic](skills/qa-systematic/)                 | Systematic web QA testing with 8-category health scoring, issue taxonomy, and regression tracking — full, quick, and regression modes              |
 
 ### Visualization & Documents
 
@@ -72,6 +75,8 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | Skill                                            | Description                                                                                                                |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | [changelog-composer](skills/changelog-composer/) | Structured changelogs from git history — conventional commit parsing, audience filtering, breaking change detection        |
+| [ship-workflow](skills/ship-workflow/)           | Automated release pipeline — merge main, run tests, pre-landing review, version bump, changelog, bisectable commits, PR  |
+| [engineering-retro](skills/engineering-retro/)   | Git-based engineering retrospective — commit analysis, velocity metrics, session patterns, health scoring over time windows |
 | [adr-writer](skills/adr-writer/)                 | Architecture Decision Records — context capture, alternatives analysis, consequence projection, status lifecycle           |
 | [api-docs-generator](skills/api-docs-generator/) | API documentation audit and enhancement — FastAPI docstrings, Pydantic examples, OpenAPI spec enrichment, coverage reports |
 

--- a/_templates/detection-patterns.md
+++ b/_templates/detection-patterns.md
@@ -1,0 +1,275 @@
+# AI Writing Detection Patterns
+
+Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. Last synced: 2025-01.
+
+24 patterns organized by detection priority. Each pattern includes signal words, the problem it creates, and a before/after example.
+
+---
+
+## HIGH Priority — Content Inflation
+
+### Pattern 1: Significance and Legacy Inflation
+
+**Signal words:** stands/serves as, is a testament/reminder, vital/significant/crucial/pivotal/key role/moment, underscores/highlights importance, reflects broader, symbolizing ongoing/enduring/lasting, setting the stage, marking/shaping, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
+
+Before:
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
+
+After:
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+### Pattern 2: Notability and Media Emphasis
+
+**Signal words:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** Hits readers over the head with claims of notability without context.
+
+Before:
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+After:
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+### Pattern 3: Superficial -ing Analyses
+
+**Signal words:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** Tacks present participle phrases onto sentences to add fake depth.
+
+Before:
+> The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
+
+After:
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+### Pattern 4: Promotional Language
+
+**Signal words:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
+
+Before:
+> Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+After:
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+### Pattern 5: Vague Attributions
+
+**Signal words:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications
+
+**Problem:** Attributes opinions to vague authorities without specific sources.
+
+Before:
+> Experts believe it plays a crucial role in the regional ecosystem.
+
+After:
+> The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+### Pattern 6: Formulaic Challenges Sections
+
+**Signal words:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
+
+Before:
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
+
+After:
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
+
+---
+
+## HIGH Priority — Vocabulary
+
+### Pattern 7: AI-Frequency Vocabulary
+
+**Overused words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
+
+Before:
+> Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
+
+After:
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
+
+### Pattern 8: Copula Avoidance
+
+**Signal words:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
+
+Before:
+> Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+After:
+> Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
+
+### Pattern 22: Filler Phrases
+
+Common substitutions:
+- "In order to achieve this goal" -> "To achieve this"
+- "Due to the fact that" -> "Because"
+- "At this point in time" -> "Now"
+- "In the event that" -> "If"
+- "has the ability to" -> "can"
+- "It is important to note that" -> (delete, state the fact directly)
+
+### Pattern 23: Excessive Hedging
+
+**Problem:** Over-qualifying every statement.
+
+Before:
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+After:
+> The policy may affect outcomes.
+
+---
+
+## MEDIUM Priority — Structure
+
+### Pattern 9: Negative Parallelisms
+
+**Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
+
+Before:
+> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
+
+After:
+> The heavy beat adds to the aggressive tone.
+
+### Pattern 10: Rule of Three
+
+**Problem:** Forces ideas into groups of three to appear comprehensive.
+
+Before:
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+After:
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### Pattern 11: Elegant Variation (Synonym Cycling)
+
+**Problem:** Excessive synonym substitution driven by repetition-penalty.
+
+Before:
+> The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
+
+After:
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### Pattern 12: False Ranges
+
+**Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
+
+Before:
+> Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
+
+After:
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### Pattern 15: Inline-Header Vertical Lists
+
+**Problem:** Lists where items start with bolded headers followed by colons.
+
+Before:
+> - **User Experience:** The UX has been significantly improved.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+After:
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+## MEDIUM Priority — Style
+
+### Pattern 13: Em Dash Overuse
+
+**Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
+
+Before:
+> The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
+
+After:
+> The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
+
+**Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
+
+### Pattern 14: Boldface Overuse
+
+**Problem:** Mechanical emphasis on phrases.
+
+Before:
+> It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
+
+After:
+> It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
+
+### Pattern 16: Title Case in Headings
+
+Before: `## Strategic Negotiations And Global Partnerships`
+After: `## Strategic negotiations and global partnerships`
+
+### Pattern 17: Emoji Decoration
+
+**Problem:** Decorating headings or bullet points with emoji.
+
+Before:
+> - :rocket: **Launch Phase:** The product launches in Q3
+> - :bulb: **Key Insight:** Users prefer simplicity
+
+After:
+> The product launches in Q3. User research showed a preference for simplicity.
+
+### Pattern 18: Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes instead of straight quotes. Not all AI models do this, but it is a tell when present.
+
+Fix: Replace all curly quotes with straight quotes.
+
+---
+
+## LOW Priority — Communication Artifacts
+
+### Pattern 19: Collaborative Communication Artifacts
+
+**Signal words:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Chatbot conversation artifacts left in published text.
+
+Before:
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+After:
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### Pattern 20: Knowledge-Cutoff Disclaimers
+
+**Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
+
+Before:
+> While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+After:
+> The company was founded in 1994, according to its registration documents.
+
+### Pattern 21: Sycophantic Tone
+
+Before:
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point.
+
+After:
+> The economic factors you mentioned are relevant here.
+
+### Pattern 24: Generic Positive Conclusions
+
+Before:
+> The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+After:
+> The company plans to open two more locations next year.

--- a/_templates/project-detection.md
+++ b/_templates/project-detection.md
@@ -1,0 +1,179 @@
+# Project Detection Reference
+
+Stack-agnostic project detection patterns for identifying test commands, package managers, version strategies, frameworks, monorepo configurations, and CI/CD systems.
+
+---
+
+## Test Command Resolution
+
+Detect the project's test command by checking these files in order:
+
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
+
+If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
+
+---
+
+## Package Manager Detection
+
+Detect from lock files (most specific wins):
+
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
+
+If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
+
+---
+
+## Version Strategy Detection
+
+Check in order:
+
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
+
+For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
+
+---
+
+## Framework Detection
+
+Detect by analyzing dependencies and configuration files:
+
+### Python
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
+| Starlette | `starlette` in dependencies (without FastAPI) |
+
+### JavaScript/TypeScript
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
+
+### Ruby
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
+
+### Go
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
+
+### Rust
+| Framework | Detection |
+|-----------|-----------|
+| Actix-web | `actix-web` in `Cargo.toml` |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
+
+### Default Ports by Framework
+
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
+
+---
+
+## Monorepo Detection
+
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
+
+For monorepos, scope operations to the relevant workspace/package when a path is specified.
+
+---
+
+## CI/CD Detection
+
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
+
+---
+
+## Changelog Detection
+
+| File | Format |
+|------|--------|
+| `CHANGELOG.md` | Keep a Changelog (most common) |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
+
+Keep a Changelog format:
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+### Changed
+### Fixed
+### Removed
+```

--- a/scripts/sync_templates.py
+++ b/scripts/sync_templates.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Sync shared template files into consuming skill directories."""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = REPO_ROOT / "_templates"
+SKILLS_DIR = REPO_ROOT / "skills"
+
+TEMPLATE_CONSUMERS: dict[str, list[str]] = {
+    "detection-patterns.md": ["humanize", "linkedin-post-style", "manuscript-review"],
+    "project-detection.md": ["ship-workflow", "plan-review", "qa-systematic"],
+}
+
+
+def sync_template(template_name: str, consumers: list[str]) -> list[str]:
+    """Sync a single template to all its consumers. Returns list of updated paths."""
+    source = TEMPLATES_DIR / template_name
+    if not source.exists():
+        print(f"  skip: {template_name} (template not yet created)", file=sys.stderr)
+        return []
+
+    source_content = source.read_bytes()
+    updated: list[str] = []
+
+    for skill_name in consumers:
+        target_dir = SKILLS_DIR / skill_name / "references"
+        target = target_dir / template_name
+
+        if target.exists() and target.read_bytes() == source_content:
+            continue
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        rel = target.relative_to(REPO_ROOT)
+        updated.append(str(rel))
+        print(f"  synced: {rel}")
+
+    return updated
+
+
+def main() -> int:
+    """Sync all templates to their consumers."""
+    all_updated: list[str] = []
+
+    for template_name, consumers in TEMPLATE_CONSUMERS.items():
+        updated = sync_template(template_name, consumers)
+        all_updated.extend(updated)
+
+    if all_updated:
+        print(f"\n{len(all_updated)} file(s) updated — re-stage and commit")
+        return 1
+
+    print("All templates in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills.yaml
+++ b/skills.yaml
@@ -117,6 +117,14 @@ skills:
   description: 'DEPRECATED: The base model handles document condensation and summarization natively at high quality. This
     skill no longer provides meaningful uplift. Retained for reference only.'
   path: skills/doc-condenser
+- name: engineering-retro
+  version: 1.0.0
+  description: Git-based engineering retrospective analyzing commit history, PR patterns, and development velocity over a
+    configurable time window. Use this skill when the user asks for a retrospective, retro, sprint review, weekly review,
+    engineering review, development summary, commit analysis, team velocity report, or says "what did we ship", "what happened
+    this week", "engineering retro", "sprint retro", "dev summary", "/engineering-retro". Supports time windows (7d default,
+    24h, 14d, 30d) and monorepo path scoping.
+  path: skills/engineering-retro
 - name: estimate-calibrator
   version: 1.1.0
   description: 'Produces calibrated three-point estimates (best/likely/worst case) with explicit unknowns, confidence intervals,
@@ -184,7 +192,7 @@ skills:
     code review or PR review — use pr-review instead. NOT for security audits of repositories — use repo-sentinel instead.'
   path: skills/immune
 - name: linkedin-post-style
-  version: 1.2.0
+  version: 1.2.1
   description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and precise.
     Use this skill whenever the user asks to write, draft, rewrite, review, improve, or refine a LinkedIn post, social media
     post, tech commentary, or any public-facing short-form writing about technology, AI, software engineering, or developer
@@ -203,7 +211,7 @@ skills:
     against scripts", "provenance audit", or any request to verify that manuscript content traces back to computational outputs.'
   path: skills/manuscript-provenance
 - name: manuscript-review
-  version: 1.2.0
+  version: 1.2.1
   description: Systematic pre-publication manuscript audit producing a structured refactoring report with section-level diagnostics,
     citation hygiene analysis, and submission-readiness assessment. Use this skill whenever the user uploads a manuscript,
     paper, thesis chapter, journal submission, or conference paper and asks for review, feedback, editing, refactoring, pre-submission
@@ -253,6 +261,14 @@ skills:
     research with notebooklm, offload analysis, bulk source import, download from notebooklm, notebooklm deliverables, or
     uses /notebooklm.'
   path: skills/notebooklm
+- name: plan-review
+  version: 1.0.0
+  description: Pre-implementation plan audit that stress-tests scope, assumptions, risks, and failure modes before code is
+    written. Use this skill when the user asks to review a plan, audit a proposal, challenge scope, stress-test an approach,
+    evaluate a technical design, or says "review this plan", "is this plan solid", "what am I missing", "challenge my assumptions",
+    "plan review", "scope check", "stress-test this", "/plan-review". Supports product lens, engineering lens, or combined
+    review.
+  path: skills/plan-review
 - name: pr-review
   version: 1.1.0
   description: 'Pull request and code review with diff-based routing across five dimensions: code quality and guideline compliance,
@@ -263,6 +279,13 @@ skills:
     with this code", "pre-merge review", "look over my changes", "code review". Use this skill when reviewing code before
     commit or merge, checking PR quality, or when the user asks for feedback on recent modifications.'
   path: skills/pr-review
+- name: pre-landing-review
+  version: 1.0.0
+  description: Gate-oriented safety audit for code changes before landing, using a structured checklist with two-pass severity
+    triage. Distinct from pr-review (which is diff-based multi-dimension review) — this is a blocking safety gate. Use this
+    skill when the user asks for a pre-landing check, safety audit, pre-merge review, gate check, landing review, or says
+    "is this safe to land", "pre-landing review", "safety check before merge", "run the checklist", "gate check", "/pre-landing-review".
+  path: skills/pre-landing-review
 - name: prompt-lab
   version: 1.1.0
   description: 'Systematic LLM prompt engineering: analyzes existing prompts for failure modes, generates structured variants
@@ -273,6 +296,13 @@ skills:
     or evaluating LLM prompts specifically. NOT for evaluating Claude Code skills or SKILL.md files — use skill-evaluator
     instead.'
   path: skills/prompt-lab
+- name: qa-systematic
+  version: 1.0.0
+  description: Systematic web application QA testing with structured issue taxonomy, health scoring, and regression tracking.
+    Use this skill when the user asks for QA testing, systematic testing, smoke testing, regression testing, web app testing,
+    browser testing, or says "QA this", "test the app", "smoke test", "run QA", "systematic test", "check the site", "regression
+    test", "full QA", "/qa-systematic". Supports full, quick, and regression modes.
+  path: skills/qa-systematic
 - name: rag-auditor
   version: 1.1.0
   description: 'Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across retrieval and generation stages. Measures
@@ -315,6 +345,13 @@ skills:
   description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through
     sequential chain-of-thought reasoning that replaced the Sequential Thinking MCP server.'
   path: skills/sequential-thinking
+- name: ship-workflow
+  version: 1.0.0
+  description: Automated release pipeline that merges main, runs tests, performs pre-landing review, bumps version, updates
+    changelog, creates bisectable commits, and opens a pull request. Use this skill when the user says "ship it", "ship this",
+    "release this", "prepare for release", "open a PR", "push and PR", "land this", "get this ready to ship", "create release",
+    "/ship-workflow". Handles the full lifecycle from pre-flight checks through PR creation.
+  path: skills/ship-workflow
 - name: skill-evaluator
   version: 1.1.0
   description: 'Evaluate Claude Code SKILL.md quality across 6 weighted dimensions: frontmatter quality, trigger coverage,

--- a/skills.yaml
+++ b/skills.yaml
@@ -353,7 +353,7 @@ skills:
     "/ship-workflow". Handles the full lifecycle from pre-flight checks through PR creation.
   path: skills/ship-workflow
 - name: skill-evaluator
-  version: 1.1.0
+  version: 1.2.0
   description: 'Evaluate Claude Code SKILL.md quality across 6 weighted dimensions: frontmatter quality, trigger coverage,
     structural completeness, content depth, consistency and integrity, and CONTRIBUTING.md compliance. Produces scored audit
     reports with severity-classified findings and actionable recommendations. Two modes: (1) Quick Audit — single skill, full

--- a/skills/engineering-retro/SKILL.md
+++ b/skills/engineering-retro/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: engineering-retro
+description: >
+  Git-based engineering retrospective analyzing commit history, PR patterns, and
+  development velocity over a configurable time window. Use this skill when the user
+  asks for a retrospective, retro, sprint review, weekly review, engineering review,
+  development summary, commit analysis, team velocity report, or says "what did we
+  ship", "what happened this week", "engineering retro", "sprint retro", "dev summary",
+  "/engineering-retro". Supports time windows (7d default, 24h, 14d, 30d) and
+  monorepo path scoping.
+metadata:
+  version: 1.0.0
+---
+
+# Engineering Retrospective
+
+Generate a structured, git-based engineering retrospective for a configurable time window. This is a **read-only analysis** — no files are modified except the optional JSON snapshot.
+
+## Arguments
+
+```
+/engineering-retro [TIME_WINDOW] [PATH_SCOPE]
+```
+
+- **TIME_WINDOW** (optional): `24h`, `7d` (default), `14d`, `30d`
+- **PATH_SCOPE** (optional): restrict analysis to a subdirectory (monorepo support), e.g. `services/api`
+
+Examples:
+- `/engineering-retro` — last 7 days, full repo
+- `/engineering-retro 30d` — last 30 days, full repo
+- `/engineering-retro 14d services/api` — last 14 days, scoped to `services/api/`
+
+## Execution Steps
+
+### Step 1: Environment Detection
+
+Detect runtime context before any analysis:
+
+```bash
+# Default branch
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+fi
+
+# System timezone
+TZ_NAME=$(date +%Z)
+
+# Time window — convert argument to --since format
+# 24h → "24 hours ago", 7d → "7 days ago", 14d → "14 days ago", 30d → "30 days ago"
+```
+
+If `DEFAULT_BRANCH` detection fails, abort with an error — do not guess.
+
+### Step 2: Gather Raw Git Data
+
+Collect commits within the time window on the detected default branch:
+
+```bash
+# All commits in window (with optional path scope)
+git log origin/$DEFAULT_BRANCH --since="$SINCE" --format="%H|%aI|%aN|%s" -- $PATH_SCOPE
+
+# Diff stats for the window
+git log origin/$DEFAULT_BRANCH --since="$SINCE" --numstat --format="%H" -- $PATH_SCOPE
+```
+
+Capture: commit hash, author date (ISO), author name, subject line, files changed, insertions, deletions.
+
+### Step 3: Compute Aggregate Metrics
+
+From the raw data, compute:
+
+- **Total commits** in window
+- **Unique contributors** (distinct author names)
+- **Files changed** (unique file paths across all commits)
+- **Lines added** (sum of insertions)
+- **Lines removed** (sum of deletions)
+- **Net delta** (added - removed)
+- **Avg commit size** (total lines changed / total commits)
+
+### Step 4: Time Distribution
+
+Analyze commit timestamps (converted to system timezone `$TZ_NAME`):
+
+- **Commits by day of week**: Mon-Sun histogram
+- **Commits by hour**: 0-23 histogram
+- **Peak day**: day with most commits
+- **Peak hours**: hours with most activity
+
+Present as a compact text histogram.
+
+### Step 5: Session Analysis
+
+Group commits into work sessions using a >2 hour gap as a session boundary:
+
+1. Sort commits by author and timestamp
+2. For each author, iterate chronologically — if gap between consecutive commits exceeds 2 hours, start a new session
+3. Compute per-session: duration (first commit to last commit), commit count
+4. Aggregate: total sessions, average session length, longest session, average commits per session
+
+Sessions with a single commit get a default duration of 0 (point-in-time).
+
+### Step 6: Commit Type Classification
+
+Classify each commit using conventional commit prefixes from the subject line:
+
+| Prefix pattern | Category |
+|---|---|
+| `feat:`, `feat(` | feature |
+| `fix:`, `fix(`, `bugfix` | fix |
+| `refactor:`, `refactor(` | refactor |
+| `chore:`, `chore(`, `build:`, `ci:` | chore |
+| `docs:`, `doc:` | docs |
+| `test:`, `tests:` | test |
+| `perf:` | perf |
+| `style:` | style |
+
+For commits without conventional prefixes, apply diff heuristics:
+- Primarily new files added → feature
+- Primarily deletions → refactor
+- Test files only → test
+- Config/CI files only → chore
+- Documentation files only → docs
+- Otherwise → uncategorized
+
+Report counts and percentages per category.
+
+### Step 7: Hotspot Analysis
+
+Identify the **top 10 most-modified files** by number of commits touching them:
+
+```bash
+git log origin/$DEFAULT_BRANCH --since="$SINCE" --name-only --format="" -- $PATH_SCOPE | sort | uniq -c | sort -rn | head -20
+```
+
+Flag any file modified in **>50% of total commits** as a hotspot. Hotspots indicate:
+- Active area of development (expected during feature work)
+- Potential coupling issues (if unrelated commits keep touching the same file)
+- Possible need for decomposition (if the file is large)
+
+### Step 8: PR Analysis
+
+If the remote is GitHub (check `git remote get-url origin` for `github.com`):
+
+```bash
+# Merged PRs in window
+gh pr list --state merged --base $DEFAULT_BRANCH --search "merged:>=$SINCE_DATE" --json number,title,author,mergedAt,additions,deletions,changedFiles,reviews
+```
+
+Compute:
+- **Total merged PRs**
+- **Size distribution**: S (<50 lines), M (50-200), L (200-500), XL (>500)
+- **Review turnaround**: time from PR creation to first review (median, p90)
+- **Merge turnaround**: time from PR creation to merge (median, p90)
+
+If not a GitHub remote or `gh` is unavailable, skip this step and note it in the output.
+
+### Step 9: Focus Score
+
+Compute the ratio of **focused commits** (touching 3 or fewer files) to total commits:
+
+```
+focus_score = commits_touching_le_3_files / total_commits
+```
+
+Interpretation:
+- **>0.8**: highly focused, small incremental changes
+- **0.5-0.8**: moderate focus, mix of targeted and broad changes
+- **<0.5**: broad changes dominating, may indicate large refactors or low commit discipline
+
+### Step 10: Per-Author Breakdown
+
+For each contributor, report:
+- Commit count
+- Lines added / removed
+- Top 3 most-touched files
+- Primary commit types (from Step 6)
+- Number of sessions and average session length (from Step 5)
+
+Frame this as **contributor highlights** — recognition of work done, not a ranking or performance metric. Order alphabetically by author name.
+
+### Step 11: Week-over-Week Comparison
+
+Check for a prior snapshot in `.engineering-retros/`:
+- Find the most recent `*.json` file
+- If it exists and covers the adjacent prior window, compute deltas:
+  - Commit count delta (%)
+  - Lines changed delta (%)
+  - Contributor count delta
+  - Focus score delta
+  - Category distribution shift
+
+If no prior snapshot exists, note this is the first retrospective and skip comparison.
+
+### Step 12: Save Snapshot
+
+Save a JSON snapshot for future comparisons:
+
+```
+.engineering-retros/<YYYY-MM-DD>.json
+```
+
+Schema:
+```json
+{
+  "date": "YYYY-MM-DD",
+  "window": "7d",
+  "path_scope": null,
+  "branch": "main",
+  "timezone": "PST",
+  "metrics": {
+    "commits": 0,
+    "contributors": 0,
+    "files_changed": 0,
+    "lines_added": 0,
+    "lines_removed": 0,
+    "net_delta": 0,
+    "focus_score": 0.0
+  },
+  "categories": {},
+  "hotspots": [],
+  "sessions": {
+    "total": 0,
+    "avg_length_minutes": 0
+  },
+  "authors": {},
+  "pr_stats": null
+}
+```
+
+Create the `.engineering-retros/` directory if it does not exist. Ensure `.engineering-retros/` is in `.gitignore` (add it if missing — this is the one permitted file modification).
+
+### Step 13: Generate Narrative Summary
+
+Produce the final output in this structure:
+
+---
+
+**Engineering Retrospective — [DATE_RANGE] ([TIMEZONE])**
+**Branch:** [DEFAULT_BRANCH] | **Scope:** [PATH_SCOPE or "full repo"]
+
+#### Metrics
+- Commits: N | Contributors: N | Files changed: N
+- Lines: +N / -N (net: +/-N)
+- Avg commit size: N lines | Focus score: N.NN
+
+#### Time Patterns
+- Peak day: [DAY] | Peak hours: [RANGE]
+- [compact histogram]
+- Sessions: N total | Avg length: Nm | Longest: Nm
+
+#### Work Breakdown
+- [category]: N commits (NN%)
+- ...
+
+#### Hotspots
+- `path/to/file` — N commits [HOTSPOT if >50%]
+- ...
+
+#### Contributor Highlights
+- **[Author]**: N commits, +N/-N lines, focused on [top files], primarily [categories]
+- ...
+
+#### PR Summary (if available)
+- Merged: N | Size dist: S/M/L/XL | Median review turnaround: Xh
+
+#### Week-over-Week (if available)
+- Commits: +/-N% | Lines: +/-N% | Focus: +/-N.NN
+
+#### Observations
+- [2-4 bullet points identifying patterns, achievements, and areas worth attention]
+- Based on data only — no speculation about intent or quality judgments about individuals
+
+---
+
+## Constraints
+
+- **Read-only**: no code modifications, no branch changes, no git operations that alter state
+- **No hardcoded timezone**: always detect from `date +%Z`
+- **No hardcoded branch**: always detect dynamically via `git symbolic-ref` or `git remote show`
+- **No individual performance judgments**: author breakdown is for recognition, not evaluation
+- **Path scope respected**: all git commands must include `-- $PATH_SCOPE` when a scope is provided
+- **Snapshot storage**: `.engineering-retros/` only, never `.context/retros/`

--- a/skills/engineering-retro/evals/cases.yaml
+++ b/skills/engineering-retro/evals/cases.yaml
@@ -1,0 +1,34 @@
+cases:
+  - id: default_retro
+    prompt: "Run an engineering retro for this week"
+    fixtures: []
+    rubric:
+      - "analyzes git commit history for the default time window"
+      - "produces metrics including commits, files changed, and lines modified"
+      - "generates a narrative summary with patterns and highlights"
+    trigger_expected: true
+
+  - id: time_windowed_retro
+    prompt: "/engineering-retro 30d"
+    fixtures: []
+    rubric:
+      - "uses 30-day time window instead of default 7d"
+      - "analyzes git history for the specified period"
+      - "produces comparative metrics if prior data exists"
+    trigger_expected: true
+
+  - id: code_review_request
+    prompt: "Review this pull request for code quality issues"
+    fixtures: []
+    rubric:
+      - "does not activate engineering retrospective workflow"
+      - "code review is a different task from retrospective analysis"
+    trigger_expected: false
+
+  - id: git_log_request
+    prompt: "Show me the git log for the last 5 commits"
+    fixtures: []
+    rubric:
+      - "does not activate engineering retrospective workflow"
+      - "raw git log display is different from structured retrospective analysis"
+    trigger_expected: false

--- a/skills/linkedin-post-style/SKILL.md
+++ b/skills/linkedin-post-style/SKILL.md
@@ -11,7 +11,7 @@ description: >
   md-to-pdf with Mermaid diagrams), custom images (via concept-to-image), or animations (via
   concept-to-video).
 metadata:
-  version: 1.2.0
+  version: 1.2.1
 ---
 
 # LinkedIn Post Style Guide
@@ -156,7 +156,7 @@ When the user provides raw content, notes, or an existing draft:
 9. **Cut pass**: Remove every sentence that doesn't earn its place. If removing it doesn't hurt, remove it.
 10. **Rhythm check**: Read aloud. Long/short alternation? Does it breathe?
 11. **Anti-pattern sweep**: Zero violations against the hard blocks list.
-12. **AI-pattern sweep**: Load `../humanize/references/detection-patterns.md` and check for residual AI tells. Specifically scan for:
+12. **AI-pattern sweep**: Load `references/detection-patterns.md` and check for residual AI tells. Specifically scan for:
     - Copula avoidance (#8) — this voice uses "is/are" directly
     - AI-frequency vocabulary (#7) — "delve", "crucial", "landscape", "foster", "underscore"
     - Filler phrases (#22) — the cut pass should have caught these

--- a/skills/linkedin-post-style/references/detection-patterns.md
+++ b/skills/linkedin-post-style/references/detection-patterns.md
@@ -1,0 +1,275 @@
+# AI Writing Detection Patterns
+
+Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. Last synced: 2025-01.
+
+24 patterns organized by detection priority. Each pattern includes signal words, the problem it creates, and a before/after example.
+
+---
+
+## HIGH Priority — Content Inflation
+
+### Pattern 1: Significance and Legacy Inflation
+
+**Signal words:** stands/serves as, is a testament/reminder, vital/significant/crucial/pivotal/key role/moment, underscores/highlights importance, reflects broader, symbolizing ongoing/enduring/lasting, setting the stage, marking/shaping, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
+
+Before:
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
+
+After:
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+### Pattern 2: Notability and Media Emphasis
+
+**Signal words:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** Hits readers over the head with claims of notability without context.
+
+Before:
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+After:
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+### Pattern 3: Superficial -ing Analyses
+
+**Signal words:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** Tacks present participle phrases onto sentences to add fake depth.
+
+Before:
+> The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
+
+After:
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+### Pattern 4: Promotional Language
+
+**Signal words:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
+
+Before:
+> Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+After:
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+### Pattern 5: Vague Attributions
+
+**Signal words:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications
+
+**Problem:** Attributes opinions to vague authorities without specific sources.
+
+Before:
+> Experts believe it plays a crucial role in the regional ecosystem.
+
+After:
+> The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+### Pattern 6: Formulaic Challenges Sections
+
+**Signal words:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
+
+Before:
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
+
+After:
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
+
+---
+
+## HIGH Priority — Vocabulary
+
+### Pattern 7: AI-Frequency Vocabulary
+
+**Overused words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
+
+Before:
+> Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
+
+After:
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
+
+### Pattern 8: Copula Avoidance
+
+**Signal words:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
+
+Before:
+> Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+After:
+> Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
+
+### Pattern 22: Filler Phrases
+
+Common substitutions:
+- "In order to achieve this goal" -> "To achieve this"
+- "Due to the fact that" -> "Because"
+- "At this point in time" -> "Now"
+- "In the event that" -> "If"
+- "has the ability to" -> "can"
+- "It is important to note that" -> (delete, state the fact directly)
+
+### Pattern 23: Excessive Hedging
+
+**Problem:** Over-qualifying every statement.
+
+Before:
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+After:
+> The policy may affect outcomes.
+
+---
+
+## MEDIUM Priority — Structure
+
+### Pattern 9: Negative Parallelisms
+
+**Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
+
+Before:
+> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
+
+After:
+> The heavy beat adds to the aggressive tone.
+
+### Pattern 10: Rule of Three
+
+**Problem:** Forces ideas into groups of three to appear comprehensive.
+
+Before:
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+After:
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### Pattern 11: Elegant Variation (Synonym Cycling)
+
+**Problem:** Excessive synonym substitution driven by repetition-penalty.
+
+Before:
+> The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
+
+After:
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### Pattern 12: False Ranges
+
+**Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
+
+Before:
+> Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
+
+After:
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### Pattern 15: Inline-Header Vertical Lists
+
+**Problem:** Lists where items start with bolded headers followed by colons.
+
+Before:
+> - **User Experience:** The UX has been significantly improved.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+After:
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+## MEDIUM Priority — Style
+
+### Pattern 13: Em Dash Overuse
+
+**Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
+
+Before:
+> The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
+
+After:
+> The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
+
+**Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
+
+### Pattern 14: Boldface Overuse
+
+**Problem:** Mechanical emphasis on phrases.
+
+Before:
+> It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
+
+After:
+> It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
+
+### Pattern 16: Title Case in Headings
+
+Before: `## Strategic Negotiations And Global Partnerships`
+After: `## Strategic negotiations and global partnerships`
+
+### Pattern 17: Emoji Decoration
+
+**Problem:** Decorating headings or bullet points with emoji.
+
+Before:
+> - :rocket: **Launch Phase:** The product launches in Q3
+> - :bulb: **Key Insight:** Users prefer simplicity
+
+After:
+> The product launches in Q3. User research showed a preference for simplicity.
+
+### Pattern 18: Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes instead of straight quotes. Not all AI models do this, but it is a tell when present.
+
+Fix: Replace all curly quotes with straight quotes.
+
+---
+
+## LOW Priority — Communication Artifacts
+
+### Pattern 19: Collaborative Communication Artifacts
+
+**Signal words:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Chatbot conversation artifacts left in published text.
+
+Before:
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+After:
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### Pattern 20: Knowledge-Cutoff Disclaimers
+
+**Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
+
+Before:
+> While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+After:
+> The company was founded in 1994, according to its registration documents.
+
+### Pattern 21: Sycophantic Tone
+
+Before:
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point.
+
+After:
+> The economic factors you mentioned are relevant here.
+
+### Pattern 24: Generic Positive Conclusions
+
+Before:
+> The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+After:
+> The company plans to open two more locations next year.

--- a/skills/manuscript-review/SKILL.md
+++ b/skills/manuscript-review/SKILL.md
@@ -13,7 +13,7 @@ description: >
   requests like "check my references" or "does the abstract work" — the full
   diagnostic surfaces issues across all facets even when only one was asked about.
 metadata:
-  version: 1.2.0
+  version: 1.2.1
 ---
 
 # Manuscript Review Skill
@@ -165,7 +165,7 @@ checklist sections. Work systematically — for each checkpoint:
 **Pass 7b — AI-Pattern Detection (advisory)**
 
 Scan prose sections for residual AI-writing patterns using detection rules
-from `../humanize/references/detection-patterns.md`. Academic manuscripts
+from `references/detection-patterns.md`. Academic manuscripts
 drafted or polished with AI assistants often retain detectable tells.
 
 Focus on patterns relevant to academic writing:

--- a/skills/manuscript-review/references/detection-patterns.md
+++ b/skills/manuscript-review/references/detection-patterns.md
@@ -1,0 +1,275 @@
+# AI Writing Detection Patterns
+
+Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. Last synced: 2025-01.
+
+24 patterns organized by detection priority. Each pattern includes signal words, the problem it creates, and a before/after example.
+
+---
+
+## HIGH Priority — Content Inflation
+
+### Pattern 1: Significance and Legacy Inflation
+
+**Signal words:** stands/serves as, is a testament/reminder, vital/significant/crucial/pivotal/key role/moment, underscores/highlights importance, reflects broader, symbolizing ongoing/enduring/lasting, setting the stage, marking/shaping, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
+
+Before:
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
+
+After:
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+### Pattern 2: Notability and Media Emphasis
+
+**Signal words:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** Hits readers over the head with claims of notability without context.
+
+Before:
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+After:
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+### Pattern 3: Superficial -ing Analyses
+
+**Signal words:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** Tacks present participle phrases onto sentences to add fake depth.
+
+Before:
+> The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
+
+After:
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+### Pattern 4: Promotional Language
+
+**Signal words:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
+
+Before:
+> Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+After:
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+### Pattern 5: Vague Attributions
+
+**Signal words:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications
+
+**Problem:** Attributes opinions to vague authorities without specific sources.
+
+Before:
+> Experts believe it plays a crucial role in the regional ecosystem.
+
+After:
+> The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+### Pattern 6: Formulaic Challenges Sections
+
+**Signal words:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
+
+Before:
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
+
+After:
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
+
+---
+
+## HIGH Priority — Vocabulary
+
+### Pattern 7: AI-Frequency Vocabulary
+
+**Overused words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
+
+Before:
+> Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
+
+After:
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
+
+### Pattern 8: Copula Avoidance
+
+**Signal words:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
+
+Before:
+> Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+After:
+> Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
+
+### Pattern 22: Filler Phrases
+
+Common substitutions:
+- "In order to achieve this goal" -> "To achieve this"
+- "Due to the fact that" -> "Because"
+- "At this point in time" -> "Now"
+- "In the event that" -> "If"
+- "has the ability to" -> "can"
+- "It is important to note that" -> (delete, state the fact directly)
+
+### Pattern 23: Excessive Hedging
+
+**Problem:** Over-qualifying every statement.
+
+Before:
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+After:
+> The policy may affect outcomes.
+
+---
+
+## MEDIUM Priority — Structure
+
+### Pattern 9: Negative Parallelisms
+
+**Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
+
+Before:
+> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
+
+After:
+> The heavy beat adds to the aggressive tone.
+
+### Pattern 10: Rule of Three
+
+**Problem:** Forces ideas into groups of three to appear comprehensive.
+
+Before:
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+After:
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### Pattern 11: Elegant Variation (Synonym Cycling)
+
+**Problem:** Excessive synonym substitution driven by repetition-penalty.
+
+Before:
+> The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
+
+After:
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### Pattern 12: False Ranges
+
+**Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
+
+Before:
+> Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
+
+After:
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### Pattern 15: Inline-Header Vertical Lists
+
+**Problem:** Lists where items start with bolded headers followed by colons.
+
+Before:
+> - **User Experience:** The UX has been significantly improved.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+After:
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+## MEDIUM Priority — Style
+
+### Pattern 13: Em Dash Overuse
+
+**Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
+
+Before:
+> The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
+
+After:
+> The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
+
+**Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
+
+### Pattern 14: Boldface Overuse
+
+**Problem:** Mechanical emphasis on phrases.
+
+Before:
+> It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
+
+After:
+> It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
+
+### Pattern 16: Title Case in Headings
+
+Before: `## Strategic Negotiations And Global Partnerships`
+After: `## Strategic negotiations and global partnerships`
+
+### Pattern 17: Emoji Decoration
+
+**Problem:** Decorating headings or bullet points with emoji.
+
+Before:
+> - :rocket: **Launch Phase:** The product launches in Q3
+> - :bulb: **Key Insight:** Users prefer simplicity
+
+After:
+> The product launches in Q3. User research showed a preference for simplicity.
+
+### Pattern 18: Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes instead of straight quotes. Not all AI models do this, but it is a tell when present.
+
+Fix: Replace all curly quotes with straight quotes.
+
+---
+
+## LOW Priority — Communication Artifacts
+
+### Pattern 19: Collaborative Communication Artifacts
+
+**Signal words:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Chatbot conversation artifacts left in published text.
+
+Before:
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+After:
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### Pattern 20: Knowledge-Cutoff Disclaimers
+
+**Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
+
+Before:
+> While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+After:
+> The company was founded in 1994, according to its registration documents.
+
+### Pattern 21: Sycophantic Tone
+
+Before:
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point.
+
+After:
+> The economic factors you mentioned are relevant here.
+
+### Pattern 24: Generic Positive Conclusions
+
+Before:
+> The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+After:
+> The company plans to open two more locations next year.

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: plan-review
+description: >
+  Pre-implementation plan audit that stress-tests scope, assumptions, risks, and
+  failure modes before code is written. Use this skill when the user asks to review
+  a plan, audit a proposal, challenge scope, stress-test an approach, evaluate a
+  technical design, or says "review this plan", "is this plan solid", "what am I
+  missing", "challenge my assumptions", "plan review", "scope check", "stress-test
+  this", "/plan-review". Supports product lens, engineering lens, or combined review.
+metadata:
+  version: 1.0.0
+---
+
+# Plan Review Skill
+
+## Purpose
+
+Execute a structured pre-implementation audit of a technical plan, proposal,
+or design document. The goal is to surface risks, bad assumptions, missing
+pieces, and scope problems _before_ any code is written — when course
+corrections are cheapest.
+
+This skill is read-only. It never modifies code. It produces a
+severity-tagged review document with a final ship/rethink/reject verdict.
+
+## Step 0 — Mode Selection
+
+Ask the user a single question via `AskUserQuestion`:
+
+> Which review lens? (1) Product — scope, user impact, business alignment.
+> (2) Engineering — architecture, failure modes, test strategy, performance.
+> (3) Combined (default) — both lenses integrated.
+
+Accept the answer and proceed. Do not ask follow-up configuration questions.
+
+Also assess scope size from the plan:
+
+- **Small change** (single file, ~100 lines or fewer): deliver a compressed
+  4-section review — Scope, Risks, Missing, Verdict. Skip the full
+  multi-section template.
+- **Standard change**: execute the full review sequence below.
+
+## Full Review Sequence
+
+### 1. Plan Comprehension
+
+Read the plan end-to-end. Produce a 2–3 sentence summary confirming
+understanding. Explicitly list:
+
+- **Stated goals** — what the plan claims to achieve.
+- **Non-goals** — what is explicitly out of scope.
+- **Constraints** — budget, timeline, compatibility, team size, or
+  technology constraints mentioned or implied.
+
+If the summary is wrong, the user corrects it here before the rest of the
+review proceeds on a false foundation.
+
+### 2. Assumption Challenge
+
+Extract every implicit assumption. For each one:
+
+| Assumption | If wrong? | Supporting evidence | What falsifies it? |
+|------------|-----------|--------------------|--------------------|
+
+Common assumption categories to probe:
+
+- Data availability and shape
+- Third-party API stability and rate limits
+- Team familiarity with chosen tools
+- Performance characteristics of dependencies
+- Backward compatibility requirements
+- Deployment environment capabilities
+
+### 3. Risk & Failure Mapping
+
+For each component or subsystem in the plan, fill a failure mode table:
+
+| Component | Failure Mode | Blast Radius | Recovery Strategy |
+|-----------|-------------|--------------|-------------------|
+
+Additionally identify **data flow shadow paths** — side effects, async
+callbacks, event propagation, or cache invalidation chains that are not on
+the happy path but will execute in production.
+
+Use ASCII diagrams to illustrate non-obvious data flow or failure
+propagation where the plan involves three or more interacting components.
+
+### 4. Component-by-Component Review (Engineering Lens)
+
+For each major component, assess:
+
+- **Error handling strategy** — Are errors classified and routed through a
+  registry, or silently swallowed by catch-all handlers?
+- **Data integrity invariants** — What invariants must hold? How are they
+  enforced? What happens when they break?
+- **Concurrency and race conditions** — Shared state, lock ordering,
+  optimistic vs. pessimistic strategies, idempotency guarantees.
+- **Performance under load** — Expected throughput, latency budget, resource
+  consumption at 10x current scale.
+- **Test strategy adequacy** — Unit, integration, and end-to-end coverage
+  for the component. What is untestable and why?
+
+This section is language- and framework-agnostic. Reference
+`references/project-detection.md` for framework-aware examples when the
+user's stack is known.
+
+Skip this section when running product-lens-only mode.
+
+### 5. Scope & Priority Assessment (Product Lens)
+
+- **Needed vs. nice-to-have** — Which features are load-bearing for the
+  stated goals? Which are speculative?
+- **Deferral candidates** — What can ship in a follow-up without increasing
+  risk?
+- **Over-engineering indicators** — Abstractions, configurability, or
+  extensibility that no current requirement demands.
+- **User-facing impact** — Does the complexity produce proportional user
+  value?
+
+Skip this section when running engineering-lens-only mode.
+
+### 6. Integration Review
+
+How components connect to each other and to the outside world:
+
+- **API contracts** — Request/response shapes, versioning, error codes
+  between modules.
+- **State management across boundaries** — Who owns state? How is it
+  synchronized? What happens during partial failure?
+- **Migration and deployment ordering** — Which components must deploy
+  first? Are there intermediate states where the system is inconsistent?
+- **Rollback compatibility** — Can each deployment step be reversed
+  independently? What data is irreversible?
+
+### 7. What's Missing
+
+Things the plan does not address that it should:
+
+- Monitoring and observability (metrics, logs, alerts, dashboards)
+- Error recovery paths beyond the first retry
+- Edge cases outside the stated happy path
+- Security considerations (authn, authz, input validation, secrets
+  management)
+- Load and scale implications (connection pools, queue depth, storage
+  growth)
+- Operational runbooks for incident response
+
+### 8. Execution Assessment
+
+Evaluate the proposed implementation order:
+
+- **Dependency ordering** — Are prerequisites built before dependents?
+- **Parallel work opportunities** — Which tasks have no mutual dependency
+  and can proceed simultaneously?
+- **Risk-first vs. value-first** — Does the plan tackle the highest-risk
+  unknowns early, or defer them?
+- **Prototype candidates** — Which components should be spiked before
+  committing to the full implementation?
+
+### 9. Verdict
+
+Deliver exactly one of:
+
+| Verdict | Meaning |
+|---------|---------|
+| **Ship** | Plan is solid. Proceed as written. |
+| **Ship with changes** | Viable, but specific modifications listed below are required before proceeding. |
+| **Rethink** | Fundamental structural issues require re-planning. Itemize what must change. |
+| **Reject** | Plan is not viable. Explain why and what alternative direction to consider. |
+
+Include a one-paragraph rationale for the verdict.
+
+## Compressed Review (Small Changes)
+
+For small-scope changes (single file, ~100 lines), deliver four sections
+only:
+
+1. **Scope** — What the change does and its boundaries.
+2. **Risks** — Failure modes and blast radius (brief table).
+3. **Missing** — Gaps worth addressing even at this scale.
+4. **Verdict** — Ship / Ship with changes / Rethink / Reject.
+
+## Interaction Protocol
+
+- Use `AskUserQuestion` one issue at a time. Never batch multiple questions
+  into a single prompt.
+- For HIGH-severity findings, surface them immediately and ask whether to
+  continue or pause for discussion before proceeding to the next section.
+- This skill is **read-only**. It does not create, modify, or delete any
+  files.
+- Use ASCII diagrams for data flow and component relationships where they
+  clarify failure propagation or integration topology.
+
+## Output Format
+
+Structured review document with:
+
+- Numbered sections matching the sequence above
+- Severity tags on every finding: `[HIGH]`, `[MEDIUM]`, `[LOW]`
+- Summary table of all findings at the end, grouped by severity
+- Final verdict with rationale

--- a/skills/plan-review/evals/cases.yaml
+++ b/skills/plan-review/evals/cases.yaml
@@ -1,0 +1,34 @@
+cases:
+  - id: plan_audit
+    prompt: "Review this implementation plan before I start coding"
+    fixtures: []
+    rubric:
+      - "performs multi-section plan audit covering assumptions, risks, and failure modes"
+      - "produces severity-tagged findings"
+      - "delivers a ship/rethink/reject verdict"
+    trigger_expected: true
+
+  - id: scope_challenge
+    prompt: "Stress-test this proposal — what am I missing and where will it break?"
+    fixtures: []
+    rubric:
+      - "challenges implicit assumptions in the plan"
+      - "maps failure modes and blast radius for each component"
+      - "identifies gaps and missing considerations"
+    trigger_expected: true
+
+  - id: code_review_not_plan
+    prompt: "Review this Python function for bugs and performance issues"
+    fixtures: []
+    rubric:
+      - "does not activate plan review workflow"
+      - "code review of existing code is different from pre-implementation plan audit"
+    trigger_expected: false
+
+  - id: architecture_diagram
+    prompt: "Draw me an architecture diagram for this system"
+    fixtures: []
+    rubric:
+      - "does not activate plan review workflow"
+      - "diagram creation is different from plan audit"
+    trigger_expected: false

--- a/skills/plan-review/references/project-detection.md
+++ b/skills/plan-review/references/project-detection.md
@@ -1,0 +1,179 @@
+# Project Detection Reference
+
+Stack-agnostic project detection patterns for identifying test commands, package managers, version strategies, frameworks, monorepo configurations, and CI/CD systems.
+
+---
+
+## Test Command Resolution
+
+Detect the project's test command by checking these files in order:
+
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
+
+If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
+
+---
+
+## Package Manager Detection
+
+Detect from lock files (most specific wins):
+
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
+
+If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
+
+---
+
+## Version Strategy Detection
+
+Check in order:
+
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
+
+For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
+
+---
+
+## Framework Detection
+
+Detect by analyzing dependencies and configuration files:
+
+### Python
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
+| Starlette | `starlette` in dependencies (without FastAPI) |
+
+### JavaScript/TypeScript
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
+
+### Ruby
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
+
+### Go
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
+
+### Rust
+| Framework | Detection |
+|-----------|-----------|
+| Actix-web | `actix-web` in `Cargo.toml` |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
+
+### Default Ports by Framework
+
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
+
+---
+
+## Monorepo Detection
+
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
+
+For monorepos, scope operations to the relevant workspace/package when a path is specified.
+
+---
+
+## CI/CD Detection
+
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
+
+---
+
+## Changelog Detection
+
+| File | Format |
+|------|--------|
+| `CHANGELOG.md` | Keep a Changelog (most common) |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
+
+Keep a Changelog format:
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+### Changed
+### Fixed
+### Removed
+```

--- a/skills/pre-landing-review/SKILL.md
+++ b/skills/pre-landing-review/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pre-landing-review
+description: >
+  Gate-oriented safety audit for code changes before landing, using a structured
+  checklist with two-pass severity triage. Distinct from pr-review (which is
+  diff-based multi-dimension review) — this is a blocking safety gate. Use this
+  skill when the user asks for a pre-landing check, safety audit, pre-merge review,
+  gate check, landing review, or says "is this safe to land", "pre-landing review",
+  "safety check before merge", "run the checklist", "gate check", "/pre-landing-review".
+metadata:
+  version: 1.0.0
+---
+
+# Pre-Landing Review
+
+Gate-oriented safety audit for code changes before landing. Uses a structured checklist with two-pass severity triage and blocking/non-blocking classification.
+
+**Distinct from `pr-review`**: pr-review is a multi-dimension code quality review. This skill is a **gate-oriented safety audit** — it uses an external checklist with two-pass severity triage and a blocking/non-blocking classification.
+
+## Workflow
+
+### 1. Determine Diff
+
+Identify the changes to review:
+
+- If on a feature branch: diff against the default branch (`git symbolic-ref refs/remotes/origin/HEAD`)
+- If given a PR number: fetch that PR's diff
+- If given specific files: review those files
+
+### 2. Load Checklist
+
+Read `references/checklist.md`. This is mandatory — if the checklist is unreadable, STOP and report the error.
+
+### 3. Pass 1 — CRITICAL (blocking)
+
+Review the diff against critical safety categories. These are potential ship-blockers.
+
+#### SQL & Data Safety
+
+- Raw SQL without parameterization
+- Schema changes without migration safety (lock timeout, reversibility)
+- Bulk updates/deletes without WHERE clause verification
+- Direct column updates bypassing model validations/callbacks
+
+#### Race Conditions & Concurrency
+
+- Read-then-write without locking
+- Unique constraint reliance without database-level enforcement
+- Shared mutable state without synchronization
+- Queue/background job idempotency
+
+#### Trust Boundaries
+
+- LLM/AI output used in SQL, shell commands, or rendered HTML without sanitization
+- User input reaching privileged operations without validation
+- External API responses used without schema validation
+- Deserialization of untrusted data
+
+For each CRITICAL finding:
+
+1. Cite exact file and line
+2. Explain the specific risk
+3. Use `AskUserQuestion` with exactly three options: **Fix now** / **Acknowledge risk** / **False positive**
+4. If "Fix now": make the fix, then re-check
+5. If "Acknowledge": record acknowledgment, continue
+6. If "False positive": record, continue
+
+### 4. Pass 2 — INFORMATIONAL (non-blocking)
+
+Review against remaining categories:
+
+**Conditional Side Effects** — side effects hidden in conditional branches, callbacks triggered by state changes, error handlers silently swallowing failures.
+
+**Magic Numbers** — unexplained numeric literals, hardcoded thresholds without constants, timeout values without rationale.
+
+**Dead Code** — unreachable branches, unused imports, commented-out code without explanation.
+
+**Test Gaps** — new code paths without test coverage, modified behavior without updated tests, missing edge case and error path tests.
+
+**Crypto & Entropy** — weak random sources for security contexts, hardcoded secrets, missing TLS/encryption for sensitive data in transit.
+
+**Time Window Safety** — timezone-naive comparisons, daylight saving edge cases, cron expressions not accounting for clock skew.
+
+**Type Coercion** — implicit type conversions that could lose data, numeric precision loss across boundaries, implicit string encoding at I/O boundaries.
+
+Present all informational findings in a single summary table (file, line, category, description).
+
+### 5. Gate Classification
+
+- All Pass 1 issues resolved (fixed or acknowledged) → **CLEAR TO LAND**
+- Any unresolved Pass 1 issue → **BLOCKED**
+- Pass 2 issues are advisory — they don't block landing
+
+### 6. Suppressions
+
+Do NOT flag:
+
+- Test files using test fixtures/factories
+- Migration files following framework conventions
+- Comments explaining why a pattern is intentional
+- Configuration files with documented values
+- Type stubs or interface definitions
+
+## Output
+
+Gate verdict (CLEAR TO LAND / BLOCKED), critical issues summary with resolution status, informational findings table.
+
+**This skill is read-only by default** — only modifies code when user explicitly chooses "Fix now" on a critical issue.

--- a/skills/pre-landing-review/evals/cases.yaml
+++ b/skills/pre-landing-review/evals/cases.yaml
@@ -1,0 +1,34 @@
+cases:
+  - id: pre_landing_check
+    prompt: "Run a pre-landing review on my branch before I merge"
+    fixtures: []
+    rubric:
+      - "loads and follows the structured checklist"
+      - "performs two-pass review with CRITICAL and INFORMATIONAL severity"
+      - "produces a gate verdict (CLEAR TO LAND or BLOCKED)"
+    trigger_expected: true
+
+  - id: safety_audit
+    prompt: "Is this safe to land? Check for data safety issues and race conditions"
+    fixtures: []
+    rubric:
+      - "prioritizes SQL/data safety and race condition checks"
+      - "uses AskUserQuestion for critical findings"
+      - "classifies findings by blocking vs non-blocking severity"
+    trigger_expected: true
+
+  - id: general_code_review
+    prompt: "Review this code for quality, readability, and best practices"
+    fixtures: []
+    rubric:
+      - "does not activate pre-landing review workflow"
+      - "general code quality review is different from gate-oriented safety audit"
+    trigger_expected: false
+
+  - id: write_tests
+    prompt: "Write unit tests for this module"
+    fixtures: []
+    rubric:
+      - "does not activate pre-landing review workflow"
+      - "test generation is different from pre-landing safety audit"
+    trigger_expected: false

--- a/skills/pre-landing-review/references/checklist.md
+++ b/skills/pre-landing-review/references/checklist.md
@@ -1,0 +1,82 @@
+# Pre-Landing Review Checklist
+
+## Pass 1 — CRITICAL (blocking)
+
+### SQL & Data Safety
+- [ ] No raw SQL without parameterized queries
+- [ ] Schema migrations use lock timeouts and are reversible
+- [ ] Bulk updates/deletes have verified WHERE clauses
+- [ ] Column updates go through model validations, not direct DB writes
+- [ ] No N+1 queries introduced in hot paths
+- [ ] Indexes exist for new query patterns
+
+### Race Conditions & Concurrency
+- [ ] No read-then-write without optimistic locking or database locks
+- [ ] Unique constraints enforced at database level, not just application
+- [ ] Shared mutable state properly synchronized
+- [ ] Background jobs are idempotent (safe to retry)
+- [ ] No TOCTOU (time-of-check-to-time-of-use) vulnerabilities
+
+### Trust Boundaries
+- [ ] LLM/AI output sanitized before use in SQL, shell, or HTML
+- [ ] User input validated before reaching privileged operations
+- [ ] External API responses validated against expected schema
+- [ ] No deserialization of untrusted data without schema validation
+- [ ] Authentication/authorization checks on all new endpoints
+- [ ] Secrets not hardcoded or logged
+
+## Pass 2 — INFORMATIONAL (non-blocking)
+
+### Conditional Side Effects
+- [ ] Side effects not hidden in conditional branches
+- [ ] State-change callbacks documented and intentional
+- [ ] Error handlers don't silently swallow failures
+
+### Magic Numbers
+- [ ] Numeric literals extracted to named constants
+- [ ] Thresholds and limits documented with rationale
+- [ ] Timeout values appropriate and configurable
+
+### Dead Code
+- [ ] No unreachable branches
+- [ ] No unused imports or variables
+- [ ] No commented-out code without explanation
+
+### Test Gaps
+- [ ] New code paths have test coverage
+- [ ] Modified behavior has updated tests
+- [ ] Edge cases and error paths tested
+- [ ] Integration points have contract tests
+
+### Crypto & Entropy
+- [ ] Cryptographically secure random for security contexts
+- [ ] No hardcoded secrets or API keys
+- [ ] TLS/encryption for sensitive data in transit
+
+### Time Window Safety
+- [ ] Timezone-aware datetime comparisons
+- [ ] Daylight saving transitions handled
+- [ ] Cron expressions account for clock skew
+
+### Type Coercion
+- [ ] No implicit type conversions that lose data
+- [ ] Numeric precision maintained across boundaries
+- [ ] String encoding explicit at I/O boundaries
+
+## Gate Classification
+
+| Category | Severity | Blocking? |
+|----------|----------|-----------|
+| SQL & Data Safety | CRITICAL | Yes |
+| Race Conditions | CRITICAL | Yes |
+| Trust Boundaries | CRITICAL | Yes |
+| All Pass 2 categories | INFORMATIONAL | No |
+
+## Suppressions
+
+Do NOT flag:
+- Test files using test fixtures or factories
+- Migration files following framework conventions
+- Code with inline comments explaining why a flagged pattern is intentional
+- Configuration files with documented values
+- Type stubs or interface definitions

--- a/skills/qa-systematic/SKILL.md
+++ b/skills/qa-systematic/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: qa-systematic
+description: >
+  Systematic web application QA testing with structured issue taxonomy, health
+  scoring, and regression tracking. Use this skill when the user asks for QA
+  testing, systematic testing, smoke testing, regression testing, web app testing,
+  browser testing, or says "QA this", "test the app", "smoke test", "run QA",
+  "systematic test", "check the site", "regression test", "full QA",
+  "/qa-systematic". Supports full, quick, and regression modes.
+metadata:
+  version: 1.0.0
+---
+
+# Systematic QA Testing
+
+## Modes
+
+### Full (default)
+Systematic page-by-page testing, 8-category health score, full issue documentation.
+
+### Quick
+30-second smoke test of critical paths only: login, main nav, primary action.
+
+### Regression
+Diff current state against saved baseline, report new/resolved issues.
+
+## Browser Automation Detection
+
+Detect available automation in priority order:
+
+1. **Playwright MCP server** — check if Playwright tools are available in the current tool list
+2. **`agent-browser` skill** — check if the agent-browser skill is loaded
+3. **Direct CLI tools** — check for `playwright`, `puppeteer`, or `cypress` binaries on PATH
+4. **Manual fallback** — instruct the user to navigate and report observations
+
+Use the highest-priority method available. State which method is in use at the start of the report.
+
+## Workflow
+
+### Phase 1: Initialize
+
+1. Detect mode from user prompt. Default to **full** if unspecified.
+2. Detect application URL:
+   - Check `references/project-detection.md` for framework port conventions (e.g., Next.js → 3000, Vite → 5173, Django → 8000).
+   - If not detectable, ask the user.
+3. Detect available browser automation method (priority list above).
+4. If regression mode: load previous baseline from `.qa-reports/`.
+
+### Phase 2: Authenticate (if needed)
+
+1. Navigate to root URL and check if a login wall is present.
+2. If credentials were provided: authenticate and store session.
+3. If not: ask the user for test credentials, or skip auth-gated pages and note the gap in the report.
+
+### Phase 3: Orient
+
+1. Navigate to root URL.
+2. Map the primary navigation structure — collect all top-level nav links.
+3. Classify each page: static, form, list, detail, dashboard.
+4. Build a test plan ordered by page category (forms and dashboards first — highest defect density).
+
+### Phase 4: Explore (Full mode)
+
+For each page, run the per-page checklist below. In quick mode, run only the items marked with (Q).
+
+#### Visual Scan
+- (Q) Layout renders correctly — no overlap, no overflow
+- Images load — no broken `<img>` tags
+- Typography consistent — no visible font fallbacks
+- Responsive: check at desktop (1280px) and mobile (375px) widths
+
+#### Interactive Elements
+- (Q) All buttons and links are clickable and responsive
+- Hover states present where expected
+- Focus indicators visible for keyboard navigation
+- Disabled states visually distinct
+
+#### Forms
+- (Q) Required field validation fires on empty submit
+- Error messages display on invalid input
+- Success feedback on valid submission
+- Form resubmission handled — no duplicate submissions on double-click
+
+#### Navigation
+- (Q) All nav links resolve — no 404s
+- Back button works as expected
+- Deep links work — direct URL access returns correct page
+- Breadcrumbs accurate (if present)
+
+#### State Management
+- Loading states displayed during async operations
+- Empty states handled — no blank pages when data is absent
+- Error states recoverable — retry or back options present
+- Data persists across navigation — no lost form data on back/forward
+
+#### Console
+- (Q) No JavaScript errors in console
+- No failed network requests (4xx/5xx)
+- No mixed content warnings
+- No deprecation warnings in hot paths
+
+#### Responsiveness
+- Mobile layout usable — no horizontal scroll at 375px
+- Touch targets >= 44px
+- Text readable without zoom (>= 16px body text)
+
+### Phase 5: Document
+
+For each issue found, classify using `references/issue-taxonomy.md`:
+
+- **Severity**: critical (blocks usage), major (degrades experience), minor (cosmetic/polish)
+- **Category**: functional, visual, accessibility, performance, content, navigation, security, console
+- **Evidence**: screenshot description or reproduction steps
+
+Assign a unique ID: `QA-001`, `QA-002`, etc.
+
+Compute health score using the weights defined below and detailed in `references/report-template.md`.
+
+### Phase 6: Wrap Up
+
+1. Generate structured report following `references/report-template.md`.
+2. Save to `.qa-reports/<YYYY-MM-DD>-<mode>.json`.
+3. If full mode: save baseline for future regression comparison.
+4. Present summary: health score, critical/major/minor counts, top 3 priority fixes.
+
+## Health Score
+
+Weighted average across 8 categories, scored 0-100.
+
+| Category       | Weight |
+|----------------|--------|
+| Console errors | 15%    |
+| Broken links   | 10%    |
+| Functional     | 20%    |
+| UX/Usability   | 15%    |
+| Accessibility  | 15%    |
+| Visual         | 10%    |
+| Performance    | 10%    |
+| Content        | 5%     |
+
+**Scoring per category**: start at 100, deduct per issue by severity:
+- Critical: -30
+- Major: -15
+- Minor: -5
+
+Floor at 0. Final health score = weighted sum of category scores.
+
+## Quick Mode Behavior
+
+Run only items marked (Q) in the Phase 4 checklist. Skip health score computation — report pass/fail per critical path. Target completion: 30 seconds of actual testing time.
+
+## Regression Mode Behavior
+
+1. Load the most recent baseline from `.qa-reports/`.
+2. Run full mode.
+3. Diff issues by ID and description similarity.
+4. Report: new issues, resolved issues, persistent issues.
+5. Save updated baseline.

--- a/skills/qa-systematic/evals/cases.yaml
+++ b/skills/qa-systematic/evals/cases.yaml
@@ -1,0 +1,34 @@
+cases:
+  - id: full_qa
+    prompt: "Run a full QA test on the web app at localhost:3000"
+    fixtures: []
+    rubric:
+      - "performs systematic page-by-page testing with structured checklist"
+      - "computes health score across 8 weighted categories"
+      - "produces a structured QA report with issue taxonomy"
+    trigger_expected: true
+
+  - id: smoke_test
+    prompt: "Quick smoke test — just check the critical paths are working"
+    fixtures: []
+    rubric:
+      - "uses quick mode for 30-second critical path verification"
+      - "tests login, main navigation, and primary user actions"
+      - "reports pass/fail without full health score"
+    trigger_expected: true
+
+  - id: unit_tests
+    prompt: "Write unit tests for the user authentication module"
+    fixtures: []
+    rubric:
+      - "does not activate QA testing workflow"
+      - "unit test writing is different from systematic web QA"
+    trigger_expected: false
+
+  - id: load_test
+    prompt: "Run a load test to see how many concurrent users the API can handle"
+    fixtures: []
+    rubric:
+      - "does not activate QA testing workflow"
+      - "load/performance testing is different from functional QA"
+    trigger_expected: false

--- a/skills/qa-systematic/references/issue-taxonomy.md
+++ b/skills/qa-systematic/references/issue-taxonomy.md
@@ -1,0 +1,53 @@
+# QA Issue Taxonomy
+
+## Severity Levels
+
+### Critical
+Issues that block core user workflows or cause data loss.
+- Application crash or unrecoverable error
+- Authentication/authorization failure
+- Data loss or corruption
+- Security vulnerability (XSS, injection, exposed credentials)
+- Core feature completely non-functional
+
+### Major
+Issues that significantly degrade the user experience but have workarounds.
+- Feature partially broken (works in some cases, fails in others)
+- Performance degradation (>3s load time on standard connection)
+- Accessibility barrier (screen reader cannot access core content)
+- Misleading error messages or missing error handling
+- Layout broken on common viewport sizes
+
+### Minor
+Cosmetic issues or polish items that don't affect functionality.
+- Alignment inconsistencies
+- Typos or grammatical errors in UI text
+- Missing hover states or focus indicators
+- Non-standard spacing or padding
+- Console warnings (not errors)
+
+## Categories
+
+### Functional
+Core features and business logic — does the app do what it claims?
+
+### Visual
+Layout, styling, design consistency — does it look correct?
+
+### Accessibility
+Screen reader support, keyboard navigation, color contrast, ARIA — can all users access it?
+
+### Performance
+Load times, interaction responsiveness, resource usage — is it fast enough?
+
+### Content
+Text accuracy, completeness, tone consistency — is the content correct?
+
+### Navigation
+Routing, links, breadcrumbs, back button — can users get where they need to go?
+
+### Security
+Client-side security issues — exposed data, insecure forms, mixed content
+
+### Console
+JavaScript errors, failed requests, deprecation warnings — is the runtime clean?

--- a/skills/qa-systematic/references/project-detection.md
+++ b/skills/qa-systematic/references/project-detection.md
@@ -1,0 +1,179 @@
+# Project Detection Reference
+
+Stack-agnostic project detection patterns for identifying test commands, package managers, version strategies, frameworks, monorepo configurations, and CI/CD systems.
+
+---
+
+## Test Command Resolution
+
+Detect the project's test command by checking these files in order:
+
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
+
+If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
+
+---
+
+## Package Manager Detection
+
+Detect from lock files (most specific wins):
+
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
+
+If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
+
+---
+
+## Version Strategy Detection
+
+Check in order:
+
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
+
+For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
+
+---
+
+## Framework Detection
+
+Detect by analyzing dependencies and configuration files:
+
+### Python
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
+| Starlette | `starlette` in dependencies (without FastAPI) |
+
+### JavaScript/TypeScript
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
+
+### Ruby
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
+
+### Go
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
+
+### Rust
+| Framework | Detection |
+|-----------|-----------|
+| Actix-web | `actix-web` in `Cargo.toml` |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
+
+### Default Ports by Framework
+
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
+
+---
+
+## Monorepo Detection
+
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
+
+For monorepos, scope operations to the relevant workspace/package when a path is specified.
+
+---
+
+## CI/CD Detection
+
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
+
+---
+
+## Changelog Detection
+
+| File | Format |
+|------|--------|
+| `CHANGELOG.md` | Keep a Changelog (most common) |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
+
+Keep a Changelog format:
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+### Changed
+### Fixed
+### Removed
+```

--- a/skills/qa-systematic/references/report-template.md
+++ b/skills/qa-systematic/references/report-template.md
@@ -1,0 +1,52 @@
+# QA Report Template
+
+## Header
+- **Date**: YYYY-MM-DD
+- **Mode**: full | quick | regression
+- **Application URL**: [URL]
+- **Browser automation**: [method used]
+- **Duration**: [time spent]
+
+## Health Score: [0-100] / 100
+
+| Category | Weight | Score | Issues |
+|----------|--------|-------|--------|
+| Console | 15% | /100 | |
+| Links | 10% | /100 | |
+| Functional | 20% | /100 | |
+| UX | 15% | /100 | |
+| Accessibility | 15% | /100 | |
+| Visual | 10% | /100 | |
+| Performance | 10% | /100 | |
+| Content | 5% | /100 | |
+
+## Issues by Severity
+
+### Critical (blocks usage)
+[List or "None found"]
+
+### Major (degrades experience)
+[List or "None found"]
+
+### Minor (cosmetic/polish)
+[List or "None found"]
+
+## Issue Detail
+
+For each issue:
+- **ID**: QA-NNN
+- **Severity**: critical | major | minor
+- **Category**: [from taxonomy]
+- **Page**: [URL or page name]
+- **Description**: [what's wrong]
+- **Expected**: [what should happen]
+- **Actual**: [what actually happens]
+- **Steps to reproduce**: [if applicable]
+
+## Regression Delta (regression mode only)
+- **New issues**: [count]
+- **Resolved issues**: [count]
+- **Persistent issues**: [count]
+
+## Recommendations
+Top 3 priority fixes based on severity x user impact.

--- a/skills/ship-workflow/SKILL.md
+++ b/skills/ship-workflow/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: ship-workflow
+description: >
+  Automated release pipeline that merges main, runs tests, performs pre-landing
+  review, bumps version, updates changelog, creates bisectable commits, and opens
+  a pull request. Use this skill when the user says "ship it", "ship this",
+  "release this", "prepare for release", "open a PR", "push and PR", "land this",
+  "get this ready to ship", "create release", "/ship-workflow". Handles the full
+  lifecycle from pre-flight checks through PR creation.
+metadata:
+  version: 1.0.0
+---
+
+# Ship Workflow
+
+Automated release pipeline that takes a feature branch from working state to
+merged PR. Executes a deterministic sequence of pre-flight checks, testing,
+review, versioning, and PR creation — stopping immediately on any failure with
+specific remediation instructions.
+
+## Pipeline Overview
+
+```
+pre-flight → merge main → test → review → version bump → changelog → bisectable commits → push → PR
+```
+
+Each step has explicit stop conditions. The pipeline never auto-resolves ambiguity.
+
+---
+
+## Step 1: Pre-flight Checks
+
+Run all three checks before proceeding:
+
+1. **Not on default branch** — detect the default branch dynamically:
+   ```bash
+   git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+   ```
+   If the current branch matches: STOP. Instruct the user to create a feature branch.
+
+2. **Clean working tree** — `git status --porcelain` must produce no output.
+   If dirty: STOP. List the uncommitted files and instruct the user to commit or stash.
+
+3. **Up-to-date with remote** — `git fetch origin` then compare local HEAD with
+   `origin/<current-branch>`. If the remote is ahead: STOP. Instruct the user to
+   pull or rebase.
+
+If any check fails, STOP with the specific remediation instruction. Do not proceed.
+
+---
+
+## Step 2: Merge Default Branch
+
+```bash
+git fetch origin
+git merge origin/<default-branch>
+```
+
+- If merge conflicts occur: STOP. Report the conflicting files. Do not auto-resolve.
+- If clean: proceed.
+
+---
+
+## Step 3: Run Tests
+
+Detect the test command from project configuration using `references/project-detection.md`:
+
+| Indicator | Test Command |
+|-----------|-------------|
+| `Makefile` with `test` target | `make test` |
+| `package.json` with `test` script | `<detected-pkg-manager> run test` |
+| `pyproject.toml` with pytest config | `uv run pytest` (or detected runner) |
+| `Cargo.toml` | `cargo test` |
+| `go.mod` | `go test ./...` |
+| `Gemfile` + `Rakefile` | `bundle exec rake test` |
+
+Detection order: check each indicator top-to-bottom; use the first match.
+
+- If tests fail: STOP. Report the failure output. Do not proceed.
+- If no test command detected: warn the user and ask whether to proceed without tests.
+
+---
+
+## Step 4: Pre-Landing Review
+
+Invoke the `pre-landing-review` skill if available. Otherwise, perform a lightweight
+diff review against the default branch:
+
+```bash
+git diff origin/<default-branch>...HEAD
+```
+
+Review the diff for:
+- Obvious bugs or logic errors
+- Security concerns (credentials, injection vectors)
+- Missing error handling on new code paths
+
+Classification:
+- **CRITICAL** findings: STOP. Resolve before proceeding.
+- **INFORMATIONAL** findings: note them for inclusion in the PR description. Proceed.
+
+---
+
+## Step 5: Version Bump
+
+Detect the version strategy from project configuration using `references/project-detection.md`:
+
+| Indicator | Version Location |
+|-----------|-----------------|
+| `VERSION` file | Update file contents directly |
+| `package.json` `version` field | Update the field |
+| `pyproject.toml` `version` field | Update the field |
+| `Cargo.toml` `version` field | Update the field |
+| Git tags only | Create tag at push time |
+
+Default bump level: **PATCH**.
+
+- For **MINOR** or **MAJOR** bumps: STOP. Confirm with the user before proceeding.
+- If no version strategy detected: skip the version bump entirely. Note the skip in
+  the PR description.
+
+---
+
+## Step 6: Update Changelog
+
+- If `CHANGELOG.md` exists: prepend an entry in [Keep a Changelog](https://keepachangelog.com/) format.
+- If no changelog file exists: skip.
+
+Auto-generate the entry from commit messages since the last tag or release. Group
+entries by conventional commit type:
+
+```markdown
+## [<new-version>] - <date>
+
+### Added
+- feat: ...
+
+### Fixed
+- fix: ...
+
+### Changed
+- refactor: ...
+```
+
+---
+
+## Step 7: Create Bisectable Commits
+
+Organize staged changes into logical, bisectable commit groups in this order:
+
+1. **Infrastructure / config changes** — build files, CI config, dependencies
+2. **Models / services / core logic** — domain layer, business rules
+3. **Controllers / views / API endpoints** — presentation and routing
+4. **Version bump + changelog** — always last
+
+Each commit uses a descriptive conventional commit message. Each commit should pass
+tests independently when possible (verify if CI turnaround allows it; otherwise trust
+the ordering).
+
+If all changes are already committed in a reasonable structure, skip reorganization.
+
+---
+
+## Step 8: Push and Create PR
+
+```bash
+git push -u origin <current-branch>
+```
+
+Create the PR:
+
+```bash
+gh pr create \
+  --title "<conventional-format-title>" \
+  --body "<generated-body>"
+```
+
+PR body includes:
+- Summary of changes (grouped by commit)
+- Test results (pass confirmation)
+- Version bump details (old → new, or "skipped")
+- Any INFORMATIONAL findings from Step 4
+
+Output the PR URL as the final result.
+
+---
+
+## Stop Conditions
+
+The pipeline halts immediately and reports when any of these occur:
+
+| Condition | Step | Action |
+|-----------|------|--------|
+| On default branch | 1 | Stop, instruct to create feature branch |
+| Dirty working tree | 1 | Stop, list files, instruct to commit/stash |
+| Behind remote | 1 | Stop, instruct to pull/rebase |
+| Merge conflicts | 2 | Stop, report conflicting files |
+| Test failures | 3 | Stop, report failure output |
+| Critical review findings | 4 | Stop, resolve before proceeding |
+| MINOR/MAJOR version bump | 5 | Stop, confirm with user |
+
+---
+
+## Important Notes
+
+- This skill **modifies the repository**: it creates commits, pushes code, and opens PRs.
+- All branch names and test commands are **detected dynamically** — nothing is hardcoded.
+- The version strategy is **inferred from project files**, not assumed.
+- If the `pre-landing-review` skill is not available, the review step degrades to a
+  lightweight diff scan rather than skipping entirely.

--- a/skills/ship-workflow/evals/cases.yaml
+++ b/skills/ship-workflow/evals/cases.yaml
@@ -1,0 +1,34 @@
+cases:
+  - id: ship_it
+    prompt: "Ship it — merge main, run tests, and open a PR"
+    fixtures: []
+    rubric:
+      - "executes full release pipeline from pre-flight through PR creation"
+      - "detects test command and version strategy from project configuration"
+      - "creates bisectable commits and opens a pull request"
+    trigger_expected: true
+
+  - id: release_with_context
+    prompt: "Get this feature ready to ship. Run the tests, bump the version, and create the PR."
+    fixtures: []
+    rubric:
+      - "performs pre-flight checks before proceeding"
+      - "runs detected test suite and stops on failure"
+      - "bumps version and updates changelog before creating PR"
+    trigger_expected: true
+
+  - id: deploy_to_prod
+    prompt: "Deploy this to production"
+    fixtures: []
+    rubric:
+      - "does not activate ship workflow"
+      - "deployment to production is different from creating a release PR"
+    trigger_expected: false
+
+  - id: version_bump_only
+    prompt: "Bump the version number to 2.0.0"
+    fixtures: []
+    rubric:
+      - "does not activate ship workflow"
+      - "isolated version bump is different from full release pipeline"
+    trigger_expected: false

--- a/skills/ship-workflow/references/project-detection.md
+++ b/skills/ship-workflow/references/project-detection.md
@@ -1,0 +1,179 @@
+# Project Detection Reference
+
+Stack-agnostic project detection patterns for identifying test commands, package managers, version strategies, frameworks, monorepo configurations, and CI/CD systems.
+
+---
+
+## Test Command Resolution
+
+Detect the project's test command by checking these files in order:
+
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
+
+If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
+
+---
+
+## Package Manager Detection
+
+Detect from lock files (most specific wins):
+
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
+
+If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
+
+---
+
+## Version Strategy Detection
+
+Check in order:
+
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
+
+For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
+
+---
+
+## Framework Detection
+
+Detect by analyzing dependencies and configuration files:
+
+### Python
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
+| Starlette | `starlette` in dependencies (without FastAPI) |
+
+### JavaScript/TypeScript
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
+
+### Ruby
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
+
+### Go
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
+
+### Rust
+| Framework | Detection |
+|-----------|-----------|
+| Actix-web | `actix-web` in `Cargo.toml` |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
+
+### Default Ports by Framework
+
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
+
+---
+
+## Monorepo Detection
+
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
+
+For monorepos, scope operations to the relevant workspace/package when a path is specified.
+
+---
+
+## CI/CD Detection
+
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
+
+---
+
+## Changelog Detection
+
+| File | Format |
+|------|--------|
+| `CHANGELOG.md` | Keep a Changelog (most common) |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
+
+Keep a Changelog format:
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+### Changed
+### Fixed
+### Removed
+```

--- a/skills/skill-evaluator/SKILL.md
+++ b/skills/skill-evaluator/SKILL.md
@@ -14,7 +14,7 @@ description: >
   skill fails to activate on relevant queries.
   NOT for evaluating or improving LLM prompts — use prompt-lab instead.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Skill Evaluator
@@ -129,9 +129,14 @@ Evaluates internal consistency and structural integrity.
   the body does not deliver)
 - Consistent terminology throughout (same concept uses same term)
 - No broken internal links or dangling references
+- **Self-containment**: No cross-skill references (`../other-skill/`) in SKILL.md or
+  reference files. Skills must be standalone packages — all referenced files must live
+  within the skill's own directory. Shared content should use the `_templates/` sync
+  system to maintain local copies.
 
 **Scoring constraints:** A name mismatch between directory and frontmatter is a CRITICAL
-finding and caps at 1/5. Missing referenced files cap at 2/5.
+finding and caps at 1/5. Cross-skill `../` references are a CRITICAL finding and cap
+at 1/5 — they break standalone packaging. Missing referenced files cap at 2/5.
 
 ### D6: CONTRIBUTING.md Compliance (8%)
 
@@ -180,6 +185,8 @@ For each skill under evaluation:
    fails, record a CRITICAL finding and score D1 and D6 as 1/5.
 3. Check the `references/` directory for existence and contents. Verify every file
    referenced in the SKILL.md body exists on disk.
+4. Scan SKILL.md and all reference files for cross-skill path references (`../`
+   patterns pointing outside the skill directory). Flag any as CRITICAL D5 findings.
 4. Evaluate each of the 6 dimensions using the criteria above and the detailed rubric
    in `references/evaluation-rubric.md`.
 5. Record findings with severity, dimension tag, description, and recommendation.

--- a/skills/skill-evaluator/references/evaluation-rubric.md
+++ b/skills/skill-evaluator/references/evaluation-rubric.md
@@ -62,11 +62,11 @@ General criteria for the 1-5 scale. Dimension-specific tables below refine these
 
 | Score | Criteria |
 | ----- | -------- |
-| 1 | Directory name does not match frontmatter `name` field (CRITICAL finding) |
+| 1 | Directory name does not match frontmatter `name` field, OR skill contains cross-skill `../` references that break standalone packaging (CRITICAL findings) |
 | 2 | Name matches but 2+ referenced files do not exist on disk, or description promises features the body does not deliver |
 | 3 | Name matches, 1 referenced file missing or 1 description-body mismatch, minor terminology inconsistencies |
-| 4 | Name matches, all referenced files exist, description aligns with body, minor terminology variation |
-| 5 | Name matches directory exactly, all referenced files exist and contain substantive content, description accurately reflects body, consistent terminology throughout |
+| 4 | Name matches, all referenced files exist and are self-contained (no `../` paths), description aligns with body, minor terminology variation |
+| 5 | Name matches directory exactly, all referenced files exist within the skill directory, description accurately reflects body, consistent terminology throughout, fully self-contained |
 
 ### D6: CONTRIBUTING.md Compliance (8%)
 

--- a/tests/test_sync_templates.py
+++ b/tests/test_sync_templates.py
@@ -1,0 +1,104 @@
+"""Tests for scripts/sync_templates.py."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.sync_templates import TEMPLATE_CONSUMERS, sync_template
+
+
+class TestSyncTemplate:
+    """Tests for template synchronization."""
+
+    def test_copies_when_target_missing(self, tmp_path: Path, monkeypatch: object) -> None:
+        import scripts.sync_templates as st
+
+        templates_dir = tmp_path / "_templates"
+        templates_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "skill-a").mkdir()
+
+        source = templates_dir / "test.md"
+        source.write_text("template content")
+
+        monkeypatch.setattr(st, "TEMPLATES_DIR", templates_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "SKILLS_DIR", skills_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "REPO_ROOT", tmp_path)  # type: ignore[attr-defined]
+
+        updated = sync_template("test.md", ["skill-a"])
+
+        target = skills_dir / "skill-a" / "references" / "test.md"
+        assert target.exists()
+        assert target.read_text() == "template content"
+        assert len(updated) == 1
+
+    def test_updates_when_target_differs(self, tmp_path: Path, monkeypatch: object) -> None:
+        import scripts.sync_templates as st
+
+        templates_dir = tmp_path / "_templates"
+        templates_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "skill-a" / "references").mkdir(parents=True)
+
+        source = templates_dir / "test.md"
+        source.write_text("updated content")
+
+        target = skills_dir / "skill-a" / "references" / "test.md"
+        target.write_text("old content")
+
+        monkeypatch.setattr(st, "TEMPLATES_DIR", templates_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "SKILLS_DIR", skills_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "REPO_ROOT", tmp_path)  # type: ignore[attr-defined]
+
+        updated = sync_template("test.md", ["skill-a"])
+
+        assert target.read_text() == "updated content"
+        assert len(updated) == 1
+
+    def test_noop_when_in_sync(self, tmp_path: Path, monkeypatch: object) -> None:
+        import scripts.sync_templates as st
+
+        templates_dir = tmp_path / "_templates"
+        templates_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "skill-a" / "references").mkdir(parents=True)
+
+        source = templates_dir / "test.md"
+        source.write_text("same content")
+
+        target = skills_dir / "skill-a" / "references" / "test.md"
+        target.write_text("same content")
+
+        monkeypatch.setattr(st, "TEMPLATES_DIR", templates_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "SKILLS_DIR", skills_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "REPO_ROOT", tmp_path)  # type: ignore[attr-defined]
+
+        updated = sync_template("test.md", ["skill-a"])
+
+        assert len(updated) == 0
+
+    def test_creates_references_dir(self, tmp_path: Path, monkeypatch: object) -> None:
+        import scripts.sync_templates as st
+
+        templates_dir = tmp_path / "_templates"
+        templates_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "skill-b").mkdir(parents=True)
+
+        source = templates_dir / "test.md"
+        source.write_text("content")
+
+        monkeypatch.setattr(st, "TEMPLATES_DIR", templates_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "SKILLS_DIR", skills_dir)  # type: ignore[attr-defined]
+        monkeypatch.setattr(st, "REPO_ROOT", tmp_path)  # type: ignore[attr-defined]
+
+        sync_template("test.md", ["skill-b"])
+
+        assert (skills_dir / "skill-b" / "references" / "test.md").exists()
+
+    def test_real_templates_registered(self) -> None:
+        """Verify TEMPLATE_CONSUMERS has expected entries."""
+        assert "detection-patterns.md" in TEMPLATE_CONSUMERS
+        assert "humanize" in TEMPLATE_CONSUMERS["detection-patterns.md"]
+        assert "linkedin-post-style" in TEMPLATE_CONSUMERS["detection-patterns.md"]
+        assert "manuscript-review" in TEMPLATE_CONSUMERS["detection-patterns.md"]


### PR DESCRIPTION
## Summary

- **Template sync system** — `_templates/` directory + `scripts/sync_templates.py` + pre-commit hook for managing shared reference files across skills without cross-skill path references
- **Cross-reference fix** — `linkedin-post-style` and `manuscript-review` no longer reference `../humanize/references/detection-patterns.md`; each skill now has its own local copy managed by the sync system
- **5 new skills** generalized from [gstack](https://github.com/garrytan/gstack) into stack-agnostic praxis skills: `engineering-retro`, `plan-review`, `pre-landing-review`, `ship-workflow`, `qa-systematic`
- **skill-evaluator v1.2.0** — D5 (Consistency & Integrity) now flags cross-skill `../` references as CRITICAL findings
- **CONTRIBUTING.md** — new sections for self-containment policy, shared template system, eval case requirements, expanded PR checklist
- **README** — catalog updated with 5 new skills, badge count 44 → 49

## Motivation

Two problems drove this work:

1. **Spec violation**: `linkedin-post-style` and `manuscript-review` used `../humanize/references/detection-patterns.md` — cross-skill references that break standalone packaging (skills are distributed individually via `npx skills add` and `.skill` archives)
2. **Skills opportunity**: 5 gstack skills (retro, plan-ceo-review + plan-eng-review, review, ship, qa) were good candidates for generalization into stack-agnostic praxis skills

The template sync system solves (1) and provides infrastructure for (2), since three of the new skills share a `project-detection.md` reference file.

## New Skills

| Skill | Source | Generalization |
|-------|--------|----------------|
| `engineering-retro` | gstack `retro` | Dynamic branch/timezone detection, configurable time windows, monorepo path scoping, `.engineering-retros/` persistence |
| `plan-review` | gstack `plan-ceo-review` + `plan-eng-review` | Merged product/engineering lenses with mode selection, language-agnostic examples, project-detection integration |
| `pre-landing-review` | gstack `review` + `checklist.md` | Stack-agnostic checklist categories, two-pass CRITICAL/INFORMATIONAL triage, AskUserQuestion interaction protocol |
| `ship-workflow` | gstack `ship` | Project-detection-based test/version/changelog resolution instead of hardcoded commands, dynamic branch detection |
| `qa-systematic` | gstack `qa` | Browser automation detection (Playwright MCP → agent-browser → CLI → manual), generic persistence, project-detection for URL/port |

## Template Sync System

```
_templates/detection-patterns.md  →  humanize, linkedin-post-style, manuscript-review
_templates/project-detection.md   →  ship-workflow, plan-review, qa-systematic
```

- `scripts/sync_templates.py` copies templates to `skills/{consumer}/references/{template}`
- Pre-commit hook triggers on `^(_templates/|skills/.*/references/)` changes
- Exit 0 = in sync, exit 1 = files updated (forces re-staging)

## Commit Sequence (11 commits)

| # | Message | Scope |
|---|---------|-------|
| 1 | `feat: add template sync infrastructure for shared reference files` | `_templates/`, sync script, tests, pre-commit |
| 2 | `fix: resolve cross-skill references in linkedin-post-style and manuscript-review` | SKILL.md fixes + local detection-patterns copies |
| 3 | `feat(engineering-retro): add git-based retrospective skill` | full skill dir + evals |
| 4 | `feat: add project-detection template for stack-agnostic skills` | `_templates/project-detection.md` |
| 5 | `feat(plan-review): add pre-implementation plan audit skill` | full skill dir + evals + synced reference |
| 6 | `feat(pre-landing-review): add checklist-driven safety audit skill` | full skill dir + checklist + evals |
| 7 | `feat(ship-workflow): add automated release pipeline skill` | full skill dir + evals + synced reference |
| 8 | `feat(qa-systematic): add systematic web QA testing skill` | full skill dir + taxonomy + report template + evals |
| 9 | `chore: regenerate manifest for 5 new skills` | `skills.yaml` (44 → 49) |
| 10 | `feat(skill-evaluator): add self-containment check to D5 integrity dimension` | evaluator SKILL.md + rubric |
| 11 | `docs: add self-containment rules, template system, and eval requirements` | CONTRIBUTING.md + README.md |

## Validation

- `uv run pytest` — 70 tests passed (65 existing + 5 new sync template tests)
- `uv run python scripts/validate_evals.py` — 49 eval files validated
- `uv run python scripts/sync_templates.py` — all templates in sync
- `uv run python scripts/generate_manifest.py` — 49 skills in manifest
- `grep -r '\.\./humanize' skills/` — empty (no cross-skill references)

## Test plan

- [ ] `uv run pytest` — all 70 tests pass
- [ ] `uv run python scripts/validate_evals.py` — 49 eval files valid
- [ ] `uv run python scripts/sync_templates.py` — exit 0 (all in sync)
- [ ] `uv run python scripts/generate_manifest.py` — generates 49 skills
- [ ] `grep -r '\.\.\/' skills/*/SKILL.md` — no cross-skill references
- [ ] Verify each new skill has valid frontmatter, evals, and references
- [ ] Run skill-evaluator against a skill with `../` reference to confirm CRITICAL flag