### PR TITLE
feat(research-critique): add research paper critique skill

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -377,6 +377,18 @@ skills:
     and public.'
   path: skills/repo-sentinel
   source: https://github.com/Mathews-Tom/armory/blob/main/skills/repo-sentinel/SKILL.md
+- name: research-critique
+  version: 1.0.0
+  description: 'Critical analysis of research papers, academic manuscripts, preprints, and technical studies — evaluating
+    methodology, claims-evidence alignment, contribution significance, and intellectual honesty. Produces coherent analytical
+    responses (not checklists) that distinguish genuine weaknesses from standard field limitations. Governs intellectual posture:
+    collegial reader, not adversarial reviewer. Triggers on: "critique this paper", "review this research", "what do you think
+    of this paper", "analyze this study", "evaluate the methodology", "is this paper sound", "assess this research", "strengths
+    and weaknesses of this paper", "does the evidence support the claims". Use this skill when the user provides a research
+    paper, preprint, or technical study and asks for critical evaluation of its scientific merit, methodology, or contribution
+    — not formatting, citation hygiene, or submission readiness (use manuscript-review for those).'
+  path: skills/research-critique
+  source: https://github.com/Mathews-Tom/armory/blob/main/skills/research-critique/SKILL.md
 - name: sequential-thinking
   version: 1.1.0
   description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through

--- a/skills/research-critique/SKILL.md
+++ b/skills/research-critique/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: research-critique
+description: >
+  Critical analysis of research papers, academic manuscripts, preprints, and
+  technical studies — evaluating methodology, claims-evidence alignment,
+  contribution significance, and intellectual honesty. Produces coherent
+  analytical responses (not checklists) that distinguish genuine weaknesses from
+  standard field limitations. Governs intellectual posture: collegial reader, not
+  adversarial reviewer. Triggers on: "critique this paper", "review this
+  research", "what do you think of this paper", "analyze this study", "evaluate
+  the methodology", "is this paper sound", "assess this research", "strengths
+  and weaknesses of this paper", "does the evidence support the claims". Use
+  this skill when the user provides a research paper, preprint, or technical
+  study and asks for critical evaluation of its scientific merit, methodology, or
+  contribution — not formatting, citation hygiene, or submission readiness
+  (use manuscript-review for those).
+metadata:
+  version: 1.0.0
+---
+
+# Research Paper Critique
+
+## Purpose
+
+Critically evaluate research papers as an engaged, intellectually honest colleague — not an adversarial reviewer generating decorative objections. The goal is understanding what a paper contributes, whether the evidence supports the claims, and where genuine tension exists between what is demonstrated and what is argued.
+
+## The failure mode you must avoid
+
+The default behavior when critiquing a paper is adversarial credentialism: treating the paper as something to defeat, generating a volume of objections to demonstrate rigor, and mistaking the enumeration of limitations for insight. This produces critiques that are shallow, performative, and often incoherent — holding papers to standards that no published work in the field meets, demanding ablations that would constitute separate papers, and flagging limitations the author already disclosed as if discovering them.
+
+The tell: if you retreat easily from a point when challenged, you were never committed to it. It was decorative, not substantive. Do not generate points you would abandon under pressure.
+
+## Analytical principles
+
+### 1. Understand before you evaluate
+
+Read the paper as the author intended it. What problem does it identify? What is the proposed mechanism or contribution? What is the experimental design trying to isolate? What claims does the paper actually make, versus what you assume it is claiming?
+
+Most bad critiques attack a paper the author did not write. Get the real paper straight first.
+
+### 2. Proportionality
+
+Every empirical paper has limitations. Uncontrolled confounds, limited domains, incomplete ablations, finite sample sizes. These exist in every paper ever published, including the landmarks of the field. Listing them is not critique. The question is always: **does this limitation actually undermine the paper's specific contribution?**
+
+A limitation that the author discloses, contextualizes, and accounts for in their claims is not a flaw you discovered. A limitation that would require a different experiment entirely to resolve is not a flaw — it is future work. A limitation that exists in every comparable study is not a differentiating weakness.
+
+Weight your critique by consequence. A confound that could fully explain the main result matters. A confound that affects a secondary finding the paper does not emphasize does not.
+
+### 3. No phantom standards
+
+Do not hold the paper against an imaginary ideal that nothing in the field achieves. Before asserting that the paper should have done X, ask: does any comparable work do X? If the answer is no, then you are requesting a methodological advance, not identifying a flaw. Name it as such.
+
+The implicit comparison should be the realistic state of the field, not a platonic ideal of experimental design.
+
+### 4. Mechanism versus evidence
+
+Many papers propose a mechanism (why something works) and provide evidence (that it works). These are different claims with different standards. The evidence can be solid while the mechanistic story is underdetermined. This is normal and nearly universal in empirical work.
+
+When critiquing the mechanism: identify what alternative explanations the data cannot distinguish between. Do not substitute your preferred alternative mechanism and assert it is "likely" doing the work — that is the same sin as the paper's, just pointing the other direction. If you cannot separate two explanations, say so honestly rather than privileging one.
+
+### 5. Scope is not a weakness
+
+A paper that tests in one domain and theorizes about generality is doing what papers do. The theory predicts what should happen elsewhere. Someone else can test it. Demanding that a single paper demonstrate generality across all domains it might apply to is demanding a research program, not a paper. Critique the scope if the paper overclaims relative to its evidence. Do not critique it for having a scope.
+
+### 6. What survives
+
+After your analysis, state clearly: what does this paper contribute that holds up? What finding, if confirmed, would the field benefit from knowing? Default to identifying the contribution, not to dismissal. A paper that advances understanding in a limited domain with honest limitations is a good paper. Say so.
+
+## Output structure
+
+Do not produce a numbered checklist of weaknesses. Instead, write a coherent analytical response that:
+
+- Opens with what the paper is doing and why it matters (or does not)
+- Identifies where the evidence genuinely supports the claims
+- Identifies where the claims outrun the evidence, with specificity about _why_ and _how much_
+- Distinguishes between limitations that threaten the core contribution and limitations that are standard for the field
+- Closes with an honest assessment of what survives scrutiny
+
+Tone: engaged, direct, respectful of the intellectual effort. You are a colleague reading carefully, not an adversary scanning for weaknesses.
+
+### Worked excerpt
+
+The following shows the expected tone and structure — not a template to fill in.
+
+> This paper proposes that chain-of-thought prompting improves arithmetic reasoning primarily through decomposition rather than retrieval, testing across three digit-multiplication benchmarks. The core evidence is solid: the ablation removing intermediate steps while preserving final-answer prompting shows a consistent 12-18% accuracy drop across all three benchmarks, which directly supports the decomposition hypothesis.
+>
+> Where the paper strains is the mechanistic claim. The authors argue decomposition works by reducing working-memory load per step, but their experiments cannot distinguish this from an alternative: that intermediate steps simply provide more surface-level pattern matches for the model. Both explanations predict the same ablation result. The authors acknowledge this briefly in Section 6 but frame it as a minor caveat — it is more central than that, because the working-memory interpretation drives their recommendations for prompt design, and those recommendations do not follow if pattern-matching is the operative mechanism.
+>
+> The single-domain scope (digit multiplication) is a standard limitation, not a differentiating weakness — no comparable study tests across arithmetic subtypes either. The sample size concern (n=500 per condition) is adequately powered for the effect sizes reported.
+>
+> What survives: the empirical finding that intermediate steps are load-bearing for accuracy is well-supported and useful. The mechanistic interpretation is underdetermined but honestly so — the paper would be stronger if it presented both explanations as open rather than favoring one.
+
+## Calibration check
+
+Before finalizing your critique, verify each point against these filters:
+
+- **Commitment test:** Would you abandon this point if pushed? If yes, cut it. Only include points you would defend.
+- **Disclosure check:** Is the author already addressing this in their limitations? If so, either explain why their treatment is insufficient or drop the point.
+- **Scope creep:** Are you demanding this paper be a different paper? A longer paper? A paper that also solves adjacent problems? If so, recalibrate.
+- **Field-level vs paper-level:** Does your critique apply equally to most papers in the field? If so, it is not a critique of this paper — it is a critique of the field. Name it as such or drop it.
+- **Contribution identified:** Have you stated what the paper actually contributes, or only what it fails to do?
+
+## Edge cases
+
+Not every input is a full empirical paper. Adapt the posture rather than refusing.
+
+| Input | Adaptation |
+|-------|------------|
+| Abstract only, no full text | Critique the claims-to-evidence ratio visible in the abstract. State explicitly what cannot be evaluated without the full paper. Do not fabricate methodology concerns you cannot verify. |
+| Position paper or opinion piece | The mechanism-vs-evidence framework does not apply. Evaluate the argument's internal coherence, whether it engages with the strongest counterarguments, and whether it advances the discourse beyond restating known positions. |
+| Survey or review article | Evaluate coverage, selection bias in cited work, whether the taxonomy or framework imposed adds clarity or distorts, and whether the synthesis produces insight beyond summarizing individual papers. |
+| Theoretical or mathematical work | Replace empirical standards with proof validity, assumption reasonableness, and whether the theoretical contribution connects to phenomena anyone cares about. Proportionality still applies — do not demand empirical validation of a theorem. |
+| Non-English paper or machine translation | Evaluate substance, not prose quality. Flag where translation ambiguity makes a claim unclear, but do not penalize phrasing. |
+| User provides their own paper for self-critique | Shift from third-person analysis to second-person guidance. Prioritize actionable revisions over assessment. Identify the strongest and weakest sections explicitly. |

--- a/skills/research-critique/evals/cases.yaml
+++ b/skills/research-critique/evals/cases.yaml
@@ -1,0 +1,48 @@
+cases:
+  - id: critique_paper_general
+    prompt: "Critique this paper on transformer attention mechanisms"
+    fixtures: []
+    rubric:
+      - "produces a coherent analytical response, not a numbered checklist of weaknesses"
+      - "identifies what the paper contributes before identifying weaknesses"
+      - "distinguishes between core-threatening limitations and standard field limitations"
+    trigger_expected: true
+
+  - id: evaluate_methodology
+    prompt: "Is the methodology in this study sound? The sample size is small but the effect sizes are large"
+    fixtures: []
+    rubric:
+      - "evaluates whether the limitation undermines the specific contribution"
+      - "applies proportionality — does not treat small sample size as automatic disqualification"
+      - "considers the realistic state of the field, not a platonic ideal"
+    trigger_expected: true
+
+  - id: assess_research_claims
+    prompt: "Does the evidence in this preprint actually support what the authors claim?"
+    fixtures: []
+    rubric:
+      - "separates mechanism claims from evidence claims"
+      - "identifies where claims outrun evidence with specificity"
+      - "closes with an honest assessment of what survives"
+    trigger_expected: true
+
+  - id: pre_submission_formatting
+    prompt: "Check the formatting and citations in my paper before I submit it"
+    fixtures: []
+    rubric:
+      - "formatting and citation hygiene is manuscript-review territory, not research critique"
+    trigger_expected: false
+
+  - id: write_literature_review
+    prompt: "Write a literature review section about reinforcement learning from human feedback"
+    fixtures: []
+    rubric:
+      - "writing new manuscript content is outside critique scope"
+    trigger_expected: false
+
+  - id: provenance_check
+    prompt: "Verify that the figures in my manuscript are generated from the analysis scripts"
+    fixtures: []
+    rubric:
+      - "computational provenance verification is manuscript-provenance territory, not research critique"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

- Add **research-critique** skill for critically evaluating research papers, preprints, and technical studies
- Posture-driven skill (intellectual approach, not procedural checklist) that governs how Claude analyzes academic work — collegial reader over adversarial reviewer
- Distinct from `manuscript-review` (pre-publication audit: formatting, citations, submission readiness) and `manuscript-provenance` (computational reproducibility verification)

## Skill contents

### SKILL.md (v1.0.0)

| Section | Purpose |
|---------|---------|
| Purpose | Defines the collegial-reader posture |
| Failure mode | Anti-pattern documentation — adversarial credentialism, decorative objections |
| 6 Analytical principles | Understand before evaluating, proportionality, no phantom standards, mechanism vs evidence, scope is not a weakness, what survives |
| Output structure | Coherent analytical prose (not numbered weakness checklists), with worked excerpt demonstrating tone and structure |
| Calibration check | 5 self-filters: commitment test, disclosure check, scope creep, field-level vs paper-level, contribution identified |
| Edge cases | Adaptation table for 6 non-standard inputs: abstract-only, position papers, surveys, theoretical work, translations, self-critique |

### Frontmatter description

- ~850 characters, 9 trigger phrases across 5 synonym families (critique/review/analyze/evaluate/assess)
- Imperative and interrogative forms covered
- Explicit negative boundary clause routing formatting/citation/submission queries to `manuscript-review`

### Eval cases (evals/cases.yaml)

| ID | Type | Tests |
|----|------|-------|
| `critique_paper_general` | positive | Coherent response, contribution-first, limitation classification |
| `evaluate_methodology` | positive | Proportionality, field-realistic standards |
| `assess_research_claims` | positive | Mechanism/evidence separation, what-survives assessment |
| `pre_submission_formatting` | negative | Boundary: routes to manuscript-review |
| `write_literature_review` | negative | Boundary: content creation out of scope |
| `provenance_check` | negative | Boundary: routes to manuscript-provenance |

### Manifest

- `skills.yaml` regenerated (51 skills)

## Skill evaluator scorecard

| Dimension | Score | Key Finding |
|-----------|-------|-------------|
| D1: Frontmatter Quality | 4.5/5 | 9 triggers, "Use this skill when..." clause; slightly over 800-char sweet spot |
| D2: Trigger Coverage | 5/5 | 5 synonym families, imperative + interrogative, implied context |
| D3: Structural Completeness | 5/5 | Workflow, output format, calibration rules, edge case table |
| D4: Content Depth | 4.5/5 | Deep decision frameworks, worked excerpt, calibration check |
| D5: Consistency & Integrity | 5/5 | Name matches directory, no broken refs, description aligns with body |
| D6: CONTRIBUTING Compliance | 5/5 | Full compliance |
| **Overall** | **95.8% — Exemplary** | No CRITICAL or HIGH findings |

## Validation

- `uv run python scripts/validate_evals.py` — 51 eval files passed
- `uv run python scripts/generate_manifest.py` — 51 skills
- `uv run pytest tests/ -q` — 81 tests passed

## Test plan

- [ ] Load skill locally: `claude --add-dir skills/research-critique`
- [ ] Test positive trigger: "Critique this paper on transformer attention mechanisms"
- [ ] Test negative boundary: "Check the formatting and citations in my paper before I submit it" (should NOT activate)
- [ ] Verify edge case handling: provide an abstract-only input and confirm adapted response
- [ ] Confirm manifest includes `research-critique` entry with correct version and description