### PR TITLE
fix(manifest): sync md-to-pdf version to 1.2.0

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -359,7 +359,7 @@ packages:
     path: skills/mcp-to-skill
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/mcp-to-skill/SKILL.md
   - name: md-to-pdf
-    version: 1.1.0
+    version: 1.2.0
     description: 'Convert Markdown files to professionally styled PDF documents with full support for Mermaid diagrams, LaTeX/KaTeX
       math equations, tables, syntax-highlighted code blocks, and all standard Markdown features. Use this skill whenever
       the user wants to convert a .md file to .pdf, generate a PDF report from Markdown, or produce print-ready documents


### PR DESCRIPTION
## Summary

- Regenerate `manifest.yaml` to reflect the md-to-pdf version bump (`1.1.0` → `1.2.0`) from PR #33

## Context

CI on PR #33 failed because the version bump in `skills/md-to-pdf/SKILL.md` was not accompanied by a `manifest.yaml` regeneration. This is a one-line fix — `python scripts/generate_manifest.py` output.

## Test plan

- [ ] CI manifest validation passes