### PR TITLE
fix(md-to-pdf): resolve Chromium crashes on macOS

### DIFF
--- a/skills/md-to-pdf/SKILL.md
+++ b/skills/md-to-pdf/SKILL.md
@@ -11,7 +11,7 @@ description: >
   "can you make a PDF from this markdown".
 license: MIT. See LICENSE.txt for complete terms.
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Markdown to PDF Converter

--- a/skills/md-to-pdf/scripts/md_to_pdf.py
+++ b/skills/md-to-pdf/scripts/md_to_pdf.py
@@ -277,7 +277,7 @@ def create_puppeteer_config(tmpdir: Path) -> Path:
 
     config = {
         "executablePath": chrome_path,
-        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--single-process"],
+        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
     }
     config_path = tmpdir / "puppeteer-config.json"
     config_path.write_text(json.dumps(config))
@@ -467,7 +467,7 @@ def html_to_pdf(html_path: Path, pdf_path: Path, page_format: str,
     with sync_playwright() as p:
         browser = p.chromium.launch(args=[
             '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage',
-            '--disable-software-rasterizer', '--single-process',
+            '--disable-software-rasterizer',
         ])
         context = browser.new_context()
         page = context.new_page()

--- a/skills/md-to-pdf/scripts/md_to_pdf.py
+++ b/skills/md-to-pdf/scripts/md_to_pdf.py
@@ -251,11 +251,13 @@ def find_chrome_binary() -> str | None:
                 return str(chrome)
 
     # Check Playwright's Chromium
-    for pw_dir in [Path("/opt/pw-browsers"), Path.home() / ".cache/ms-playwright"]:
+    for pw_dir in [Path("/opt/pw-browsers"), Path.home() / ".cache/ms-playwright",
+                   Path.home() / "Library/Caches/ms-playwright"]:
         if pw_dir.exists():
-            for chrome in pw_dir.rglob("chrome"):
-                if chrome.is_file() and os.access(str(chrome), os.X_OK):
-                    return str(chrome)
+            for pattern in ["chrome", "Chromium"]:
+                for chrome in pw_dir.rglob(pattern):
+                    if chrome.is_file() and os.access(str(chrome), os.X_OK):
+                        return str(chrome)
 
     # Check system Chrome
     for p in ["/opt/google/chrome/chrome", "/usr/bin/chromium-browser",


### PR DESCRIPTION
## Summary

The `md-to-pdf` skill fails on macOS due to three Chromium-related issues:

1. **Playwright cache path not searched on macOS** — `find_chrome_binary()` searched `~/.cache/ms-playwright/` (Linux) but not `~/Library/Caches/ms-playwright/` (macOS), causing Chromium discovery to fail.

2. **Binary name mismatch** — On macOS, Playwright's executable is named `Chromium`, not `chrome`. The `rglob("chrome")` pattern missed it entirely.

3. **`--single-process` crashes Chromium on macOS** — This flag is Linux-only safe. On macOS, Chromium's multi-process architecture is required; single-process mode causes immediate `TargetClosedError` as browser and renderer crash together. This flag was present in **two** separate code paths:
   - `create_puppeteer_config()` — JSON config passed to mmdc (Mermaid CLI via Puppeteer)
   - `html_to_pdf()` — Playwright browser launch args for PDF rendering

## Changes

### `skills/md-to-pdf/scripts/md_to_pdf.py`

- **`find_chrome_binary()`**: Added `~/Library/Caches/ms-playwright/` to the Playwright search paths. Search now uses both `chrome` and `Chromium` as rglob patterns instead of just `chrome`.
- **`create_puppeteer_config()`**: Removed `--single-process` from the Puppeteer args array passed to mmdc for Mermaid diagram rendering.
- **`html_to_pdf()`**: Removed `--single-process` from the Playwright Chromium launch args for PDF generation.

### `skills/md-to-pdf/SKILL.md`

- Version bump `1.1.0` → `1.2.0`

## Commits

| Commit | Description |
|--------|-------------|
| `fix(md-to-pdf): add macOS Chromium discovery paths` | Cache path + binary name fix in `find_chrome_binary()` |
| `fix(md-to-pdf): remove --single-process from Chromium launch args` | Both Puppeteer config and Playwright launch |
| `chore(md-to-pdf): bump version to 1.2.0` | Version metadata update |

## Test plan

- [ ] Run `md-to-pdf` on macOS to verify Chromium is discovered in `~/Library/Caches/ms-playwright/`
- [ ] Verify Mermaid diagram rendering completes without Puppeteer crash
- [ ] Verify PDF generation completes without Playwright `TargetClosedError`
- [ ] Confirm Linux environments still work (paths are additive, not replaced)