### PR TITLE
refactor(presets): rename sec-strict, add 4 new presets, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # armory
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 72](https://img.shields.io/badge/packages-72-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 81](https://img.shields.io/badge/packages-81-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 
 Curated, production-grade skills, agents, hooks, rules, commands, utilities, and presets for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -13,6 +13,24 @@ Curated, production-grade skills, agents, hooks, rules, commands, utilities, and
 **Philosophy:** Packages in this collection are practical and context-free. They define the _how_, not just the _what_ — covering inputs, outputs, edge cases, and failure modes. They are tested in real workloads, not constructed as examples.
 
 Intended for developers who treat AI coding agents as a serious part of their workflow.
+
+---
+
+## Presets
+
+Presets are curated bundles that install multiple packages in one command. Start with `core`, layer on domain-specific presets as needed.
+
+| Preset | Skills | Description |
+| ------ | ------ | ----------- |
+| [core](presets/core/) | 3 skills, 1 hook, 1 rule | Baseline review-commit lifecycle — PR review, code refinement, pre-landing gate, git protection, commit standards. Start here. |
+| [sec-strict](presets/sec-strict/) | 5 skills, 2 agents, 2 rules, 1 hook, 1 command | Audit-grade security stack — secret scanning, dependency auditing, security review agents, repo sentinel, cost tracking. Superset of `core`. |
+| [python-strict](presets/python-strict/) | — | Full Python enforcement — type checking, test standards, security scanning, import ordering. Layer on top of `core`. |
+| [research](presets/research/) | — | Academic research workflow — literature review, manuscript review, provenance auditing, research critique, YouTube analysis. |
+| [biz-validation](presets/biz-validation/) | 4 skills | Business idea validation — market analysis (TAM/SAM/SOM), competitive landscape (Porter's Five Forces), feasibility assessment (unit economics, technical risk), orchestrated validation (Lean Canvas, JTBD, SWOT/PESTLE). |
+| [eng-ops](presets/eng-ops/) | 8 skills | Engineering operations lifecycle — ship workflow, systematic QA, test scaffolding, benchmarking, migration risk, effort estimation, retrospectives, debugging. |
+| [media-craft](presets/media-craft/) | 6 skills | Visual and video production — concept-to-image (PNG/SVG), concept-to-video (Manim), Remotion video (React), HTML presentations, interactive HTML artifacts, architecture diagrams. |
+| [content-ops](presets/content-ops/) | 8 skills | Writing and publishing pipeline — humanize AI text, social content, manuscript review, authorship verification, changelogs, PDF export, summarization, format conversion. |
+| [ai-builder](presets/ai-builder/) | 6 skills | AI/ML development toolkit — agent building, prompt engineering, GPU optimization, RAG auditing, MCP-to-skill conversion, notebook generation. |
 
 ---
 
@@ -43,7 +61,8 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | [youtube-search](skills/youtube-search/)       | Search YouTube by keyword via yt-dlp — returns structured metadata (title, URL, channel, views, duration, date) for discovery and source curation               |
 | [youtube-analysis](skills/youtube-analysis/)   | YouTube video transcript extraction and structured concept analysis — multi-level summaries, key concepts, takeaways, no API keys required                      |
 | [notebooklm](skills/notebooklm/)               | Google NotebookLM automation via notebooklm-py — create notebooks, add sources, chat, generate podcasts, videos, infographics, quizzes, flashcards, and more    |
-| [immune](skills/immune/)                       | Hybrid adaptive memory with Cheatsheet (positive patterns) and Immune (negative patterns) — Hot/Cold tiered memory, multi-domain antibody scanning, auto-learning |
+| [research-critique](skills/research-critique/)   | Critical analysis of research papers — methodology evaluation, claims-evidence alignment, contribution assessment with collegial analytical posture              |
+| [immune](skills/immune/)                         | Hybrid adaptive memory with Cheatsheet (positive patterns) and Immune (negative patterns) — Hot/Cold tiered memory, multi-domain antibody scanning, auto-learning |
 
 ### Skills — Review & Quality
 
@@ -90,6 +109,15 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 | [sql-optimizer](skills/sql-optimizer/)                     | SQL performance analysis — EXPLAIN interpretation, anti-pattern detection, index recommendations, rewrites |
 | [migration-risk-analyzer](skills/migration-risk-analyzer/) | Database migration risk assessment — lock analysis, downtime estimation, rollback strategies, validation   |
 | [benchmark-runner](skills/benchmark-runner/)               | Structured benchmark design — metric selection, test case matrix, environment capture, statistical rigor   |
+
+### Skills — Business Validation
+
+| Skill                                                | Description                                                                                                                                   |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [idea-validator](skills/idea-validator/)             | Full business idea validation orchestrator — Lean Canvas, JTBD, parallel market/competitive/feasibility agents, SWOT/PESTLE, weighted scoring |
+| [market-analyzer](skills/market-analyzer/)           | Market sizing and trend analysis — TAM/SAM/SOM calculation, Rogers adoption curve, data triangulation, timing assessment                     |
+| [competitive-analyzer](skills/competitive-analyzer/) | Competitive landscape analysis — Porter's Five Forces, feature/pricing matrices, positioning maps, moat taxonomy                             |
+| [feasibility-assessor](skills/feasibility-assessor/) | Financial and technical feasibility — unit economics (CAC/LTV), revenue modeling, break-even, technical risk scoring, build-vs-buy            |
 
 ### Skills — AI/ML & Planning
 
@@ -158,17 +186,6 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [arxiv-search](utilities/arxiv-search/)                 | Search arXiv for papers, output structured JSON metadata    |
 | [dependency-tree](utilities/dependency-tree/)           | Visualize project dependency graph                          |
 | [test-coverage-report](utilities/test-coverage-report/) | Coverage summary for changed files                          |
-
-## Presets
-
-| Preset                                    | Description                                  |
-| ----------------------------------------- | -------------------------------------------- |
-| [core](presets/core/)                     | Essential skills + git safety for every user  |
-| [python-strict](presets/python-strict/)   | Full Python enforcement stack                 |
-| [research](presets/research/)             | Academic research and manuscript workflow      |
-| [sec-strict](presets/sec-strict/)         | Security auditing and enforcement             |
-
----
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [core](presets/core/)                     | Essential skills + git safety for every user  |
 | [python-strict](presets/python-strict/)   | Full Python enforcement stack                 |
 | [research](presets/research/)             | Academic research and manuscript workflow      |
-| [security-first](presets/security-first/) | Security auditing and enforcement             |
+| [sec-strict](presets/sec-strict/)         | Security auditing and enforcement             |
 
 ---
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -792,6 +792,16 @@ packages:
     source: https://github.com/Mathews-Tom/armory/blob/main/utilities/test-coverage-report/UTILITY.md
     runtime: python
   presets:
+  - name: ai-builder
+    version: 1.0.0
+    description: AI development toolkit for building, testing, and optimizing LLM-powered systems in Claude Code. Bundles
+      agent development, prompt engineering, GPU and inference optimization, RAG pipeline auditing, MCP server conversion,
+      and notebook generation into a single install. Covers the full AI workflow from designing prompts through building agents,
+      optimizing GPU utilization, auditing retrieval quality, and extending tool integrations. Use this preset when setting
+      up an AI development environment, machine learning toolkit, or LLM tools workspace. Relevant for agent development,
+      MCP development, RAG pipeline construction, and inference optimization workflows.
+    path: presets/ai-builder
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/ai-builder/PRESET.md
   - name: biz-validation
     version: 1.0.0
     description: 'Complete business idea validation toolkit bundling four complementary skills: market analysis (TAM/SAM/SOM,
@@ -804,6 +814,16 @@ packages:
       setting up a complete business analysis capability across market research, competition, and feasibility assessment.'
     path: presets/biz-validation
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/biz-validation/PRESET.md
+  - name: content-ops
+    version: 1.0.0
+    description: Complete writing toolkit and content pipeline for Claude Code. Bundles text humanization, social media formatting,
+      manuscript review and provenance verification, release notes generation, document summarization, PDF export, and markdown
+      conversion into a single publishing workflow. Covers the full content lifecycle from draft through refinement, review,
+      and export. Handles technical writing, document management, and document conversion tasks. Use this preset when setting
+      up a content creation environment, manuscript tools workspace, social content workflow, or any project requiring a cohesive
+      publishing workflow with release notes and format conversion capabilities.
+    path: presets/content-ops
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/content-ops/PRESET.md
   - name: core
     version: 1.0.0
     description: 'Essential packages for every Claude Code user. Bundles pull request review, code refinement, pre-landing
@@ -813,6 +833,28 @@ packages:
       protected branches, and enforce consistent commit messages.'
     path: presets/core
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/core/PRESET.md
+  - name: eng-ops
+    version: 1.0.0
+    description: Full-cycle engineering operations preset covering the build-test-ship pipeline and surrounding practices.
+      Bundles shipping workflow orchestration, systematic QA and test planning, test scaffolding and harness generation, performance
+      benchmarking, migration safety analysis, effort estimation calibration, engineering retrospectives, and root cause debugging
+      investigation. Use this preset when managing an engineering workflow, running a shipping pipeline, coordinating release
+      management, conducting test planning or QA toolkit setup, executing performance testing or benchmark suites, evaluating
+      migration safety and risk, calibrating effort estimation for sprints, facilitating a retrospective, or assembling a
+      debugging toolkit for incident response.
+    path: presets/eng-ops
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/eng-ops/PRESET.md
+  - name: media-craft
+    version: 1.0.0
+    description: Visual content creation toolkit for Claude Code. Bundles image generation (PNG/SVG from HTML/CSS), video
+      production (MP4/GIF via Manim and React/Remotion), slide deck authoring, interactive HTML visual builders, and system
+      architecture diagrams into a single install. Create visual assets, make an image, generate video, design presentation
+      decks, produce graphics, build slides, and compose animations from natural language descriptions. Serves as a media
+      toolkit for creative assets, visual content pipelines, and animation toolkit workflows. Use this preset when producing
+      graphics, illustrations, explainer videos, branded content, interactive data visualizations, or architectural topology
+      diagrams from concept descriptions.
+    path: presets/media-craft
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/media-craft/PRESET.md
   - name: python-strict
     version: 1.0.0
     description: 'Full-stack Python enforcement preset. Extends the core review-commit lifecycle with test-driven development,

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -830,12 +830,12 @@ packages:
       Use this preset when setting up a research project, academic writing environment, or scholarly review workflow.
     path: presets/research
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/research/PRESET.md
-  - name: security-first
+  - name: sec-strict
     version: 1.0.0
     description: Security-focused preset for projects requiring audit-grade protection. Extends the core review-commit lifecycle
       with security-specific review agents, secret scanning, dependency vulnerability auditing, repository configuration sentinel,
       cost tracking, and security coding standards. Use this preset for applications handling sensitive data, regulated environments,
       or any codebase where security posture is a primary concern. Bundles 11 packages across skills, agents, rules, hooks,
       and commands.
-    path: presets/security-first
-    source: https://github.com/Mathews-Tom/armory/blob/main/presets/security-first/PRESET.md
+    path: presets/sec-strict
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/sec-strict/PRESET.md

--- a/presets/ai-builder/PRESET.md
+++ b/presets/ai-builder/PRESET.md
@@ -1,0 +1,76 @@
+---
+name: ai-builder
+type: preset
+description: >
+  AI development toolkit for building, testing, and optimizing LLM-powered systems in Claude
+  Code. Bundles agent development, prompt engineering, GPU and inference optimization, RAG
+  pipeline auditing, MCP server conversion, and notebook generation into a single install.
+  Covers the full AI workflow from designing prompts through building agents, optimizing GPU
+  utilization, auditing retrieval quality, and extending tool integrations. Use this preset
+  when setting up an AI development environment, machine learning toolkit, or LLM tools
+  workspace. Relevant for agent development, MCP development, RAG pipeline construction,
+  and inference optimization workflows.
+metadata:
+  version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: agent-builder
+      - name: prompt-lab
+      - name: gpu-optimizer
+      - name: rag-auditor
+      - name: mcp-to-skill
+      - name: notebooklm
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# AI Builder
+
+End-to-end toolkit for developing, optimizing, and validating AI-powered systems.
+
+## Included Skills
+
+| Skill         | Purpose                                    | Domain               |
+| ------------- | ------------------------------------------ | -------------------- |
+| agent-builder | Custom agent creation and orchestration    | Agent development    |
+| prompt-lab    | Prompt engineering, testing, and iteration | Prompt design        |
+| gpu-optimizer | GPU/CUDA performance tuning                | Inference optimization |
+| rag-auditor   | RAG pipeline quality and retrieval auditing | Retrieval systems    |
+| mcp-to-skill  | Convert MCP servers into installable skills | Tool integration     |
+| notebooklm   | Notebook generation for exploration        | Documentation        |
+
+## Workflow
+
+1. **Design** — Use `prompt-lab` to engineer, test, and iterate on prompts. Establish
+   baseline performance before building higher-level abstractions.
+2. **Build** — Use `agent-builder` to create custom agents that compose prompts, tools,
+   and orchestration logic into autonomous workflows.
+3. **Optimize** — Use `gpu-optimizer` to profile and tune GPU/CUDA utilization for
+   inference workloads. Reduce latency and cost per request.
+4. **Audit** — Use `rag-auditor` to evaluate retrieval quality, chunk relevance, and
+   end-to-end RAG pipeline accuracy. Catch retrieval drift before it reaches users.
+5. **Extend** — Use `mcp-to-skill` to convert existing MCP servers into reusable skills,
+   expanding the agent's tool surface without writing integrations from scratch.
+6. **Document** — Use `notebooklm` to generate notebooks that capture experiments,
+   results, and architectural decisions.
+
+## Choosing the Right Skill
+
+| Situation                                        | Skill         |
+| ------------------------------------------------ | ------------- |
+| Writing or refining a system prompt               | prompt-lab    |
+| Building multi-step agent workflows               | agent-builder |
+| Slow inference or high GPU memory usage           | gpu-optimizer |
+| Poor retrieval relevance or hallucination spikes  | rag-auditor   |
+| Wrapping an MCP server as a portable skill        | mcp-to-skill  |
+| Creating exploratory or explanatory notebooks     | notebooklm   |
+
+## When to Use
+
+- Setting up an AI or LLM development environment from scratch.
+- Building custom agents that compose prompts, retrieval, and tool use.
+- Optimizing GPU utilization and inference latency for deployed models.
+- Auditing RAG pipelines for retrieval quality and grounding accuracy.
+- Converting MCP servers into skills for broader distribution.
+- Prototyping AI workflows that span prompt design through deployment.

--- a/presets/ai-builder/evals/cases.yaml
+++ b/presets/ai-builder/evals/cases.yaml
@@ -1,0 +1,38 @@
+cases:
+  - id: install_ai_dev_environment
+    prompt: "I need to set up a complete AI development toolkit for building agents and optimizing inference"
+    fixtures: []
+    rubric:
+      - "installs all six AI builder skills as a bundle"
+      - "covers agent creation, prompt engineering, GPU optimization, and RAG auditing"
+    trigger_expected: true
+
+  - id: build_agent_and_prompts
+    prompt: "I'm building a custom LLM agent with RAG — what packages do I need for prompt design and retrieval auditing?"
+    fixtures: []
+    rubric:
+      - "recommends the ai-builder preset as a complete AI workflow"
+      - "mentions prompt-lab and rag-auditor as included skills"
+    trigger_expected: true
+
+  - id: mcp_and_notebook_workflow
+    prompt: "I want to convert MCP servers to skills and document my AI experiments in notebooks"
+    fixtures: []
+    rubric:
+      - "recommends the ai-builder preset"
+      - "mentions mcp-to-skill and notebooklm as included skills"
+    trigger_expected: true
+
+  - id: negative_academic_research
+    prompt: "I need to do a systematic literature review and write an academic paper"
+    fixtures: []
+    rubric:
+      - "academic research workflows are covered by the research preset, not ai-builder"
+    trigger_expected: false
+
+  - id: negative_security_scanning
+    prompt: "Set up dependency scanning and security auditing for my project"
+    fixtures: []
+    rubric:
+      - "security tooling is covered by the sec-strict preset, not ai-builder"
+    trigger_expected: false

--- a/presets/biz-validation/PRESET.md
+++ b/presets/biz-validation/PRESET.md
@@ -14,15 +14,17 @@ description: >
   Use this preset when setting up a complete business analysis capability across
   market research, competition, and feasibility assessment.
 type: preset
-packages:
-  - skills/market-analyzer
-  - skills/competitive-analyzer
-  - skills/feasibility-assessor
-  - skills/idea-validator
 metadata:
   version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: market-analyzer
+      - name: competitive-analyzer
+      - name: feasibility-assessor
+      - name: idea-validator
   compatibility:
-    platforms: [macos, linux, windows]
+    platforms: [darwin, linux]
 ---
 
 # Biz Validation

--- a/presets/content-ops/PRESET.md
+++ b/presets/content-ops/PRESET.md
@@ -1,0 +1,81 @@
+---
+name: content-ops
+type: preset
+description: >
+  Complete writing toolkit and content pipeline for Claude Code. Bundles text
+  humanization, social media formatting, manuscript review and provenance
+  verification, release notes generation, document summarization, PDF export,
+  and markdown conversion into a single publishing workflow. Covers the full
+  content lifecycle from draft through refinement, review, and export. Handles
+  technical writing, document management, and document conversion tasks. Use
+  this preset when setting up a content creation environment, manuscript tools
+  workspace, social content workflow, or any project requiring a cohesive
+  publishing workflow with release notes and format conversion capabilities.
+metadata:
+  version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: humanize
+      - name: linkedin-post-style
+      - name: manuscript-review
+      - name: manuscript-provenance
+      - name: changelog-composer
+      - name: md-to-pdf
+      - name: doc-condenser
+      - name: to-markdown
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# Content Ops
+
+An end-to-end content lifecycle toolkit for drafting, refining, reviewing, publishing, and exporting documents.
+
+## Included Skills
+
+| Skill                  | Purpose                                      | Output                              |
+| ---------------------- | -------------------------------------------- | ----------------------------------- |
+| `humanize`             | De-AI text, restore natural writing voice     | Rewritten prose free of AI patterns |
+| `linkedin-post-style`  | Format content for LinkedIn and social media  | Platform-ready social posts         |
+| `manuscript-review`    | Pre-submission readiness audit                | Structured review with action items |
+| `manuscript-provenance`| Verify authorship and computational origins   | Provenance verification report      |
+| `changelog-composer`   | Generate release notes from commit history    | Formatted changelog / release notes |
+| `md-to-pdf`            | Export markdown documents to PDF              | PDF file                            |
+| `doc-condenser`        | Summarize and condense lengthy documents      | Condensed summary document          |
+| `to-markdown`          | Convert various formats to markdown           | Markdown file                       |
+
+## Workflow
+
+1. **Draft** — Write or import raw content. Use `to-markdown` to convert source material
+   from other formats into markdown for a consistent working format.
+2. **Refine** — Use `humanize` to remove AI-sounding patterns and restore natural voice.
+   Use `doc-condenser` to tighten verbose sections or produce executive summaries.
+3. **Review** — Use `manuscript-review` for a structured audit of formatting, structure,
+   and prose quality. Use `manuscript-provenance` to verify that all figures, tables, and
+   numbers trace to their computational origins.
+4. **Publish** — Use `linkedin-post-style` to produce social media announcements. Use
+   `changelog-composer` to generate release notes from commit history.
+5. **Export** — Use `md-to-pdf` to produce final PDF deliverables from markdown sources.
+
+## Choosing the Right Skill
+
+| Task                                          | Skill                  |
+| --------------------------------------------- | ---------------------- |
+| Text sounds too robotic or AI-generated       | `humanize`             |
+| Need a LinkedIn or social media post          | `linkedin-post-style`  |
+| Preparing a manuscript for submission         | `manuscript-review`    |
+| Confirming data/figures match source code     | `manuscript-provenance`|
+| Writing release notes for a new version       | `changelog-composer`   |
+| Exporting a document as PDF                   | `md-to-pdf`            |
+| Shortening a long document or extracting key points | `doc-condenser`  |
+| Converting HTML, DOCX, or other formats to MD | `to-markdown`          |
+
+## When to Use
+
+- Technical writing projects requiring draft-to-PDF workflows.
+- Open source projects needing automated release notes and changelogs.
+- Manuscript preparation pipelines from raw draft through submission audit.
+- Content marketing workflows producing blog posts, social announcements, and summaries.
+- Document conversion and standardization across mixed-format source material.
+- Any project where content passes through multiple refinement stages before publication.

--- a/presets/content-ops/evals/cases.yaml
+++ b/presets/content-ops/evals/cases.yaml
@@ -1,0 +1,36 @@
+cases:
+  - id: install_content_pipeline
+    prompt: "I need a writing toolkit for drafting, editing, and exporting documents"
+    fixtures: []
+    rubric:
+      - "installs all eight content-ops skills as a bundle"
+      - "covers drafting, refinement, review, publishing, and export stages"
+    trigger_expected: true
+
+  - id: release_notes_and_social
+    prompt: "Set up tools for generating release notes and LinkedIn posts for my open source project"
+    fixtures: []
+    rubric:
+      - "recommends the content-ops preset covering changelog-composer and linkedin-post-style"
+    trigger_expected: true
+
+  - id: manuscript_workflow
+    prompt: "I'm preparing a manuscript and need review, provenance checks, and PDF export"
+    fixtures: []
+    rubric:
+      - "recommends the content-ops preset for manuscript-review, manuscript-provenance, and md-to-pdf"
+    trigger_expected: true
+
+  - id: negative_code_analysis
+    prompt: "I need static analysis and linting tools for my Python codebase"
+    fixtures: []
+    rubric:
+      - "code analysis and linting are not covered by the content-ops preset"
+    trigger_expected: false
+
+  - id: negative_research_review
+    prompt: "I need to do a systematic literature review and search arXiv for papers"
+    fixtures: []
+    rubric:
+      - "literature review and paper discovery are covered by the research preset, not content-ops"
+    trigger_expected: false

--- a/presets/core/PRESET.md
+++ b/presets/core/PRESET.md
@@ -32,13 +32,13 @@ cover the review-commit lifecycle without imposing language-specific constraints
 
 ## Included Packages
 
-| Type  | Package             | Role                                              |
-| ----- | ------------------- | ------------------------------------------------- |
-| Skill | pr-review           | Diff-based code review across five dimensions     |
-| Skill | code-refiner        | Structural simplification preserving behavior     |
-| Skill | pre-landing-review  | Final merge-readiness gate                        |
-| Hook  | git-protection      | Blocks force-push and branch deletion on main     |
-| Rule  | commit-standards    | Enforces conventional commit message formatting   |
+| Type  | Package            | Role                                            |
+| ----- | ------------------ | ----------------------------------------------- |
+| Skill | pr-review          | Diff-based code review across five dimensions   |
+| Skill | code-refiner       | Structural simplification preserving behavior   |
+| Skill | pre-landing-review | Final merge-readiness gate                      |
+| Hook  | git-protection     | Blocks force-push and branch deletion on main   |
+| Rule  | commit-standards   | Enforces conventional commit message formatting |
 
 ## Workflow
 
@@ -62,4 +62,4 @@ cover the review-commit lifecycle without imposing language-specific constraints
 Layer additional presets on top of `core`:
 
 - **python-strict** — adds Python-focused testing, security scanning, and stricter rules.
-- **security-first** — adds security auditing, dependency scanning, and cost tracking.
+- **sec-strict** — adds security auditing, dependency scanning, and cost tracking.

--- a/presets/eng-ops/PRESET.md
+++ b/presets/eng-ops/PRESET.md
@@ -1,0 +1,82 @@
+---
+name: eng-ops
+type: preset
+description: >
+  Full-cycle engineering operations preset covering the build-test-ship pipeline and
+  surrounding practices. Bundles shipping workflow orchestration, systematic QA and test
+  planning, test scaffolding and harness generation, performance benchmarking, migration
+  safety analysis, effort estimation calibration, engineering retrospectives, and root
+  cause debugging investigation. Use this preset when managing an engineering workflow,
+  running a shipping pipeline, coordinating release management, conducting test planning
+  or QA toolkit setup, executing performance testing or benchmark suites, evaluating
+  migration safety and risk, calibrating effort estimation for sprints, facilitating a
+  retrospective, or assembling a debugging toolkit for incident response.
+metadata:
+  version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: ship-workflow
+      - name: qa-systematic
+      - name: test-harness
+      - name: benchmark-runner
+      - name: migration-risk-analyzer
+      - name: estimate-calibrator
+      - name: engineering-retro
+      - name: debug-investigator
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# Eng Ops
+
+End-to-end engineering operations toolkit spanning the plan-build-test-ship-reflect lifecycle.
+
+## Included Skills
+
+| Skill                    | Purpose                                        | Phase   |
+| ------------------------ | ---------------------------------------------- | ------- |
+| ship-workflow            | Orchestrate end-to-end shipping pipeline       | ship    |
+| qa-systematic            | Systematic test planning and QA strategy       | plan    |
+| test-harness             | Test scaffolding and generation                | test    |
+| benchmark-runner         | Performance benchmarking and regression checks | test    |
+| migration-risk-analyzer  | Migration safety and rollback analysis         | build   |
+| estimate-calibrator      | Effort estimation calibration and tracking     | plan    |
+| engineering-retro        | Structured engineering retrospectives          | reflect |
+| debug-investigator       | Root cause analysis and debugging              | build   |
+
+## Workflow
+
+1. **Plan** — use `estimate-calibrator` to size work and `qa-systematic` to define the
+   test strategy before writing code.
+2. **Build** — invoke `debug-investigator` for root cause analysis when issues arise.
+   Run `migration-risk-analyzer` before applying schema or infrastructure changes.
+3. **Test** — generate test scaffolding with `test-harness`. Validate performance
+   characteristics with `benchmark-runner`.
+4. **Ship** — orchestrate the release pipeline end-to-end with `ship-workflow`.
+5. **Reflect** — run `engineering-retro` after a milestone or incident to capture
+   lessons learned and action items.
+
+## Choosing the Right Skill
+
+| Situation                                          | Skill                   |
+| -------------------------------------------------- | ----------------------- |
+| Need to estimate story points or delivery timeline | estimate-calibrator     |
+| Designing a test plan for a feature or service     | qa-systematic           |
+| Generating test files, fixtures, or boilerplate    | test-harness            |
+| Measuring latency, throughput, or memory usage     | benchmark-runner        |
+| Evaluating risk of a database or infra migration   | migration-risk-analyzer |
+| Tracking down a bug or production incident         | debug-investigator      |
+| Cutting a release or coordinating deploy steps     | ship-workflow           |
+| Running a sprint retro or post-incident review     | engineering-retro       |
+
+## When to Use
+
+- Setting up or improving an engineering team's operational workflow.
+- Projects entering a shipping phase that need release coordination.
+- Teams adopting structured test planning and QA practices.
+- Performance-sensitive services requiring benchmark regression gates.
+- Database or infrastructure migrations requiring risk assessment.
+- Sprint planning sessions needing calibrated effort estimates.
+- Post-incident or post-milestone retrospectives.
+- Debugging complex production issues across multiple services.

--- a/presets/eng-ops/evals/cases.yaml
+++ b/presets/eng-ops/evals/cases.yaml
@@ -1,0 +1,33 @@
+cases:
+  - id: install_eng_ops_for_shipping
+    prompt: "Set up a complete build-test-ship pipeline for our engineering team."
+    fixtures: []
+    rubric:
+      - "recommends or activates the eng-ops preset"
+      - "mentions ship-workflow, test-harness, or benchmark-runner as included skills"
+      - "describes the engineering lifecycle coverage"
+    trigger_expected: true
+
+  - id: install_eng_ops_for_retro
+    prompt: "We need tooling for sprint retrospectives and effort estimation calibration."
+    fixtures: []
+    rubric:
+      - "recommends the eng-ops preset"
+      - "mentions engineering-retro and estimate-calibrator as included skills"
+    trigger_expected: true
+
+  - id: single_debug_skill_not_preset
+    prompt: "Help me debug this null pointer exception in the auth service."
+    fixtures: []
+    rubric:
+      - "assists with debugging directly or suggests debug-investigator skill"
+      - "does not activate the eng-ops preset"
+    trigger_expected: false
+
+  - id: security_audit_not_eng_ops
+    prompt: "Run a security audit and dependency vulnerability scan on our codebase."
+    fixtures: []
+    rubric:
+      - "does not recommend the eng-ops preset"
+      - "suggests security-focused tooling or the sec-strict preset instead"
+    trigger_expected: false

--- a/presets/media-craft/PRESET.md
+++ b/presets/media-craft/PRESET.md
@@ -1,0 +1,70 @@
+---
+name: media-craft
+type: preset
+description: >
+  Visual content creation toolkit for Claude Code. Bundles image generation
+  (PNG/SVG from HTML/CSS), video production (MP4/GIF via Manim and React/Remotion),
+  slide deck authoring, interactive HTML visual builders, and system architecture
+  diagrams into a single install. Create visual assets, make an image, generate video,
+  design presentation decks, produce graphics, build slides, and compose animations
+  from natural language descriptions. Serves as a media toolkit for creative assets,
+  visual content pipelines, and animation toolkit workflows. Use this preset when
+  producing graphics, illustrations, explainer videos, branded content, interactive
+  data visualizations, or architectural topology diagrams from concept descriptions.
+metadata:
+  version: 1.0.0
+preset:
+  packages:
+    skills:
+      - name: concept-to-image
+      - name: concept-to-video
+      - name: remotion-video
+      - name: html-presentation
+      - name: static-web-artifacts-builder
+      - name: architecture-diagram
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# Media Craft
+
+A concept-to-deliverable pipeline for generating images, videos, presentations, interactive visuals, and diagrams.
+
+## Included Skills
+
+| Skill                        | Purpose                                      | Output Format |
+| ---------------------------- | -------------------------------------------- | ------------- |
+| concept-to-image             | Generate illustrations from descriptions     | PNG, SVG      |
+| concept-to-video             | Produce animated explainers and motion clips  | MP4, GIF      |
+| remotion-video               | Build branded, programmatic video content     | MP4           |
+| html-presentation            | Author slide decks from structured content   | HTML          |
+| static-web-artifacts-builder | Create interactive data visuals and widgets   | HTML          |
+| architecture-diagram         | Render system topology and architecture maps | SVG, PNG      |
+
+## Workflow
+
+1. **Concept → Image** — Describe a visual concept in plain language. `concept-to-image` renders it as a PNG or SVG using HTML/CSS techniques.
+2. **Concept → Video** — Provide a narrative or sequence. `concept-to-video` produces an MP4 or GIF animation via Manim. For branded or React-based video, use `remotion-video` instead.
+3. **Concept → Presentation** — Supply an outline or topic. `html-presentation` generates a full slide deck with transitions and speaker notes.
+4. **Concept → Interactive HTML** — Describe a data visualization or interactive widget. `static-web-artifacts-builder` outputs a self-contained HTML artifact.
+5. **Concept → Diagram** — Specify system components and relationships. `architecture-diagram` renders topology diagrams for documentation or review.
+
+## Choosing the Right Skill
+
+| If you need...                              | Use                          |
+| ------------------------------------------- | ---------------------------- |
+| A static illustration, icon, or graphic     | concept-to-image             |
+| An animated explainer or math visualization | concept-to-video             |
+| A branded marketing or product video        | remotion-video               |
+| A conference talk or lecture deck           | html-presentation            |
+| An interactive chart, dashboard, or widget  | static-web-artifacts-builder |
+| A system architecture or infrastructure map | architecture-diagram         |
+
+## When to Use
+
+- Generating visual assets for blog posts, documentation, or social media.
+- Producing explainer videos or animated walkthroughs of technical concepts.
+- Building branded video content with React/Remotion pipelines.
+- Creating conference presentations or internal slide decks from outlines.
+- Designing interactive data visualizations or dashboards as standalone HTML.
+- Rendering architecture diagrams for system design reviews or RFCs.

--- a/presets/media-craft/evals/cases.yaml
+++ b/presets/media-craft/evals/cases.yaml
@@ -1,0 +1,36 @@
+cases:
+  - id: create_visual_assets
+    prompt: "I need to create visual content — images, videos, and presentations for a product launch"
+    fixtures: []
+    rubric:
+      - "installs all six media-craft skills as a bundle"
+      - "covers image generation, video production, presentations, and diagrams"
+    trigger_expected: true
+
+  - id: generate_explainer_video
+    prompt: "Generate an animated explainer video and some diagrams for my architecture docs"
+    fixtures: []
+    rubric:
+      - "recommends the media-craft preset for video and diagram generation"
+    trigger_expected: true
+
+  - id: build_slide_deck
+    prompt: "Build slides for my conference talk and produce graphics for each slide"
+    fixtures: []
+    rubric:
+      - "activates media-craft preset covering html-presentation and concept-to-image"
+    trigger_expected: true
+
+  - id: negative_code_linting
+    prompt: "Set up Python linting and type checking for my project"
+    fixtures: []
+    rubric:
+      - "code quality tooling is covered by the python-strict preset, not media-craft"
+    trigger_expected: false
+
+  - id: negative_literature_review
+    prompt: "I need to do a systematic literature review for my thesis"
+    fixtures: []
+    rubric:
+      - "academic research workflows are covered by the research preset, not media-craft"
+    trigger_expected: false

--- a/presets/research/evals/cases.yaml
+++ b/presets/research/evals/cases.yaml
@@ -25,5 +25,5 @@ cases:
     prompt: "I need security scanning and dependency auditing tools"
     fixtures: []
     rubric:
-      - "security tooling is covered by the security-first preset, not research"
+      - "security tooling is covered by the sec-strict preset, not research"
     trigger_expected: false

--- a/presets/sec-strict/PRESET.md
+++ b/presets/sec-strict/PRESET.md
@@ -1,5 +1,5 @@
 ---
-name: security-first
+name: sec-strict
 type: preset
 description: >
   Security-focused preset for projects requiring audit-grade protection. Extends the
@@ -33,27 +33,27 @@ preset:
     platforms: [darwin, linux]
 ---
 
-# Security First Preset
+# Sec Strict Preset
 
 An audit-grade security stack for projects where security posture is a primary concern.
 Installs 11 packages providing layered defense across the development lifecycle.
 
 ## Included Packages
 
-| Type    | Package             | Role                                                |
-| ------- | ------------------- | --------------------------------------------------- |
-| Skill   | pr-review           | Diff-based code review across five dimensions       |
-| Skill   | code-refiner        | Structural simplification preserving behavior       |
-| Skill   | pre-landing-review  | Final merge-readiness gate                          |
-| Skill   | repo-sentinel       | Repository configuration and policy monitoring      |
-| Skill   | dependency-audit    | Dependency vulnerability and license scanning       |
-| Agent   | security-reviewer   | Security-focused automated code review              |
-| Agent   | secret-scanner      | Detects leaked credentials and API keys             |
-| Rule    | security-standards  | Enforces secure coding patterns                     |
-| Rule    | commit-standards    | Enforces conventional commit message formatting     |
-| Hook    | git-protection      | Blocks force-push and branch deletion on main       |
-| Hook    | cost-tracker        | Monitors and logs API usage costs                   |
-| Command | security-scan       | On-demand security vulnerability scanning           |
+| Type    | Package            | Role                                            |
+| ------- | ------------------ | ----------------------------------------------- |
+| Skill   | pr-review          | Diff-based code review across five dimensions   |
+| Skill   | code-refiner       | Structural simplification preserving behavior   |
+| Skill   | pre-landing-review | Final merge-readiness gate                      |
+| Skill   | repo-sentinel      | Repository configuration and policy monitoring  |
+| Skill   | dependency-audit   | Dependency vulnerability and license scanning   |
+| Agent   | security-reviewer  | Security-focused automated code review          |
+| Agent   | secret-scanner     | Detects leaked credentials and API keys         |
+| Rule    | security-standards | Enforces secure coding patterns                 |
+| Rule    | commit-standards   | Enforces conventional commit message formatting |
+| Hook    | git-protection     | Blocks force-push and branch deletion on main   |
+| Hook    | cost-tracker       | Monitors and logs API usage costs               |
+| Command | security-scan      | On-demand security vulnerability scanning       |
 
 ## Defense Layers
 
@@ -77,5 +77,5 @@ Installs 11 packages providing layered defense across the development lifecycle.
 
 ## Relationship to Core
 
-This preset is a superset of `core`. Installing `security-first` provides everything
+This preset is a superset of `core`. Installing `sec-strict` provides everything
 in `core` plus security-specific tooling. There is no need to install both.

--- a/presets/sec-strict/evals/cases.yaml
+++ b/presets/sec-strict/evals/cases.yaml
@@ -3,7 +3,7 @@ cases:
     prompt: "Set up a security-focused stack for our application that handles user data."
     fixtures: []
     rubric:
-      - "recommends or activates the security-first preset"
+      - "recommends or activates the sec-strict preset"
       - "mentions security-reviewer, secret-scanner, or dependency-audit as included"
       - "acknowledges this covers sensitive data handling"
     trigger_expected: true
@@ -12,7 +12,7 @@ cases:
     prompt: "We need audit-grade security tooling for our SOC 2 compliant service."
     fixtures: []
     rubric:
-      - "recommends security-first preset"
+      - "recommends sec-strict preset"
       - "mentions security-standards rule or security-scan command"
     trigger_expected: true
 
@@ -21,7 +21,7 @@ cases:
     fixtures: []
     rubric:
       - "executes the security-scan command directly"
-      - "does not activate the security-first preset"
+      - "does not activate the sec-strict preset"
     trigger_expected: false
 
   - id: performance_optimization_not_security


### PR DESCRIPTION
## Summary

Renames `security-first` → `sec-strict` for naming consistency, adds 4 new domain-specific presets, and restructures the README to feature presets prominently at the top of the package catalog.

### Changes

**Rename**
- `presets/security-first/` → `presets/sec-strict/` — shorter name consistent with `python-strict` convention
- Updated all cross-references: README, `core` PRESET.md, `research` evals, manifest

**4 New Presets**

| Preset | Skills | Purpose |
|--------|--------|---------|
| `ai-builder` | 6 | AI/ML development — agent building, prompt engineering, GPU optimization, RAG auditing, MCP-to-skill, notebooks |
| `content-ops` | 8 | Writing & publishing — humanize, social content, manuscript review/provenance, changelogs, PDF export, summarization, format conversion |
| `eng-ops` | 8 | Engineering operations — ship workflow, systematic QA, test scaffolding, benchmarking, migration risk, estimation, retrospectives, debugging |
| `media-craft` | 6 | Visual & video production — concept-to-image (PNG/SVG), concept-to-video (Manim), Remotion (React), HTML presentations, interactive HTML, architecture diagrams |

Each preset includes:
- `PRESET.md` with YAML frontmatter (name, type, description with trigger phrases, packages list, platform compatibility)
- `evals/cases.yaml` with positive and negative trigger cases
- Markdown body with included skills table, workflow documentation, decision guide, and usage scenarios

**README Restructure**
- Moved presets to top of Package Catalog as a new `## Presets` section with detailed descriptions (skills count, key frameworks, relationship to other presets)
- Added 4 missing business validation skills to catalog (`idea-validator`, `market-analyzer`, `competitive-analyzer`, `feasibility-assessor`)
- Added missing `research-critique` skill to catalog
- Removed duplicate presets table from bottom of catalog
- Updated package count badge: 72 → 81

### Preset Inventory (9 total)

| Preset | Category | Skills Bundled |
|--------|----------|---------------|
| `core` | Baseline | pr-review, code-refiner, pre-landing-review, git-protection, commit-standards |
| `sec-strict` | Security | core + security-reviewer, secret-scanner, dependency-audit, repo-sentinel, security-scan |
| `python-strict` | Language | Python type checking, test standards, security scanning |
| `research` | Academic | literature-review, manuscript-review, manuscript-provenance, research-critique, youtube-analysis |
| `biz-validation` | Business | market-analyzer, competitive-analyzer, feasibility-assessor, idea-validator |
| `eng-ops` | Engineering | ship-workflow, qa-systematic, test-harness, benchmark-runner, migration-risk-analyzer, estimate-calibrator, engineering-retro, debug-investigator |
| `media-craft` | Creative | concept-to-image, concept-to-video, remotion-video, html-presentation, static-web-artifacts-builder, architecture-diagram |
| `content-ops` | Writing | humanize, linkedin-post-style, manuscript-review, manuscript-provenance, changelog-composer, md-to-pdf, doc-condenser, to-markdown |
| `ai-builder` | AI/ML | agent-builder, prompt-lab, gpu-optimizer, rag-auditor, mcp-to-skill, notebooklm |

### File Changes

- 14 files changed, 556 insertions, 45 deletions
- 4 new preset directories with PRESET.md + evals
- 1 preset renamed (directory + all references)
- README restructured with presets at top
- Manifest regenerated (9 presets total)

## Test plan

- [ ] Verify `uv run python scripts/validate_evals.py` passes (all 8 preset evals + existing)
- [ ] Verify `uv run python scripts/generate_manifest.py` produces consistent output
- [ ] Verify no stale `security-first` references: `grep -r 'security-first' .`
- [ ] Verify all preset package references resolve: each skill listed in preset packages exists under `skills/`
- [ ] Verify README presets table links resolve to correct directories
- [ ] Verify package count badge (81) matches manifest totals