### PR TITLE
feat: add literature review packages (arxiv-search, literature-review, research preset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # armory
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 69](https://img.shields.io/badge/packages-69-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 72](https://img.shields.io/badge/packages-72-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 
 Curated, production-grade skills, agents, hooks, rules, commands, utilities, and presets for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -39,10 +39,11 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 
 | Skill                                        | Description                                                                                                                                                       |
 | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [youtube-search](skills/youtube-search/)     | Search YouTube by keyword via yt-dlp — returns structured metadata (title, URL, channel, views, duration, date) for discovery and source curation                 |
-| [youtube-analysis](skills/youtube-analysis/) | YouTube video transcript extraction and structured concept analysis — multi-level summaries, key concepts, takeaways, no API keys required                        |
-| [notebooklm](skills/notebooklm/)             | Google NotebookLM automation via notebooklm-py — create notebooks, add sources, chat, generate podcasts, videos, infographics, quizzes, flashcards, and more      |
-| [immune](skills/immune/)                     | Hybrid adaptive memory with Cheatsheet (positive patterns) and Immune (negative patterns) — Hot/Cold tiered memory, multi-domain antibody scanning, auto-learning |
+| [literature-review](skills/literature-review/) | Systematic literature review — search, screen, extract, and synthesize academic research with gap analysis and structured citations                              |
+| [youtube-search](skills/youtube-search/)       | Search YouTube by keyword via yt-dlp — returns structured metadata (title, URL, channel, views, duration, date) for discovery and source curation               |
+| [youtube-analysis](skills/youtube-analysis/)   | YouTube video transcript extraction and structured concept analysis — multi-level summaries, key concepts, takeaways, no API keys required                      |
+| [notebooklm](skills/notebooklm/)               | Google NotebookLM automation via notebooklm-py — create notebooks, add sources, chat, generate podcasts, videos, infographics, quizzes, flashcards, and more    |
+| [immune](skills/immune/)                       | Hybrid adaptive memory with Cheatsheet (positive patterns) and Immune (negative patterns) — Hot/Cold tiered memory, multi-domain antibody scanning, auto-learning |
 
 ### Skills — Review & Quality
 
@@ -154,16 +155,18 @@ Skills below are superseded by base model capabilities. They remain installable 
 
 | Utility                                                 | Description                        |
 | ------------------------------------------------------- | ---------------------------------- |
-| [dependency-tree](utilities/dependency-tree/)           | Visualize project dependency graph |
-| [test-coverage-report](utilities/test-coverage-report/) | Coverage summary for changed files |
+| [arxiv-search](utilities/arxiv-search/)                 | Search arXiv for papers, output structured JSON metadata    |
+| [dependency-tree](utilities/dependency-tree/)           | Visualize project dependency graph                          |
+| [test-coverage-report](utilities/test-coverage-report/) | Coverage summary for changed files                          |
 
 ## Presets
 
 | Preset                                    | Description                                  |
 | ----------------------------------------- | -------------------------------------------- |
-| [core](presets/core/)                     | Essential skills + git safety for every user |
-| [python-strict](presets/python-strict/)   | Full Python enforcement stack                |
-| [security-first](presets/security-first/) | Security auditing and enforcement            |
+| [core](presets/core/)                     | Essential skills + git safety for every user  |
+| [python-strict](presets/python-strict/)   | Full Python enforcement stack                 |
+| [research](presets/research/)             | Academic research and manuscript workflow      |
+| [security-first](presets/security-first/) | Security auditing and enforcement             |
 
 ---
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -238,6 +238,25 @@ packages:
       Mermaid diagrams), custom images (via concept-to-image), or animations (via concept-to-video).
     path: skills/linkedin-post-style
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/linkedin-post-style/SKILL.md
+  - name: literature-review
+    version: 1.0.0
+    description: 'Systematic literature review workflow for surveying, synthesizing, and analyzing a body of academic research
+      across a defined topic or research question. Covers the full review lifecycle: defining scope and inclusion criteria,
+      searching academic databases (arXiv via arxiv-search utility, Semantic Scholar, Google Scholar via web search), screening
+      and filtering results, extracting structured findings, thematic synthesis, gap identification, and producing a structured
+      review document with proper citations. Use this skill when you need to survey a research area, map the landscape of
+      a topic, identify research gaps, build a bibliography, compare methodologies across studies, write a related work section,
+      conduct a systematic review, perform a scoping review, or synthesize findings across multiple papers. Triggers on: "literature
+      review", "survey the literature", "what has been published on", "research landscape", "related work", "systematic review",
+      "scoping review", "map the research on", "what do we know about", "synthesize the research", "compare approaches to",
+      "bibliography on", "find papers about", "review the state of the art", "what are the key papers on", "research gap analysis".'
+    path: skills/literature-review
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/literature-review/SKILL.md
+    complements:
+    - arxiv-search
+    - research-critique
+    - manuscript-review
+    - manuscript-provenance
   - name: manuscript-provenance
     version: 1.1.0
     description: 'Computational provenance audit verifying that every number, table, figure, ordering, and terminology in
@@ -249,6 +268,8 @@ packages:
       outputs.'
     path: skills/manuscript-provenance
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-provenance/SKILL.md
+    complements:
+    - literature-review
   - name: manuscript-review
     version: 1.2.1
     description: Systematic pre-publication manuscript audit producing a structured refactoring report with section-level
@@ -261,6 +282,8 @@ packages:
       was asked about.
     path: skills/manuscript-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-review/SKILL.md
+    complements:
+    - literature-review
   - name: mcp-to-skill
     version: 1.1.0
     description: 'Convert MCP (Model Context Protocol) servers into on-demand skills to dramatically reduce active context
@@ -424,6 +447,8 @@ packages:
       or contribution — not formatting, citation hygiene, or submission readiness (use manuscript-review for those).'
     path: skills/research-critique
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/research-critique/SKILL.md
+    complements:
+    - literature-review
   - name: sequential-thinking
     version: 1.1.0
     description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through
@@ -667,6 +692,20 @@ packages:
     path: commands/tdd
     source: https://github.com/Mathews-Tom/armory/blob/main/commands/tdd/COMMAND.md
   utilities:
+  - name: arxiv-search
+    version: 1.0.0
+    description: Searches arXiv for academic papers by keyword, author, title, or category and outputs structured JSON with
+      full metadata (title, authors, abstract, dates, categories, DOI, PDF URL). Supports field-prefixed queries (au:, ti:,
+      abs:, cat:), sorting by relevance/date, result limits, and direct ID lookup. Use this utility when you need to discover
+      research papers, build a reading list, gather references for a literature review, fetch paper metadata by arXiv ID,
+      or survey recent publications in a research area. Complements research-critique (per-paper analysis) and literature-review
+      (multi-paper synthesis).
+    path: utilities/arxiv-search
+    source: https://github.com/Mathews-Tom/armory/blob/main/utilities/arxiv-search/UTILITY.md
+    runtime: python
+    complements:
+    - literature-review
+    - research-critique
   - name: dependency-tree
     version: 1.0.0
     description: Parses project dependency configuration files (pyproject.toml, package.json, go.mod) and prints a formatted
@@ -704,6 +743,14 @@ packages:
       install.'
     path: presets/python-strict
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/python-strict/PRESET.md
+  - name: research
+    version: 1.0.0
+    description: Complete academic research workflow for Claude Code. Bundles literature discovery (arXiv search), systematic
+      literature review, single-paper critical analysis, manuscript pre-publication audit, and computational provenance verification
+      into a single install. Covers the full research lifecycle from surveying a field through writing and validating a manuscript.
+      Use this preset when setting up a research project, academic writing environment, or scholarly review workflow.
+    path: presets/research
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/research/PRESET.md
   - name: security-first
     version: 1.0.0
     description: Security-focused preset for projects requiring audit-grade protection. Extends the core review-commit lifecycle

--- a/presets/research/PRESET.md
+++ b/presets/research/PRESET.md
@@ -1,0 +1,72 @@
+---
+name: research
+type: preset
+description: >
+  Complete academic research workflow for Claude Code. Bundles literature discovery
+  (arXiv search), systematic literature review, single-paper critical analysis,
+  manuscript pre-publication audit, and computational provenance verification into
+  a single install. Covers the full research lifecycle from surveying a field through
+  writing and validating a manuscript. Use this preset when setting up a research
+  project, academic writing environment, or scholarly review workflow.
+metadata:
+  version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: literature-review
+      - name: research-critique
+      - name: manuscript-review
+      - name: manuscript-provenance
+    utilities:
+      - name: arxiv-search
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# Research Preset
+
+An end-to-end scholarly workflow for discovering, evaluating, synthesizing, and publishing
+academic research.
+
+## Included Packages
+
+| Type    | Package              | Role                                                     |
+| ------- | -------------------- | -------------------------------------------------------- |
+| Utility | arxiv-search         | Search arXiv for papers, retrieve structured metadata    |
+| Skill   | literature-review    | Systematic review: search, screen, extract, synthesize   |
+| Skill   | research-critique    | Critical analysis of a single paper's merit              |
+| Skill   | manuscript-review    | Pre-publication audit of formatting, structure, citations |
+| Skill   | manuscript-provenance| Verify manuscript numbers trace to computational outputs |
+
+## Workflow
+
+1. **Discover** — Use `arxiv-search` to find papers on a topic. Query by keyword,
+   author, category, or specific arXiv IDs.
+2. **Survey** — Use `literature-review` to systematically screen, extract, and synthesize
+   findings across the discovered papers. Produces thematic reviews, comparison tables,
+   or gap analyses.
+3. **Evaluate** — Use `research-critique` for deep analysis of individual papers —
+   methodology, claims-evidence alignment, contribution significance.
+4. **Write** — Draft manuscript with the context and citations gathered in prior steps.
+5. **Audit** — Use `manuscript-review` for a 24-checkpoint pre-submission audit covering
+   structure, citation hygiene, prose quality, and AI-pattern detection.
+6. **Verify** — Use `manuscript-provenance` to confirm every number, table, and figure
+   in the manuscript traces to code and computational outputs.
+
+## When to Use
+
+- Research projects requiring systematic literature surveys.
+- Academic writing workflows from literature review to submission.
+- Thesis chapters or dissertation work.
+- Conference/journal paper preparation.
+- Grant proposal background research.
+
+## Dependencies
+
+The `arxiv-search` utility requires the `arxiv` Python package:
+
+```bash
+uv pip install arxiv
+```
+
+All other packages are prompt-only skills with no additional dependencies.

--- a/presets/research/evals/cases.yaml
+++ b/presets/research/evals/cases.yaml
@@ -1,0 +1,29 @@
+cases:
+  - id: install_research_workflow
+    prompt: "I need to set up my environment for academic research and paper writing"
+    fixtures: []
+    rubric:
+      - "installs all five research packages as a bundle"
+      - "covers discovery, review, critique, manuscript audit, and provenance"
+    trigger_expected: true
+
+  - id: thesis_setup
+    prompt: "I'm starting my thesis — what packages do I need for literature review and writing?"
+    fixtures: []
+    rubric:
+      - "recommends the research preset as a complete scholarly workflow"
+    trigger_expected: true
+
+  - id: negative_code_review
+    prompt: "Set up my environment for code review and pull requests"
+    fixtures: []
+    rubric:
+      - "code review workflows are covered by the core preset, not research"
+    trigger_expected: false
+
+  - id: negative_security_audit
+    prompt: "I need security scanning and dependency auditing tools"
+    fixtures: []
+    rubric:
+      - "security tooling is covered by the security-first preset, not research"
+    trigger_expected: false

--- a/skills.yaml
+++ b/skills.yaml
@@ -233,6 +233,25 @@ skills:
     diagrams), custom images (via concept-to-image), or animations (via concept-to-video).
   path: skills/linkedin-post-style
   source: https://github.com/Mathews-Tom/armory/blob/main/skills/linkedin-post-style/SKILL.md
+- name: literature-review
+  version: 1.0.0
+  description: 'Systematic literature review workflow for surveying, synthesizing, and analyzing a body of academic research
+    across a defined topic or research question. Covers the full review lifecycle: defining scope and inclusion criteria,
+    searching academic databases (arXiv via arxiv-search utility, Semantic Scholar, Google Scholar via web search), screening
+    and filtering results, extracting structured findings, thematic synthesis, gap identification, and producing a structured
+    review document with proper citations. Use this skill when you need to survey a research area, map the landscape of a
+    topic, identify research gaps, build a bibliography, compare methodologies across studies, write a related work section,
+    conduct a systematic review, perform a scoping review, or synthesize findings across multiple papers. Triggers on: "literature
+    review", "survey the literature", "what has been published on", "research landscape", "related work", "systematic review",
+    "scoping review", "map the research on", "what do we know about", "synthesize the research", "compare approaches to",
+    "bibliography on", "find papers about", "review the state of the art", "what are the key papers on", "research gap analysis".'
+  path: skills/literature-review
+  source: https://github.com/Mathews-Tom/armory/blob/main/skills/literature-review/SKILL.md
+  complements:
+  - arxiv-search
+  - research-critique
+  - manuscript-review
+  - manuscript-provenance
 - name: manuscript-provenance
   version: 1.1.0
   description: 'Computational provenance audit verifying that every number, table, figure, ordering, and terminology in a
@@ -243,6 +262,8 @@ skills:
     against scripts", "provenance audit", or any request to verify that manuscript content traces back to computational outputs.'
   path: skills/manuscript-provenance
   source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-provenance/SKILL.md
+  complements:
+  - literature-review
 - name: manuscript-review
   version: 1.2.1
   description: Systematic pre-publication manuscript audit producing a structured refactoring report with section-level diagnostics,
@@ -254,6 +275,8 @@ skills:
     work" — the full diagnostic surfaces issues across all facets even when only one was asked about.
   path: skills/manuscript-review
   source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-review/SKILL.md
+  complements:
+  - literature-review
 - name: mcp-to-skill
   version: 1.1.0
   description: 'Convert MCP (Model Context Protocol) servers into on-demand skills to dramatically reduce active context window
@@ -416,6 +439,8 @@ skills:
     — not formatting, citation hygiene, or submission readiness (use manuscript-review for those).'
   path: skills/research-critique
   source: https://github.com/Mathews-Tom/armory/blob/main/skills/research-critique/SKILL.md
+  complements:
+  - literature-review
 - name: sequential-thinking
   version: 1.1.0
   description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: literature-review
+description: >
+  Systematic literature review workflow for surveying, synthesizing, and analyzing
+  a body of academic research across a defined topic or research question. Covers
+  the full review lifecycle: defining scope and inclusion criteria, searching
+  academic databases (arXiv via arxiv-search utility, Semantic Scholar, Google
+  Scholar via web search), screening and filtering results, extracting structured
+  findings, thematic synthesis, gap identification, and producing a structured
+  review document with proper citations. Use this skill when you need to survey
+  a research area, map the landscape of a topic, identify research gaps, build
+  a bibliography, compare methodologies across studies, write a related work
+  section, conduct a systematic review, perform a scoping review, or synthesize
+  findings across multiple papers. Triggers on: "literature review", "survey
+  the literature", "what has been published on", "research landscape", "related
+  work", "systematic review", "scoping review", "map the research on", "what
+  do we know about", "synthesize the research", "compare approaches to",
+  "bibliography on", "find papers about", "review the state of the art",
+  "what are the key papers on", "research gap analysis".
+metadata:
+  version: 1.0.0
+  complements:
+    - arxiv-search
+    - research-critique
+    - manuscript-review
+    - manuscript-provenance
+---
+
+# Literature Review
+
+Systematic discovery, extraction, and synthesis of academic research on a defined topic.
+
+## When to use this skill vs. others
+
+| Need | Skill |
+|------|-------|
+| Survey a research area, synthesize multiple papers | **literature-review** (this skill) |
+| Critique a single paper's methodology and claims | research-critique |
+| Audit a manuscript's formatting, structure, citations | manuscript-review |
+| Verify a manuscript's numbers trace to code | manuscript-provenance |
+| Search arXiv for papers matching a query | arxiv-search (utility) |
+
+## Workflow
+
+### Phase 1: Scope Definition
+
+Before searching, establish the review boundaries:
+
+1. **Research question** — What specific question does the review answer? Vague topics produce vague reviews. "What techniques exist for X" is weaker than "How do methods for X compare on metric Y across domains Z?"
+2. **Inclusion criteria** — Define what counts:
+   - Date range (e.g., 2020–present)
+   - Publication type (peer-reviewed, preprints, both)
+   - Domains/categories (e.g., cs.CL, cs.AI)
+   - Minimum relevance threshold
+3. **Exclusion criteria** — Define what does not count:
+   - Tangentially related work
+   - Non-primary sources (blog posts, tutorials) unless explicitly included
+   - Duplicate or superseded versions
+4. **Expected output** — What form should the review take? Narrative synthesis, tabular comparison, gap analysis, annotated bibliography, or related-work section?
+
+Present the scope to the user for confirmation before proceeding.
+
+### Phase 2: Search & Discovery
+
+Execute searches across available sources. Use multiple queries with varying specificity to avoid single-query blind spots.
+
+**Primary source: arXiv (via arxiv-search utility)**
+
+```bash
+uv run --with arxiv python scripts/arxiv_search.py "QUERY" --max-results 30 --sort-by relevance
+```
+
+Vary queries systematically:
+- Broad topic query: `"retrieval augmented generation"`
+- Field-scoped query: `ti:retrieval AND abs:generation AND cat:cs.CL`
+- Author-anchored query: `au:lewis AND abs:retrieval` (when key authors are known)
+- Recency query: same terms with `--sort-by submitted`
+
+**Secondary sources (via web search/fetch):**
+- Semantic Scholar API: `https://api.semanticscholar.org/graph/v1/paper/search?query=QUERY&limit=20&fields=title,authors,abstract,year,citationCount,externalIds`
+- Google Scholar (via web search): `site:scholar.google.com QUERY`
+- Connected Papers (for citation graph exploration): `https://www.connectedpapers.com/search?q=QUERY`
+
+**Snowball strategy:**
+- Forward snowball: find papers that cite a key paper (Semantic Scholar citations endpoint)
+- Backward snowball: follow the references of key papers
+- Use citation count as a signal for influence, not quality
+
+### Phase 3: Screening & Filtering
+
+For each discovered paper, apply the inclusion/exclusion criteria from Phase 1.
+
+Produce a **screening table**:
+
+| # | ID | Title | Authors | Year | Relevant? | Reason |
+|---|-----|-------|---------|------|-----------|--------|
+| 1 | 2301.07041 | Paper Title | Author et al. | 2023 | Yes | Directly addresses RQ |
+| 2 | 2302.12345 | Other Paper | Author B | 2023 | No | Tangential — focuses on X not Y |
+
+Rules:
+- Screen on title + abstract first. Read full paper only for borderline cases.
+- When uncertain, include. It is cheaper to drop a paper later than to miss it.
+- Track exclusion reasons — they inform the review's limitations section.
+- Flag papers that appear in multiple search queries as likely high-relevance.
+
+### Phase 4: Data Extraction
+
+For each included paper, extract a structured record:
+
+```yaml
+- id: "2301.07041"
+  title: "Paper Title"
+  authors: ["Author One", "Author Two"]
+  year: 2023
+  venue: "NeurIPS 2023"
+  research_question: "How does X affect Y?"
+  methodology: "Controlled experiment with N=1000"
+  key_findings:
+    - "Finding 1 with quantitative result"
+    - "Finding 2 with effect size"
+  limitations: "Single-domain evaluation"
+  relevance_to_rq: "Directly compares methods A and B on metric Y"
+  citation_count: 142
+```
+
+Extraction discipline:
+- Record what the paper demonstrates, not what it claims to demonstrate.
+- Distinguish empirical findings (data-backed) from interpretive claims (author's framing).
+- Note methodology details that enable cross-paper comparison (datasets, metrics, baselines).
+- If the paper is available via `pdf_url`, read it for extraction. Do not extract from abstracts alone for included papers.
+
+### Phase 5: Synthesis
+
+Transform extracted records into structured analysis. The synthesis method depends on the output format requested in Phase 1.
+
+**Thematic synthesis** — Group papers by theme, approach, or finding:
+- Identify recurring themes across papers
+- Note where papers agree, disagree, or address different aspects
+- Highlight methodological trends (what approaches are gaining/losing traction)
+
+**Comparative synthesis** — Build comparison tables:
+
+| Method | Paper(s) | Dataset | Metric | Result | Limitations |
+|--------|----------|---------|--------|--------|-------------|
+| Method A | [1], [3] | D1 | F1 | 0.85 | Domain-specific |
+| Method B | [2], [4] | D1, D2 | F1 | 0.82 | Requires X |
+
+**Chronological synthesis** — Map the evolution of the field:
+- What was the state of knowledge at time T?
+- What shifted and why?
+- Where is the field heading?
+
+**Gap analysis** — Identify what is missing:
+- Questions raised but not answered by existing work
+- Methodological gaps (no one has tried approach X on problem Y)
+- Domain gaps (studied in domain A but not B)
+- Contradictions between studies that remain unresolved
+
+### Phase 6: Output
+
+Produce the review document in the format specified in Phase 1.
+
+**Standard structure for a narrative review:**
+
+1. **Introduction** — Research question, scope, and motivation for the review
+2. **Search methodology** — Databases searched, queries used, inclusion/exclusion criteria, screening results (N found → N screened → N included)
+3. **Findings** — Thematic or chronological synthesis of included papers
+4. **Discussion** — Cross-cutting analysis, trends, contradictions, gaps
+5. **Limitations of this review** — Search scope restrictions, potential biases, papers not accessible
+6. **References** — Full citation list for all included papers
+
+**Standard structure for a tabular review:**
+
+1. Summary table (all included papers with key metadata)
+2. Comparison matrix (methods × metrics × results)
+3. Gap analysis table (questions × coverage)
+4. Reference list
+
+**Citation format:**
+Default to `Author et al. (Year)` in-text with full references at the end. Adapt to the user's specified format (APA, Chicago, IEEE) if requested.
+
+## Quality Checks
+
+Before delivering the review, verify:
+
+- [ ] Every included paper has a structured extraction record
+- [ ] Every claim in the synthesis is traceable to at least one extracted finding
+- [ ] The gap analysis identifies at least one concrete research opportunity
+- [ ] The review acknowledges its own limitations (search scope, access, biases)
+- [ ] Citation format is consistent throughout
+- [ ] No paper is cited that was excluded during screening
+- [ ] Contradictions between papers are noted, not silently resolved by picking a side
+
+## Edge Cases
+
+| Situation | Adaptation |
+|-----------|------------|
+| Very few papers found (<5) | The field may be nascent. Note this explicitly. Broaden search terms or check if the topic goes by different terminology. Consider adjacent fields. |
+| Too many papers found (>100) | Tighten inclusion criteria. Consider limiting to top venues, recent years, or high-citation papers. Produce a scoping review rather than exhaustive review. |
+| User provides a paper list instead of a topic | Skip Phase 2 (Search). Start from Phase 3 (Screening) with the provided list. |
+| User wants a related-work section for their own paper | Tailor synthesis to position the user's contribution. Organize by approaches the user's work builds on, alternatives it competes with, and gaps it fills. |
+| No full-text access to key papers | Extract from abstracts and note the limitation. Do not fabricate methodology details. Flag which papers were abstract-only in the extraction records. |
+| Interdisciplinary topic | Search across multiple category prefixes. Note when different fields use different terminology for the same concept. |
+| User asks for a "quick" literature review | Reduce Phase 2 to a single search query, Phase 3 to title-only screening, Phase 4 to abstract-only extraction. Label the output as a preliminary survey, not a systematic review. |

--- a/skills/literature-review/evals/cases.yaml
+++ b/skills/literature-review/evals/cases.yaml
@@ -1,0 +1,76 @@
+cases:
+  - id: systematic_review
+    prompt: "Conduct a literature review on retrieval augmented generation techniques"
+    fixtures: []
+    rubric:
+      - "defines scope with research question and inclusion/exclusion criteria"
+      - "searches arXiv and/or other academic sources"
+      - "produces structured synthesis with themes, comparisons, or chronology"
+      - "identifies gaps in the existing research"
+    trigger_expected: true
+
+  - id: related_work_section
+    prompt: "Help me write a related work section about chain-of-thought prompting for my paper"
+    fixtures: []
+    rubric:
+      - "searches for relevant papers on the topic"
+      - "organizes findings to position the user's contribution"
+      - "produces narrative synthesis, not paper-by-paper summary"
+    trigger_expected: true
+
+  - id: research_landscape
+    prompt: "What is the current state of research on multimodal large language models?"
+    fixtures: []
+    rubric:
+      - "surveys recent publications on the topic"
+      - "identifies major themes, approaches, and trends"
+      - "notes gaps or open questions"
+    trigger_expected: true
+
+  - id: compare_approaches
+    prompt: "Compare the different approaches to knowledge distillation in the literature"
+    fixtures: []
+    rubric:
+      - "identifies multiple approaches from published work"
+      - "builds a comparison across defined dimensions"
+      - "notes trade-offs and when each approach is appropriate"
+    trigger_expected: true
+
+  - id: bibliography_building
+    prompt: "Build me a bibliography of key papers on reinforcement learning from human feedback"
+    fixtures: []
+    rubric:
+      - "searches for papers on the topic"
+      - "produces a structured list with full citation metadata"
+      - "covers foundational and recent work"
+    trigger_expected: true
+
+  - id: gap_analysis
+    prompt: "What research gaps exist in the area of LLM evaluation benchmarks?"
+    fixtures: []
+    rubric:
+      - "surveys existing evaluation approaches"
+      - "identifies coverage, methodological, or evidence gaps"
+      - "distinguishes genuine gaps from standard field limitations"
+    trigger_expected: true
+
+  - id: negative_single_paper_critique
+    prompt: "What are the weaknesses in this specific paper about BERT?"
+    fixtures: []
+    rubric:
+      - "single-paper critique is research-critique territory, not literature review"
+    trigger_expected: false
+
+  - id: negative_manuscript_formatting
+    prompt: "Check the citation formatting in my manuscript"
+    fixtures: []
+    rubric:
+      - "citation hygiene and formatting is manuscript-review territory"
+    trigger_expected: false
+
+  - id: negative_provenance
+    prompt: "Verify that my literature review table is generated from the search scripts"
+    fixtures: []
+    rubric:
+      - "computational provenance is manuscript-provenance territory"
+    trigger_expected: false

--- a/skills/literature-review/references/citation-formats.md
+++ b/skills/literature-review/references/citation-formats.md
@@ -1,0 +1,90 @@
+# Citation Formats Reference
+
+## In-Text Citation Styles
+
+### APA 7th Edition
+- Single author: `(Smith, 2023)` or `Smith (2023)`
+- Two authors: `(Smith & Jones, 2023)` or `Smith and Jones (2023)`
+- Three+ authors: `(Smith et al., 2023)` or `Smith et al. (2023)`
+- Multiple citations: `(Smith, 2023; Jones et al., 2022)` — chronological order
+- Direct quote: `(Smith, 2023, p. 42)`
+
+### IEEE
+- Numbered brackets: `[1]`, `[2]`, `[1], [3]`, `[1]–[5]`
+- Ordered by appearance in text, not alphabetically
+
+### Chicago (Author-Date)
+- Single author: `(Smith 2023)` or `Smith (2023)`
+- Two authors: `(Smith and Jones 2023)`
+- Three+ authors: `(Smith et al. 2023)`
+
+### ACM
+- Numbered brackets: `[Smith et al. 2023]` or `[42]`
+- Varies by venue (numbered vs. author-date)
+
+## Reference List Formats
+
+### APA 7th Edition
+```
+Smith, J. A., & Jones, B. C. (2023). Title of the paper in sentence case.
+    Journal Name in Title Case, 42(3), 123–145.
+    https://doi.org/10.1234/example
+
+Smith, J. A., Jones, B. C., & Lee, D. (2023). Conference paper title.
+    In Proceedings of the Conference Name (pp. 100–110). Publisher.
+    https://doi.org/10.1234/example
+```
+
+### IEEE
+```
+[1] J. A. Smith and B. C. Jones, "Title of the paper in sentence case,"
+    Journal Name, vol. 42, no. 3, pp. 123–145, Mar. 2023,
+    doi: 10.1234/example.
+
+[2] J. A. Smith, B. C. Jones, and D. Lee, "Conference paper title,"
+    in Proc. Conf. Name, City, Country, 2023, pp. 100–110.
+```
+
+### arXiv Preprint
+```
+# APA
+Smith, J. A., & Jones, B. C. (2023). Title of the preprint. arXiv.
+    https://arxiv.org/abs/2301.07041
+
+# IEEE
+[1] J. A. Smith and B. C. Jones, "Title of the preprint," arXiv preprint
+    arXiv:2301.07041, 2023.
+```
+
+## Default Format for Literature Reviews
+
+When no format is specified, use **APA-style author-date** in-text citations with a full reference list at the end. This is the most widely recognized format in AI/ML research contexts.
+
+For NLP and AI conference papers (ACL, EMNLP, NeurIPS, ICML, ICLR), note that published versions take precedence over arXiv preprints. Cite the venue version when available, with arXiv as a secondary link.
+
+## Constructing Citations from arxiv-search Output
+
+The `arxiv-search` utility returns:
+```json
+{
+  "id": "2301.07041v1",
+  "title": "Paper Title",
+  "authors": ["First Author", "Second Author"],
+  "published": "2023-01-17T18:59:00+00:00",
+  "doi": "10.1234/example",
+  "journal_ref": "Nature 2023",
+  "entry_url": "http://arxiv.org/abs/2301.07041v1"
+}
+```
+
+Map to APA:
+```
+Author, F., & Author, S. (2023). Paper title. Nature.
+    https://doi.org/10.1234/example
+```
+
+If `journal_ref` is null (preprint only):
+```
+Author, F., & Author, S. (2023). Paper title. arXiv.
+    https://arxiv.org/abs/2301.07041
+```

--- a/skills/literature-review/references/search-strategy.md
+++ b/skills/literature-review/references/search-strategy.md
@@ -1,0 +1,116 @@
+# Search Strategy Reference
+
+## arXiv Query Syntax
+
+arXiv supports boolean field-prefixed queries through the Atom API.
+
+### Field Prefixes
+
+| Prefix | Field | Notes |
+|--------|-------|-------|
+| `ti:` | Title | Matches words in the title |
+| `au:` | Author | Last name or "lastname_firstname" |
+| `abs:` | Abstract | Matches words in the abstract |
+| `cat:` | Category | arXiv category (e.g., cs.CL, cs.AI, stat.ML) |
+| `all:` | All fields | Searches across all metadata |
+| `co:` | Comment | Author comments field |
+| `jr:` | Journal ref | Journal reference field |
+
+### Boolean Operators
+
+- `AND` — both terms must match
+- `OR` — either term matches
+- `ANDNOT` — first term matches, second does not
+
+Operators must be uppercase. Implicit operator between terms is AND.
+
+### Examples
+
+```
+# Papers about attention in NLP
+ti:attention AND cat:cs.CL
+
+# Papers by Vaswani about transformers
+au:vaswani AND ti:transformer
+
+# RAG papers excluding computer vision
+abs:retrieval augmented generation ANDNOT cat:cs.CV
+
+# Multi-author collaboration
+au:bengio AND au:lecun
+
+# Recent survey papers
+ti:survey AND abs:large language models AND cat:cs.CL
+```
+
+### arXiv Categories (Common CS/AI)
+
+| Category | Description |
+|----------|-------------|
+| cs.AI | Artificial Intelligence |
+| cs.CL | Computation and Language (NLP) |
+| cs.CV | Computer Vision |
+| cs.LG | Machine Learning |
+| cs.IR | Information Retrieval |
+| cs.SE | Software Engineering |
+| cs.CR | Cryptography and Security |
+| cs.DB | Databases |
+| cs.DC | Distributed Computing |
+| cs.HC | Human-Computer Interaction |
+| stat.ML | Machine Learning (Statistics) |
+
+## Semantic Scholar API
+
+Base URL: `https://api.semanticscholar.org/graph/v1`
+
+### Paper Search
+
+```
+GET /paper/search?query=QUERY&limit=20&fields=title,authors,abstract,year,citationCount,externalIds,venue
+```
+
+### Paper Details (by arXiv ID)
+
+```
+GET /paper/ARXIV:2301.07041?fields=title,authors,abstract,year,citationCount,references,citations
+```
+
+### Citation Graph
+
+```
+# Papers that cite a given paper
+GET /paper/ARXIV:2301.07041/citations?fields=title,authors,year,citationCount&limit=50
+
+# Papers referenced by a given paper
+GET /paper/ARXIV:2301.07041/references?fields=title,authors,year,citationCount&limit=50
+```
+
+### Rate Limits
+
+- Without API key: 100 requests per 5 minutes
+- With API key (free): 1 request per second
+
+## Search Strategy Patterns
+
+### Exhaustive Search (Systematic Review)
+
+1. Define 3-5 query variations covering different terminology
+2. Run each query across arXiv and Semantic Scholar
+3. Deduplicate by arXiv ID or DOI
+4. Apply date range filter post-search
+5. Track query-to-result mapping for reproducibility
+
+### Targeted Search (Related Work)
+
+1. Start from 2-3 known key papers
+2. Forward snowball: papers citing them (Semantic Scholar citations endpoint)
+3. Backward snowball: papers they reference (Semantic Scholar references endpoint)
+4. Fill gaps with keyword search for uncovered themes
+
+### Exploratory Search (Scoping Review)
+
+1. Single broad query, sorted by citation count
+2. Identify top-cited papers as anchors
+3. Read abstracts to identify sub-themes
+4. Refine queries for each sub-theme
+5. Stop when new queries return mostly already-seen papers (saturation)

--- a/skills/literature-review/references/synthesis-framework.md
+++ b/skills/literature-review/references/synthesis-framework.md
@@ -1,0 +1,151 @@
+# Synthesis Framework Reference
+
+## Synthesis Methods
+
+### Thematic Synthesis
+
+Organize findings by recurring themes across papers rather than paper-by-paper summary.
+
+**Process:**
+1. Code each paper's key findings into thematic labels
+2. Group papers sharing themes
+3. For each theme: state the consensus, note disagreements, identify evolution
+4. Cross-reference themes to reveal gaps
+
+**Output structure:**
+```
+## Theme: [Label]
+
+[Summary of what papers collectively show about this theme]
+
+Papers contributing to this theme:
+- [Author et al., Year]: [specific finding]
+- [Author et al., Year]: [specific finding]
+
+Points of agreement: [what converges]
+Points of tension: [where papers disagree and why]
+```
+
+**Pitfall:** Forcing papers into themes they do not fit. If a paper contributes to multiple themes, list it in each. If it fits none, it may indicate a missing theme or misalignment with the review scope.
+
+### Comparative Synthesis
+
+Build structured comparisons across defined dimensions.
+
+**Process:**
+1. Identify comparison axes (method, dataset, metric, scale, limitations)
+2. Extract comparable data points from each paper
+3. Build comparison matrix
+4. Analyze patterns in the matrix (what predicts success, what trade-offs exist)
+
+**Output structure:**
+
+| Dimension | Paper A | Paper B | Paper C |
+|-----------|---------|---------|---------|
+| Method | X | Y | Z |
+| Dataset | D1 | D1, D2 | D2 |
+| Key metric | 0.85 | 0.82 | 0.88 |
+| Scale | 1K samples | 10K samples | 1K samples |
+| Limitation | Domain-specific | Slow | Requires X |
+
+**Pitfall:** Comparing incomparable results. Papers using different datasets, metrics, or evaluation protocols cannot be directly compared on numbers. Note comparability constraints explicitly.
+
+### Chronological Synthesis
+
+Map the temporal evolution of a research area.
+
+**Process:**
+1. Order papers by publication date
+2. Identify inflection points (papers that shifted the field's direction)
+3. Track how methods, assumptions, and benchmarks changed over time
+4. Note what drove changes (new datasets, new techniques, failures of prior approaches)
+
+**Output structure:**
+```
+## [Year Range]: [Era Label]
+
+State of knowledge: [what was understood/assumed]
+Key developments:
+- [Paper]: [what it introduced and why it mattered]
+- [Paper]: [what it introduced and why it mattered]
+Shift trigger: [what caused the transition to the next era]
+```
+
+**Pitfall:** Post-hoc narrative construction. The chronological story should match how the field actually evolved, not impose a clean narrative arc that the messy reality does not support.
+
+### Gap Analysis
+
+Identify what is unstudied, understudied, or contradictory.
+
+**Categories of gaps:**
+
+| Gap Type | Description | Example |
+|----------|-------------|---------|
+| **Coverage gap** | Topic or domain not yet studied | "No work applies X to domain Y" |
+| **Methodological gap** | Approach not yet tried on a known problem | "X has been tested with method A but not B" |
+| **Evidence gap** | Claims made without sufficient evidence | "Multiple papers claim X but none provide controlled experiments" |
+| **Contradiction** | Studies reach conflicting conclusions | "Paper A finds X improves Y; Paper B finds it does not" |
+| **Scale gap** | Only tested at small scale | "All studies use <1K samples; real-world scale unknown" |
+| **Replication gap** | Findings not independently replicated | "Only the original authors have reported this result" |
+
+**Process:**
+1. Map the space: what questions exist × what has been studied
+2. Identify empty cells (unstudied combinations)
+3. Identify weak cells (studied but with limitations)
+4. Identify conflicting cells (contradictory findings)
+5. Rank gaps by importance to the research question
+
+## Extraction Template
+
+For each included paper, extract:
+
+```yaml
+paper:
+  id: ""              # arXiv ID, DOI, or other identifier
+  title: ""
+  authors: []
+  year: null
+  venue: ""           # Conference/journal name
+  type: ""            # empirical | theoretical | survey | position
+
+research:
+  question: ""        # What question does this paper address?
+  hypothesis: ""      # What does it predict/propose?
+  contribution: ""    # What is the claimed novel contribution?
+
+methodology:
+  approach: ""        # High-level method description
+  datasets: []        # Datasets used
+  metrics: []         # Evaluation metrics
+  baselines: []       # What it compares against
+  scale: ""           # Data/compute scale
+
+findings:
+  primary: []         # Main results (quantitative where possible)
+  secondary: []       # Supporting results
+  negative: []        # What did NOT work (often buried in appendices)
+
+assessment:
+  strengths: []       # What this paper does well
+  limitations: []     # As stated by authors + your assessment
+  relevance: ""       # How it relates to the review's research question
+  themes: []          # Thematic labels for synthesis grouping
+```
+
+## Anti-Patterns
+
+### The "List of Summaries" Review
+
+Summarizing each paper sequentially without synthesis. This is a bibliography, not a review. Each paragraph should make a point that draws on multiple papers.
+
+### The "Everything is Related" Review
+
+Including papers with tenuous connections to fill space. A focused review of 15 relevant papers is more valuable than an unfocused review of 50.
+
+### The Silent Resolution
+
+When two papers contradict, picking the one you prefer and ignoring the other. Both must be presented, with analysis of why they disagree (different methods, data, definitions).
+
+### The Missing Self-Critique
+
+Every review has blind spots: databases not searched, languages not covered, recency bias, access limitations. Acknowledge them in a limitations section. A review that claims comprehensiveness is less credible than one that defines its boundaries.

--- a/utilities/arxiv-search/UTILITY.md
+++ b/utilities/arxiv-search/UTILITY.md
@@ -1,0 +1,101 @@
+---
+name: arxiv-search
+type: utility
+description: >
+  Searches arXiv for academic papers by keyword, author, title, or category and
+  outputs structured JSON with full metadata (title, authors, abstract, dates,
+  categories, DOI, PDF URL). Supports field-prefixed queries (au:, ti:, abs:, cat:),
+  sorting by relevance/date, result limits, and direct ID lookup. Use this utility
+  when you need to discover research papers, build a reading list, gather references
+  for a literature review, fetch paper metadata by arXiv ID, or survey recent
+  publications in a research area. Complements research-critique (per-paper analysis)
+  and literature-review (multi-paper synthesis).
+metadata:
+  version: 1.0.0
+  complements:
+    - literature-review
+    - research-critique
+utility:
+  runtime: python
+  entry_point: scripts/arxiv_search.py
+  executable: true
+---
+
+# arxiv-search
+
+Search arXiv and retrieve structured paper metadata.
+
+## Dependencies
+
+```bash
+uv pip install arxiv
+```
+
+## Usage
+
+```bash
+# Keyword search
+uv run --with arxiv python scripts/arxiv_search.py "transformer attention mechanisms"
+
+# Author search
+uv run --with arxiv python scripts/arxiv_search.py "au:vaswani AND ti:attention"
+
+# Category-scoped search with date sorting
+uv run --with arxiv python scripts/arxiv_search.py "cat:cs.CL AND abs:retrieval augmented" \
+  --sort-by submitted --max-results 20
+
+# Fetch specific papers by ID
+uv run --with arxiv python scripts/arxiv_search.py "" --ids 2301.07041 1706.03762
+
+# Compact output (one JSON per line, for piping)
+uv run --with arxiv python scripts/arxiv_search.py "large language models" --compact
+```
+
+## Query Syntax
+
+arXiv supports field-prefixed boolean queries:
+
+| Prefix | Field | Example |
+|--------|-------|---------|
+| `ti:` | Title | `ti:attention mechanism` |
+| `au:` | Author | `au:vaswani` |
+| `abs:` | Abstract | `abs:retrieval augmented generation` |
+| `cat:` | Category | `cat:cs.CL` |
+| `all:` | All fields | `all:transformer` |
+
+Combine with `AND`, `OR`, `ANDNOT`:
+```
+au:bengio AND ti:representation learning ANDNOT cat:cs.CV
+```
+
+## Output Format
+
+```json
+[
+  {
+    "id": "2301.07041v1",
+    "title": "Paper Title",
+    "authors": ["Author One", "Author Two"],
+    "abstract": "Full abstract text...",
+    "published": "2023-01-17T18:59:00+00:00",
+    "updated": "2023-03-10T12:00:00+00:00",
+    "primary_category": "cs.CL",
+    "categories": ["cs.CL", "cs.AI"],
+    "doi": "10.1234/example",
+    "journal_ref": "Nature 2023",
+    "pdf_url": "http://arxiv.org/pdf/2301.07041v1",
+    "entry_url": "http://arxiv.org/abs/2301.07041v1"
+  }
+]
+```
+
+## Rate Limiting
+
+The script enforces a 3-second delay between API requests and retries up to 3 times on failure, respecting arXiv's usage policies. Page size is capped at 100 results per request.
+
+## Limitations
+
+- arXiv API only — does not search Semantic Scholar, PubMed, or other databases.
+- No full-text search; queries match metadata fields (title, abstract, author, category).
+- Public API tier with no authentication — subject to arXiv rate limits.
+- PDF download is not performed; use the `pdf_url` field to retrieve papers separately.

--- a/utilities/arxiv-search/evals/cases.yaml
+++ b/utilities/arxiv-search/evals/cases.yaml
@@ -1,0 +1,46 @@
+cases:
+  - id: search_by_topic
+    prompt: "Find recent arXiv papers about retrieval augmented generation"
+    fixtures: []
+    rubric:
+      - "executes arxiv search with relevant query terms"
+      - "returns structured metadata including title, authors, abstract"
+    trigger_expected: true
+
+  - id: search_by_author
+    prompt: "Look up papers by Yann LeCun on arXiv"
+    fixtures: []
+    rubric:
+      - "uses author field prefix (au:) to search"
+      - "returns paper list with metadata"
+    trigger_expected: true
+
+  - id: fetch_by_id
+    prompt: "Get the metadata for arXiv paper 1706.03762"
+    fixtures: []
+    rubric:
+      - "uses id_list to fetch specific paper"
+      - "returns structured metadata for the requested paper"
+    trigger_expected: true
+
+  - id: survey_category
+    prompt: "What papers were submitted to cs.CL this week about large language models?"
+    fixtures: []
+    rubric:
+      - "uses category prefix and date sorting"
+      - "returns recent submissions matching the query"
+    trigger_expected: true
+
+  - id: negative_critique_paper
+    prompt: "Critique the methodology in this transformer paper"
+    fixtures: []
+    rubric:
+      - "paper critique is research-critique territory, not search"
+    trigger_expected: false
+
+  - id: negative_download_pdf
+    prompt: "Download this paper's PDF to my desktop"
+    fixtures: []
+    rubric:
+      - "file download is outside search scope; the utility returns pdf_url for manual retrieval"
+    trigger_expected: false

--- a/utilities/arxiv-search/scripts/arxiv_search.py
+++ b/utilities/arxiv-search/scripts/arxiv_search.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Search arXiv for academic papers and output structured results."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import arxiv
+
+
+def _serialize_result(result: arxiv.Result) -> dict[str, object]:
+    """Convert an arxiv.Result to a JSON-serializable dict."""
+    return {
+        "id": result.get_short_id(),
+        "title": result.title,
+        "authors": [a.name for a in result.authors],
+        "abstract": result.summary,
+        "published": result.published.isoformat() if result.published else None,
+        "updated": result.updated.isoformat() if result.updated else None,
+        "primary_category": result.primary_category,
+        "categories": result.categories,
+        "doi": result.doi,
+        "journal_ref": result.journal_ref,
+        "pdf_url": result.pdf_url,
+        "entry_url": result.entry_id,
+    }
+
+
+def search(
+    query: str,
+    *,
+    max_results: int,
+    sort_by: str,
+    sort_order: str,
+    id_list: list[str] | None = None,
+) -> list[dict[str, object]]:
+    """Execute an arXiv search and return serialized results."""
+    import arxiv
+
+    sort_by_map = {
+        "relevance": arxiv.SortCriterion.Relevance,
+        "submitted": arxiv.SortCriterion.SubmittedDate,
+        "updated": arxiv.SortCriterion.LastUpdatedDate,
+    }
+    sort_order_map = {
+        "descending": arxiv.SortOrder.Descending,
+        "ascending": arxiv.SortOrder.Ascending,
+    }
+
+    s = arxiv.Search(
+        query=query,
+        max_results=max_results,
+        sort_by=sort_by_map[sort_by],
+        sort_order=sort_order_map[sort_order],
+        id_list=id_list or [],
+    )
+
+    client = arxiv.Client(page_size=min(max_results, 100), delay_seconds=3.0, num_retries=3)
+    return [_serialize_result(r) for r in client.results(s)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Search arXiv for academic papers.",
+        epilog="Requires: uv run --with arxiv python scripts/arxiv_search.py ...",
+    )
+    parser.add_argument("query", help="arXiv search query (supports field prefixes: au:, ti:, abs:, cat:)")
+    parser.add_argument("--max-results", type=int, default=10, help="Maximum number of results (default: 10)")
+    parser.add_argument(
+        "--sort-by",
+        choices=["relevance", "submitted", "updated"],
+        default="relevance",
+        help="Sort criterion (default: relevance)",
+    )
+    parser.add_argument(
+        "--sort-order",
+        choices=["descending", "ascending"],
+        default="descending",
+        help="Sort order (default: descending)",
+    )
+    parser.add_argument("--ids", nargs="*", help="Specific arXiv paper IDs to fetch (e.g., 2301.07041)")
+    parser.add_argument("--compact", action="store_true", help="Output one JSON object per line instead of pretty-printing")
+    args = parser.parse_args()
+
+    results = search(
+        args.query,
+        max_results=args.max_results,
+        sort_by=args.sort_by,
+        sort_order=args.sort_order,
+        id_list=args.ids,
+    )
+
+    if not results:
+        print("No results found.", file=sys.stderr)
+        return 1
+
+    if args.compact:
+        for r in results:
+            print(json.dumps(r))
+    else:
+        print(json.dumps(results, indent=2))
+
+    print(f"\n{len(results)} result(s) returned.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds three new packages enabling a systematic academic research workflow:

- **`arxiv-search` utility** — Python CLI wrapping the [`arxiv`](https://pypi.org/project/arxiv/) PyPI package (v2.4.1) for searching arXiv by keyword, author, title, or category. Outputs structured JSON with full paper metadata (title, authors, abstract, dates, categories, DOI, PDF URL). Supports field-prefixed boolean queries (`au:`, `ti:`, `abs:`, `cat:`), sorting by relevance/date, result limits, direct ID lookup, and compact JSONL output for piping. Built-in rate limiting (3s delay) respects arXiv API policies. No API key required.

- **`literature-review` skill** — Six-phase systematic review workflow: scope definition → search & discovery → screening & filtering → data extraction → synthesis → structured output. Includes three reference documents:
  - `search-strategy.md` — arXiv query syntax, Semantic Scholar API endpoints, and three search strategy patterns (exhaustive, targeted, exploratory)
  - `synthesis-framework.md` — four synthesis methods (thematic, comparative, chronological, gap analysis) with extraction templates and anti-patterns
  - `citation-formats.md` — APA, IEEE, Chicago, ACM format references with arXiv-to-citation field mapping

- **`research` preset** — Bundles five packages into a single install covering the full research lifecycle:
  - `arxiv-search` (discovery) → `literature-review` (synthesis) → `research-critique` (per-paper analysis) → `manuscript-review` (pre-submission audit) → `manuscript-provenance` (computational grounding)

## Changes

### New packages (3)
| Package | Type | Files | Lines |
|---------|------|-------|-------|
| `utilities/arxiv-search/` | Utility | `UTILITY.md`, `scripts/arxiv_search.py`, `evals/cases.yaml` | 258 |
| `skills/literature-review/` | Skill | `SKILL.md`, 3 reference docs, `evals/cases.yaml` | 637 |
| `presets/research/` | Preset | `PRESET.md`, `evals/cases.yaml` | 101 |

### Updated files
- **`README.md`** — Added all three packages to catalog tables, updated package count badge (69 → 72)
- **`manifest.yaml`** — Regenerated with 53 skills, 3 agents, 3 hooks, 3 rules, 3 commands, 3 utilities, 4 presets. Bidirectional `complements` enforced (literature-review ↔ arxiv-search, literature-review ↔ research-critique, literature-review ↔ manuscript-review, literature-review ↔ manuscript-provenance)
- **`skills.yaml`** — Regenerated (legacy manifest, skills-only)

### Eval coverage
- `arxiv-search`: 4 positive, 2 negative cases
- `literature-review`: 6 positive, 3 negative cases
- `research`: 2 positive, 2 negative cases
- All existing eval suites continue to pass (72 packages validated)

## Validation

```
Generated manifest.yaml with 53 skills, 3 agents, 3 hooks, 3 rules, 3 commands, 3 utilities, 4 presets
Validated 53 skills, 3 agents, 3 hooks, 3 rules, 3 commands, 3 utilities, 4 presets — all passed
206 passed in 0.35s
```

## Test plan

- [ ] Verify `uv run python scripts/generate_manifest.py` produces identical `manifest.yaml`
- [ ] Verify `uv run python scripts/validate_evals.py` passes all packages
- [ ] Verify `uv run pytest tests/ -q` — all 206 tests pass
- [ ] Verify `uv pip install arxiv && uv run python utilities/arxiv-search/scripts/arxiv_search.py "transformer attention" --max-results 3` returns structured JSON
- [ ] Verify bidirectional complements in `manifest.yaml` (literature-review listed in research-critique's complements, and vice versa)
- [ ] Verify README badge shows 72 packages