### PR TITLE
feat(adapters): cross-platform adapter generation for Cursor, Codex, and Gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov/
 playwright-report/
 
 # ── Generated output ──────────────────────────
+adapters/
 *.pdf
 *.png
 *.svg

--- a/README.md
+++ b/README.md
@@ -342,15 +342,83 @@ uv run scripts/package.py hooks/git-protection            # produces .hook
 
 ---
 
-## Portability
+## Cross-Platform Adapters
 
-These packages are Claude-native (Claude Code and Claude.ai).
+Packages are authored as Claude Code-native definitions. The adapter generator transforms them into platform-specific formats for Cursor, OpenAI Codex, and Gemini CLI.
 
-Adapters for other agent surfaces are planned in `adapters/`:
+### Generate
 
-- **Cursor** — `.cursorrules`
-- **OpenAI Codex** — `AGENTS.md`
-- **Gemini CLI** — `GEMINI.md`
+```bash
+# All platforms
+uv run scripts/generate_adapters.py
+
+# Single platform
+uv run scripts/generate_adapters.py --platform cursor
+uv run scripts/generate_adapters.py --platform codex
+uv run scripts/generate_adapters.py --platform gemini
+
+# Filter by package type
+uv run scripts/generate_adapters.py --platform cursor --type skills --type rules
+
+# Preview without writing
+uv run scripts/generate_adapters.py --dry-run
+```
+
+Output lands in `adapters/{platform}/` (gitignored — generated, not source).
+
+### Platform Mapping
+
+| Armory Type | Cursor | Codex | Gemini |
+|-------------|--------|-------|--------|
+| **Skills** | `.cursor/rules/{name}.mdc` | `skills/AGENTS.md` | `.gemini/skills/{name}/SKILL.md` |
+| **Agents** | `.cursor/rules/{name}.mdc` | `agents/AGENTS.md` | `.gemini/agents/{name}.md` |
+| **Rules** | `.cursor/rules/{name}.mdc` (alwaysApply) | `standards/AGENTS.md` | Sections in `GEMINI.md` |
+| **Commands** | `.cursor/commands/{name}.md` | `workflows/AGENTS.md` | `.gemini/commands/workflow/{name}.toml` |
+| **Hooks** | — | — | — |
+| **Utilities** | — | — | Wrapped as `.gemini/skills/` |
+| **Presets** | — | — | — |
+
+### Use with Cursor
+
+Copy the generated `.cursor/` directory into your project root:
+
+```bash
+uv run scripts/generate_adapters.py --platform cursor
+cp -r adapters/cursor/.cursor /path/to/your/project/
+```
+
+Rules with `alwaysApply: true` (project standards) load on every prompt. Skills and agents load when Cursor matches the description or glob pattern.
+
+### Use with OpenAI Codex
+
+Copy the generated Codex directory to your project root:
+
+```bash
+uv run scripts/generate_adapters.py --platform codex
+cp adapters/codex/AGENTS.md /path/to/your/project/
+cp -r adapters/codex/{standards,agents,workflows,skills} /path/to/your/project/
+```
+
+The root `AGENTS.md` is a condensed index under the 32 KiB budget. Full content is in subdirectory `AGENTS.md` files, loaded via Codex's hierarchical discovery when the working directory matches.
+
+### Use with Gemini CLI
+
+Copy the generated `.gemini/` directory into your project root:
+
+```bash
+uv run scripts/generate_adapters.py --platform gemini
+cp -r adapters/gemini/.gemini /path/to/your/project/
+```
+
+Skills are a near 1:1 copy (references, scripts, and assets included). Rules become sections in `GEMINI.md`. Commands are converted to TOML format. Agents are markdown files with cleaned frontmatter.
+
+### What's Lost
+
+Not all package types have equivalents on every platform:
+
+- **Hooks** have no equivalent on Cursor or Codex. Gemini has hooks but uses a different event model.
+- **Presets** require a dependency resolver that no target platform provides.
+- **Utilities** with executable scripts are skipped on Cursor and Codex (passive context only). Gemini wraps them as skills.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ Intended for developers who treat AI coding agents as a serious part of their wo
 
 Orchestrator agents compose skills and other agents into multi-phase workflows. Each can run solo or be spawned by another agent via the Agent tool.
 
-| Agent                                              | Model  | Description                                                                                                     |
-| -------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
-| [team-lead](agents/team-lead/)                     | opus   | Meta-orchestrator — decomposes multi-domain requests, delegates to specialized agents, synthesizes results       |
-| [codebase-auditor](agents/codebase-auditor/)       | sonnet | Unified quality assessment — spawns code-reviewer, security-reviewer, secret-scanner in parallel, merges report |
-| [project-architect](agents/project-architect/)     | opus   | Phased requirements discovery producing architecture documents with diagrams and tech stack justification        |
-| [project-planner](agents/project-planner/)         | sonnet | Task decomposition with dependency mapping, three-point estimates, milestone timelines, and risk logs            |
-| [research-analyst](agents/research-analyst/)       | opus   | Multi-source investigation with parallel agents across web, academic, video, and competitive sources             |
-| [idea-scout](agents/idea-scout/)                   | opus   | Business idea validation — Lean Canvas, parallel market/competitive/feasibility research, weighted scorecard     |
-| [full-stack-builder](agents/full-stack-builder/)   | opus   | End-to-end implementation from spec — scaffolding, sprints, quality passes, documentation, pre-delivery review   |
-| [release-captain](agents/release-captain/)         | sonnet | Ship lifecycle with quality gates — pre-flight, secret scan, changelog, version bump, PR creation               |
-| [proposal-writer](agents/proposal-writer/)         | opus   | Technical proposals with ROI calculations, three-tier pricing, and Problem-Agitate-Solve framing                |
-| [content-strategist](agents/content-strategist/)   | sonnet | Multi-channel content creation with per-channel adaptation and automated quality passes                          |
-| [media-producer](agents/media-producer/)           | sonnet | Visual and video format router — selects the right skill based on concept type and output needs                  |
+| Agent                                            | Model  | Description                                                                                                     |
+| ------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------- |
+| [team-lead](agents/team-lead/)                   | opus   | Meta-orchestrator — decomposes multi-domain requests, delegates to specialized agents, synthesizes results      |
+| [codebase-auditor](agents/codebase-auditor/)     | sonnet | Unified quality assessment — spawns code-reviewer, security-reviewer, secret-scanner in parallel, merges report |
+| [project-architect](agents/project-architect/)   | opus   | Phased requirements discovery producing architecture documents with diagrams and tech stack justification       |
+| [project-planner](agents/project-planner/)       | sonnet | Task decomposition with dependency mapping, three-point estimates, milestone timelines, and risk logs           |
+| [research-analyst](agents/research-analyst/)     | opus   | Multi-source investigation with parallel agents across web, academic, video, and competitive sources            |
+| [idea-scout](agents/idea-scout/)                 | opus   | Business idea validation — Lean Canvas, parallel market/competitive/feasibility research, weighted scorecard    |
+| [full-stack-builder](agents/full-stack-builder/) | opus   | End-to-end implementation from spec — scaffolding, sprints, quality passes, documentation, pre-delivery review  |
+| [release-captain](agents/release-captain/)       | sonnet | Ship lifecycle with quality gates — pre-flight, secret scan, changelog, version bump, PR creation               |
+| [proposal-writer](agents/proposal-writer/)       | opus   | Technical proposals with ROI calculations, three-tier pricing, and Problem-Agitate-Solve framing                |
+| [content-strategist](agents/content-strategist/) | sonnet | Multi-channel content creation with per-channel adaptation and automated quality passes                         |
+| [media-producer](agents/media-producer/)         | sonnet | Visual and video format router — selects the right skill based on concept type and output needs                 |
 
 ### Agents — Analyzers
 
@@ -189,24 +189,24 @@ Skills below are superseded by base model capabilities. They remain installable 
 
 Presets install curated bundles of passive packages (rules, hooks, commands) in one command. For active workflow orchestration, use agents instead.
 
-| Preset                                    | Packages                                          | Description                                                                                              |
-| ----------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [core](presets/core/)                     | 3 skills, 1 hook, 1 rule                          | Baseline review-commit lifecycle. Start here.                                                            |
-| [sec-strict](presets/sec-strict/)         | 5 skills, 3 agents, 2 rules, 2 hooks, 1 command   | Audit-grade security stack with codebase-auditor. Superset of `core`.                                    |
-| [python-strict](presets/python-strict/)   | 4 skills, 2 agents, 3 rules, 2 hooks, 2 commands  | Full Python enforcement — TDD, type checking, test coverage, security standards.                         |
-| [ai-builder](presets/ai-builder/)         | 6 skills                                          | AI/ML development toolkit — agent building, prompt engineering, GPU optimization, RAG auditing.           |
+| Preset                                  | Packages                                         | Description                                                                                     |
+| --------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| [core](presets/core/)                   | 3 skills, 1 hook, 1 rule                         | Baseline review-commit lifecycle. Start here.                                                   |
+| [sec-strict](presets/sec-strict/)       | 5 skills, 3 agents, 2 rules, 2 hooks, 1 command  | Audit-grade security stack with codebase-auditor. Superset of `core`.                           |
+| [python-strict](presets/python-strict/) | 4 skills, 2 agents, 3 rules, 2 hooks, 2 commands | Full Python enforcement — TDD, type checking, test coverage, security standards.                |
+| [ai-builder](presets/ai-builder/)       | 6 skills                                         | AI/ML development toolkit — agent building, prompt engineering, GPU optimization, RAG auditing. |
 
 ### Deprecated Presets
 
 Superseded by orchestrator agents that provide autonomous workflow orchestration instead of manual skill invocation.
 
-| Preset | Replacement |
-| ------ | ----------- |
-| ~~biz-validation~~ | `idea-scout` agent |
-| ~~media-craft~~ | `media-producer` agent |
-| ~~content-ops~~ | `content-strategist` agent |
-| ~~research~~ | `research-analyst` agent |
-| ~~eng-ops~~ | `release-captain` + `full-stack-builder` agents |
+| Preset             | Replacement                                     |
+| ------------------ | ----------------------------------------------- |
+| ~~biz-validation~~ | `idea-scout` agent                              |
+| ~~media-craft~~    | `media-producer` agent                          |
+| ~~content-ops~~    | `content-strategist` agent                      |
+| ~~research~~       | `research-analyst` agent                        |
+| ~~eng-ops~~        | `release-captain` + `full-stack-builder` agents |
 
 ---
 
@@ -368,15 +368,15 @@ Output lands in `adapters/{platform}/` (gitignored — generated, not source).
 
 ### Platform Mapping
 
-| Armory Type | Cursor | Codex | Gemini |
-|-------------|--------|-------|--------|
-| **Skills** | `.cursor/rules/{name}.mdc` | `skills/AGENTS.md` | `.gemini/skills/{name}/SKILL.md` |
-| **Agents** | `.cursor/rules/{name}.mdc` | `agents/AGENTS.md` | `.gemini/agents/{name}.md` |
-| **Rules** | `.cursor/rules/{name}.mdc` (alwaysApply) | `standards/AGENTS.md` | Sections in `GEMINI.md` |
-| **Commands** | `.cursor/commands/{name}.md` | `workflows/AGENTS.md` | `.gemini/commands/workflow/{name}.toml` |
-| **Hooks** | — | — | — |
-| **Utilities** | — | — | Wrapped as `.gemini/skills/` |
-| **Presets** | — | — | — |
+| Armory Type   | Cursor                                   | Codex                 | Gemini                                  |
+| ------------- | ---------------------------------------- | --------------------- | --------------------------------------- |
+| **Skills**    | `.cursor/rules/{name}.mdc`               | `skills/AGENTS.md`    | `.gemini/skills/{name}/SKILL.md`        |
+| **Agents**    | `.cursor/rules/{name}.mdc`               | `agents/AGENTS.md`    | `.gemini/agents/{name}.md`              |
+| **Rules**     | `.cursor/rules/{name}.mdc` (alwaysApply) | `standards/AGENTS.md` | Sections in `GEMINI.md`                 |
+| **Commands**  | `.cursor/commands/{name}.md`             | `workflows/AGENTS.md` | `.gemini/commands/workflow/{name}.toml` |
+| **Hooks**     | —                                        | —                     | —                                       |
+| **Utilities** | —                                        | —                     | Wrapped as `.gemini/skills/`            |
+| **Presets**   | —                                        | —                     | —                                       |
 
 ### Use with Cursor
 

--- a/scripts/generate_adapters.py
+++ b/scripts/generate_adapters.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Generate platform-specific adapter output from armory package definitions.
+
+Transforms Claude Code-native packages (SKILL.md, AGENT.md, RULE.md, COMMAND.md)
+into platform-specific formats for Cursor, Codex, and Gemini CLI.
+
+Usage:
+    uv run scripts/generate_adapters.py                           # All platforms
+    uv run scripts/generate_adapters.py --platform cursor         # Cursor only
+    uv run scripts/generate_adapters.py --platform codex          # Codex only
+    uv run scripts/generate_adapters.py --platform gemini         # Gemini only
+    uv run scripts/generate_adapters.py --platform cursor --type rules --type skills
+    uv run scripts/generate_adapters.py --dry-run                 # Preview only
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Ensure repo root is on sys.path for direct script execution.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml
+
+from scripts.frontmatter import extract_body, parse_frontmatter
+from scripts.package_types import REPO_ROOT, TYPES
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PackageContent:
+    """Parsed package with frontmatter and body separated."""
+
+    name: str
+    pkg_type: str
+    frontmatter: dict[str, Any]
+    body: str
+    path: Path
+    references: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Language → glob mapping
+# ---------------------------------------------------------------------------
+
+_LANGUAGE_GLOBS: dict[str, str] = {
+    "python": "**/*.py",
+    "typescript": "**/*.{ts,tsx}",
+    "javascript": "**/*.{js,jsx}",
+    "go": "**/*.go",
+    "rust": "**/*.rs",
+    "java": "**/*.java",
+    "ruby": "**/*.rb",
+    "c": "**/*.{c,h}",
+    "cpp": "**/*.{cpp,hpp,cc,hh}",
+    "csharp": "**/*.cs",
+    "swift": "**/*.swift",
+    "kotlin": "**/*.{kt,kts}",
+    "shell": "**/*.{sh,bash,zsh}",
+    "sql": "**/*.sql",
+    "html": "**/*.{html,htm}",
+    "css": "**/*.{css,scss,less}",
+    "yaml": "**/*.{yaml,yml}",
+    "json": "**/*.json",
+    "markdown": "**/*.md",
+    "toml": "**/*.toml",
+}
+
+
+def language_to_globs(languages: list[str]) -> list[str]:
+    """Map language identifiers to glob patterns.
+
+    Returns empty list for wildcard or unrecognized languages.
+    """
+    if not languages or languages == ["*"]:
+        return []
+    globs: list[str] = []
+    for lang in languages:
+        normalized = lang.lower().strip().lstrip("*.")
+        pattern = _LANGUAGE_GLOBS.get(normalized)
+        if pattern:
+            globs.append(pattern)
+    return globs
+
+
+def truncate_description(description: str, max_chars: int = 200) -> str:
+    """Truncate description to max_chars, preserving word boundaries."""
+    description = description.strip()
+    if len(description) <= max_chars:
+        return description
+    truncated = description[:max_chars].rsplit(" ", 1)[0]
+    return truncated.rstrip(".,;:") + "..."
+
+
+# ---------------------------------------------------------------------------
+# Package loading
+# ---------------------------------------------------------------------------
+
+
+def _load_references(pkg_dir: Path) -> dict[str, str]:
+    """Load all reference markdown files from a package's references/ directory."""
+    refs_dir = pkg_dir / "references"
+    if not refs_dir.is_dir():
+        return {}
+    refs: dict[str, str] = {}
+    for ref_file in sorted(refs_dir.iterdir()):
+        if ref_file.suffix == ".md" and ref_file.is_file():
+            refs[ref_file.name] = ref_file.read_text(encoding="utf-8")
+    return refs
+
+
+def load_packages(
+    type_filter: list[str] | None = None,
+) -> dict[str, list[PackageContent]]:
+    """Load all packages, grouped by type key.
+
+    Args:
+        type_filter: If set, only load these package types (e.g. ["skill", "rule"]).
+    """
+    packages: dict[str, list[PackageContent]] = {}
+
+    for type_key, pkg_type in TYPES.items():
+        if type_filter and type_key not in type_filter:
+            continue
+
+        if not pkg_type.repo_dir.is_dir():
+            continue
+
+        type_packages: list[PackageContent] = []
+        for pkg_dir in sorted(pkg_type.repo_dir.iterdir()):
+            def_file = pkg_dir / pkg_type.definition_file
+            if not pkg_dir.is_dir() or not def_file.exists():
+                continue
+
+            content = def_file.read_text(encoding="utf-8")
+            try:
+                fm = parse_frontmatter(content)
+            except ValueError:
+                print(f"WARNING: {def_file} has invalid frontmatter, skipping", file=sys.stderr)
+                continue
+
+            name = fm.get("name", "")
+            if not name:
+                continue
+
+            body = extract_body(content)
+            references = _load_references(pkg_dir)
+
+            type_packages.append(
+                PackageContent(
+                    name=name,
+                    pkg_type=type_key,
+                    frontmatter=fm,
+                    body=body,
+                    path=pkg_dir,
+                    references=references,
+                )
+            )
+
+        if type_packages:
+            packages[type_key] = type_packages
+
+    return packages
+
+
+def inline_references(pkg: PackageContent) -> str:
+    """Combine package body with all reference file contents."""
+    parts = [pkg.body]
+    for ref_name, ref_content in pkg.references.items():
+        parts.append(f"\n\n---\n\n## Reference: {ref_name.removesuffix('.md')}\n\n{ref_content}")
+    return "\n".join(parts)
+
+
+def extract_language_targets(fm: dict[str, Any]) -> list[str]:
+    """Extract language targets from frontmatter metadata."""
+    metadata = fm.get("metadata", {})
+    if isinstance(metadata, dict):
+        targets = metadata.get("language_targets")
+        if isinstance(targets, list):
+            return targets
+        applies_to = metadata.get("applies_to")
+        if isinstance(applies_to, dict):
+            langs = applies_to.get("languages")
+            if isinstance(langs, list):
+                return langs
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Base adapter
+# ---------------------------------------------------------------------------
+
+
+class AdapterGenerator(ABC):
+    """Base class for platform-specific adapters."""
+
+    platform: str
+
+    def __init__(self, output_dir: Path, *, dry_run: bool = False) -> None:
+        self.output_dir = output_dir
+        self.dry_run = dry_run
+        self._files_written: list[Path] = []
+
+    def _write(self, path: Path, content: str) -> None:
+        """Write content to path (or log in dry-run mode)."""
+        self._files_written.append(path)
+        if self.dry_run:
+            print(f"  [dry-run] {path.relative_to(REPO_ROOT)}")
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def _copy_dir(self, src: Path, dst: Path) -> None:
+        """Copy directory tree (or log in dry-run mode)."""
+        if self.dry_run:
+            print(f"  [dry-run] copy {src.relative_to(REPO_ROOT)} → {dst.relative_to(REPO_ROOT)}")
+            return
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+    @abstractmethod
+    def generate(self, packages: dict[str, list[PackageContent]]) -> None:
+        """Generate platform-specific output from loaded packages."""
+
+    def report(self) -> str:
+        """Return summary of files written."""
+        return f"{self.platform}: {len(self._files_written)} files"
+
+
+# ---------------------------------------------------------------------------
+# Cursor adapter
+# ---------------------------------------------------------------------------
+
+
+class CursorAdapter(AdapterGenerator):
+    """Generate .cursor/rules/*.mdc and .cursor/commands/*.md."""
+
+    platform = "cursor"
+
+    def generate(self, packages: dict[str, list[PackageContent]]) -> None:
+        rules_dir = self.output_dir / ".cursor" / "rules"
+        commands_dir = self.output_dir / ".cursor" / "commands"
+
+        # Skills → individual .mdc rules (alwaysApply: false)
+        for pkg in packages.get("skill", []):
+            content = self._build_mdc(pkg, always_apply=False)
+            self._write(rules_dir / f"{pkg.name}.mdc", content)
+
+        # Agents → individual .mdc rules (alwaysApply: false)
+        for pkg in packages.get("agent", []):
+            content = self._build_mdc(pkg, always_apply=False)
+            self._write(rules_dir / f"{pkg.name}.mdc", content)
+
+        # Rules → individual .mdc rules (alwaysApply: true)
+        for pkg in packages.get("rule", []):
+            content = self._build_mdc(pkg, always_apply=True)
+            self._write(rules_dir / f"{pkg.name}.mdc", content)
+
+        # Commands → .cursor/commands/*.md
+        for pkg in packages.get("command", []):
+            self._write(commands_dir / f"{pkg.name}.md", pkg.body)
+
+        # Hooks, utilities, presets → skipped (no Cursor equivalent)
+        for skipped_type in ("hook", "utility", "preset"):
+            count = len(packages.get(skipped_type, []))
+            if count:
+                print(f"  cursor: skipped {count} {skipped_type}(s) (no equivalent)", file=sys.stderr)
+
+    def _build_mdc(self, pkg: PackageContent, *, always_apply: bool) -> str:
+        """Build .mdc file content with YAML frontmatter + body."""
+        description = truncate_description(pkg.frontmatter.get("description", ""))
+        globs = language_to_globs(extract_language_targets(pkg.frontmatter))
+
+        # Build frontmatter
+        fm_parts: list[str] = [
+            "---",
+            f"description: {description}",
+        ]
+        if globs:
+            fm_parts.append(f"globs: {', '.join(globs)}")
+        fm_parts.append(f"alwaysApply: {'true' if always_apply else 'false'}")
+        fm_parts.append("---")
+
+        # Body: inline references for self-contained .mdc
+        body = inline_references(pkg)
+
+        return "\n".join(fm_parts) + "\n\n" + body
+
+
+# ---------------------------------------------------------------------------
+# Codex adapter
+# ---------------------------------------------------------------------------
+
+
+class CodexAdapter(AdapterGenerator):
+    """Generate AGENTS.md with hierarchical discovery for large package sets.
+
+    Codex supports hierarchical AGENTS.md discovery: files in subdirectories are
+    loaded when CWD matches. The root AGENTS.md stays under 32 KiB with condensed
+    references; full content lives in per-package files under subdirectories.
+    """
+
+    platform = "codex"
+    SIZE_BUDGET_BYTES = 32 * 1024  # 32 KiB default
+
+    def generate(self, packages: dict[str, list[PackageContent]]) -> None:
+        # Root AGENTS.md: condensed index referencing subdirectory files
+        root_sections: list[str] = []
+
+        # Rules → condensed in root, full body in standards/AGENTS.md
+        rules = packages.get("rule", [])
+        if rules:
+            root_sections.append("# Project Standards\n")
+            root_sections.append("Full standards in `standards/AGENTS.md`.\n")
+            for pkg in rules:
+                description = truncate_description(pkg.frontmatter.get("description", ""), 300)
+                root_sections.append(f"- **{_title_case(pkg.name)}**: {description}")
+            root_sections.append("")
+
+            # Full standards file
+            std_parts = ["# Project Standards\n"]
+            for pkg in rules:
+                std_parts.append(f"## {_title_case(pkg.name)}\n")
+                std_parts.append(pkg.body)
+                std_parts.append("")
+            self._write(self.output_dir / "standards" / "AGENTS.md", "\n".join(std_parts))
+
+        # Agents → condensed in root, full body in agents/AGENTS.md
+        agents = packages.get("agent", [])
+        if agents:
+            root_sections.append("# Agents\n")
+            root_sections.append("Full agent instructions in `agents/AGENTS.md`.\n")
+            for pkg in agents:
+                description = truncate_description(pkg.frontmatter.get("description", ""), 300)
+                root_sections.append(f"- **{_title_case(pkg.name)}**: {description}")
+            root_sections.append("")
+
+            # Full agents file
+            agent_parts = ["# Agent Instructions\n"]
+            for pkg in agents:
+                agent_parts.append(f"## {_title_case(pkg.name)}\n")
+                agent_parts.append(pkg.body)
+                agent_parts.append("")
+            self._write(self.output_dir / "agents" / "AGENTS.md", "\n".join(agent_parts))
+
+        # Commands → condensed in root, full body in workflows/AGENTS.md
+        commands = packages.get("command", [])
+        if commands:
+            root_sections.append("# Workflows\n")
+            root_sections.append("Full workflow instructions in `workflows/AGENTS.md`.\n")
+            for pkg in commands:
+                description = truncate_description(pkg.frontmatter.get("description", ""), 300)
+                root_sections.append(f"- **{_title_case(pkg.name)}**: {description}")
+            root_sections.append("")
+
+            # Full workflows file
+            wf_parts = ["# Workflow Instructions\n"]
+            for pkg in commands:
+                wf_parts.append(f"## {_title_case(pkg.name)}\n")
+                wf_parts.append(pkg.body)
+                wf_parts.append("")
+            self._write(self.output_dir / "workflows" / "AGENTS.md", "\n".join(wf_parts))
+
+        # Skills → condensed in root, full body in skills/AGENTS.md
+        skills = packages.get("skill", [])
+        if skills:
+            root_sections.append("# Skills Reference\n")
+            root_sections.append("Full skill instructions in `skills/AGENTS.md`.\n")
+            for pkg in skills:
+                description = truncate_description(pkg.frontmatter.get("description", ""), 300)
+                root_sections.append(f"- **{_title_case(pkg.name)}**: {description}")
+            root_sections.append("")
+
+            # Full skills file
+            skill_parts = ["# Skill Instructions\n"]
+            for pkg in skills:
+                skill_parts.append(f"## {_title_case(pkg.name)}\n")
+                skill_parts.append(pkg.body)
+                skill_parts.append("")
+            self._write(self.output_dir / "skills" / "AGENTS.md", "\n".join(skill_parts))
+
+        # Hooks, utilities, presets → skipped
+        for skipped_type in ("hook", "utility", "preset"):
+            count = len(packages.get(skipped_type, []))
+            if count:
+                print(f"  codex: skipped {count} {skipped_type}(s) (no equivalent)", file=sys.stderr)
+
+        root_content = "\n".join(root_sections)
+        size = len(root_content.encode("utf-8"))
+        pct = (size / self.SIZE_BUDGET_BYTES) * 100
+        if size > self.SIZE_BUDGET_BYTES:
+            print(
+                f"  codex: root AGENTS.md is {size:,} bytes ({pct:.0f}% of 32 KiB budget)",
+                file=sys.stderr,
+            )
+        else:
+            print(f"  codex: root AGENTS.md is {size:,} bytes ({pct:.0f}% of 32 KiB budget)", file=sys.stderr)
+
+        self._write(self.output_dir / "AGENTS.md", root_content)
+
+
+# ---------------------------------------------------------------------------
+# Gemini adapter
+# ---------------------------------------------------------------------------
+
+
+class GeminiAdapter(AdapterGenerator):
+    """Generate .gemini/ structure: GEMINI.md, skills/, commands/, agents/."""
+
+    platform = "gemini"
+
+    def generate(self, packages: dict[str, list[PackageContent]]) -> None:
+        gemini_dir = self.output_dir / ".gemini"
+
+        # Skills → .gemini/skills/{name}/SKILL.md (near 1:1 copy)
+        for pkg in packages.get("skill", []):
+            self._generate_skill(gemini_dir / "skills" / pkg.name, pkg)
+
+        # Agents → .gemini/agents/{name}.md
+        agents = packages.get("agent", [])
+        if agents:
+            for pkg in agents:
+                content = self._build_agent_md(pkg)
+                self._write(gemini_dir / "agents" / f"{pkg.name}.md", content)
+
+        # Rules → sections in GEMINI.md
+        rules = packages.get("rule", [])
+        gemini_md_parts: list[str] = []
+        if rules:
+            gemini_md_parts.append("# Project Standards\n")
+            for pkg in rules:
+                gemini_md_parts.append(pkg.body)
+                gemini_md_parts.append("")
+
+        if gemini_md_parts:
+            self._write(gemini_dir / "GEMINI.md", "\n".join(gemini_md_parts))
+
+        # Commands → .gemini/commands/workflow/{name}.toml
+        for pkg in packages.get("command", []):
+            content = self._build_command_toml(pkg)
+            self._write(gemini_dir / "commands" / "workflow" / f"{pkg.name}.toml", content)
+
+        # Hooks → documented as manual setup
+        hooks = packages.get("hook", [])
+        if hooks:
+            print(f"  gemini: skipped {len(hooks)} hook(s) (different event model)", file=sys.stderr)
+
+        # Utilities → wrap as skills
+        for pkg in packages.get("utility", []):
+            self._generate_skill(gemini_dir / "skills" / pkg.name, pkg)
+
+        # Presets → skipped
+        presets = packages.get("preset", [])
+        if presets:
+            print(f"  gemini: skipped {len(presets)} preset(s) (no equivalent)", file=sys.stderr)
+
+    def _generate_skill(self, skill_dir: Path, pkg: PackageContent) -> None:
+        """Generate a Gemini skill directory (SKILL.md + references/)."""
+        # Build cleaned frontmatter (remove Claude-specific fields)
+        clean_fm = self._clean_skill_frontmatter(pkg.frontmatter)
+        fm_yaml = yaml.dump(clean_fm, default_flow_style=False, sort_keys=False, width=120).strip()
+        content = f"---\n{fm_yaml}\n---\n\n{pkg.body}"
+        self._write(skill_dir / "SKILL.md", content)
+
+        # Copy references directory if present
+        refs_src = pkg.path / "references"
+        if refs_src.is_dir() and any(refs_src.iterdir()):
+            refs_dst = skill_dir / "references"
+            self._copy_dir(refs_src, refs_dst)
+
+        # Copy scripts directory if present
+        scripts_src = pkg.path / "scripts"
+        if scripts_src.is_dir() and any(scripts_src.iterdir()):
+            scripts_dst = skill_dir / "scripts"
+            self._copy_dir(scripts_src, scripts_dst)
+
+        # Copy assets directory if present
+        assets_src = pkg.path / "assets"
+        if assets_src.is_dir() and any(assets_src.iterdir()):
+            assets_dst = skill_dir / "assets"
+            self._copy_dir(assets_src, assets_dst)
+
+    def _clean_skill_frontmatter(self, fm: dict[str, Any]) -> dict[str, Any]:
+        """Remove Claude-specific fields from skill frontmatter."""
+        clean: dict[str, Any] = {}
+        # Keep universal fields
+        for key in ("name", "description"):
+            if key in fm:
+                clean[key] = fm[key]
+        # Keep metadata but strip Claude-specific sub-fields
+        metadata = fm.get("metadata")
+        if isinstance(metadata, dict):
+            clean_meta: dict[str, Any] = {}
+            for k, v in metadata.items():
+                if k not in ("execution_phase", "priority", "enabled"):
+                    clean_meta[k] = v
+            if clean_meta:
+                clean["metadata"] = clean_meta
+        return clean
+
+    def _build_agent_md(self, pkg: PackageContent) -> str:
+        """Build a Gemini agent markdown file."""
+        description = pkg.frontmatter.get("description", "").strip()
+        fm = {"name": pkg.name, "description": description}
+        fm_yaml = yaml.dump(fm, default_flow_style=False, sort_keys=False, width=120).strip()
+        return f"---\n{fm_yaml}\n---\n\n{pkg.body}"
+
+    def _build_command_toml(self, pkg: PackageContent) -> str:
+        """Build a Gemini TOML command file."""
+        description = truncate_description(pkg.frontmatter.get("description", "").strip())
+        body_escaped = pkg.body.replace('"""', '\\"\\"\\"')
+        lines = [
+            "[command]",
+            f'description = "{description}"',
+            "",
+            "[command.steps]",
+            'prompt = """',
+            body_escaped,
+            '"""',
+            "",
+        ]
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _title_case(name: str) -> str:
+    """Convert kebab-case to title case: 'code-reviewer' → 'Code Reviewer'."""
+    return name.replace("-", " ").title()
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry
+# ---------------------------------------------------------------------------
+
+_ADAPTERS: dict[str, type[AdapterGenerator]] = {
+    "cursor": CursorAdapter,
+    "codex": CodexAdapter,
+    "gemini": GeminiAdapter,
+}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate platform-specific adapter output from armory packages.",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=list(_ADAPTERS.keys()),
+        help="Target platform (default: all)",
+    )
+    parser.add_argument(
+        "--type",
+        dest="types",
+        action="append",
+        choices=list(TYPES.keys()),
+        help="Package types to include (default: all). Repeatable.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be generated without writing files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "adapters",
+        help="Output root directory (default: adapters/)",
+    )
+    args = parser.parse_args()
+
+    # Load packages
+    packages = load_packages(type_filter=args.types)
+    total = sum(len(pkgs) for pkgs in packages.values())
+    if total == 0:
+        print("ERROR: No packages found", file=sys.stderr)
+        return 1
+
+    counts = ", ".join(f"{len(v)} {k}(s)" for k, v in packages.items())
+    print(f"Loaded {total} packages: {counts}")
+
+    # Determine which adapters to run
+    platforms = [args.platform] if args.platform else list(_ADAPTERS.keys())
+
+    # Generate
+    for platform in platforms:
+        adapter_cls = _ADAPTERS[platform]
+        platform_dir = args.output_dir / platform
+        adapter = adapter_cls(platform_dir, dry_run=args.dry_run)
+        print(f"\n{'[dry-run] ' if args.dry_run else ''}Generating {platform}...")
+        adapter.generate(packages)
+        print(f"  {adapter.report()}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `scripts/generate_adapters.py` — build-time transformation script that converts Claude Code-native packages into platform-specific formats for three target agent surfaces
- Replace the placeholder Portability section in README with a full adapter usage guide covering CLI, platform mapping, per-platform setup instructions, and loss matrix
- Add `adapters/` to `.gitignore` (generated output, not source)

## Adapter Details

### Cursor (`.cursor/rules/*.mdc` + `.cursor/commands/*.md`)

- Skills and agents → individual `.mdc` rules with `alwaysApply: false` and glob patterns derived from `language_targets` metadata
- Rules → `.mdc` rules with `alwaysApply: true` (always-on project standards)
- Commands → `.cursor/commands/*.md` (body only)
- Reference files inlined into `.mdc` body for self-contained rules
- Hooks, utilities, presets skipped (no Cursor equivalent)

### Codex (`AGENTS.md` + hierarchical subdirectories)

- Root `AGENTS.md` is a condensed index (24 KB, 75% of 32 KiB budget) with description-only entries
- Full content in subdirectory `AGENTS.md` files (`standards/`, `agents/`, `workflows/`, `skills/`) using Codex's hierarchical discovery
- Hooks, utilities, presets skipped

### Gemini (`.gemini/` directory structure)

- Skills are a near 1:1 copy with cleaned frontmatter (Claude-specific fields like `type`, `model`, `color`, `execution_phase` stripped). References, scripts, and assets directories copied alongside
- Agents → `.gemini/agents/{name}.md` with name + description frontmatter
- Rules → concatenated into `GEMINI.md` as always-on context
- Commands → `.gemini/commands/workflow/{name}.toml` in Gemini CLI format
- Utilities wrapped as Gemini skills
- Hooks skipped (different event model), presets skipped

### Architecture

Built on existing infrastructure (`scripts/frontmatter.py`, `scripts/package_types.py`):
- `PackageContent` dataclass holds parsed frontmatter, body, and references
- `AdapterGenerator` ABC with `_write()` and `_copy_dir()` (both support dry-run)
- Three concrete adapters: `CursorAdapter`, `CodexAdapter`, `GeminiAdapter`
- Shared utilities: `language_to_globs()`, `truncate_description()`, `inline_references()`, `extract_language_targets()`
- CLI supports `--platform`, `--type`, `--dry-run`, `--output-dir`

### Output (92 packages → 160 generated files)

| Platform | Files | Key constraint |
|----------|-------|----------------|
| Cursor | 77 | References must be inlined (no modular loading) |
| Codex | 5 | 32 KiB root budget, hierarchical overflow |
| Gemini | 78 | Near 1:1 skill format, TOML commands |

## Test plan

- [x] `uv run scripts/generate_adapters.py --dry-run` — all 3 platforms generate without errors
- [x] `uv run scripts/generate_adapters.py` — real generation produces correct output structure
- [x] Cursor `.mdc` files have valid frontmatter (`description`, `alwaysApply`, optional `globs`)
- [x] Codex root `AGENTS.md` is under 32 KiB budget (24,704 bytes = 75%)
- [x] Gemini skills have cleaned frontmatter (no `type`, `model`, `color` fields)
- [x] Gemini reference/script/asset directories are copied alongside skills
- [x] Gemini TOML commands have valid format
- [x] Skipped package types produce diagnostic stderr messages
- [ ] Manual: copy Cursor output to a Cursor project and verify rules load
- [ ] Manual: copy Codex output to a Codex project and verify hierarchical discovery
- [ ] Manual: copy Gemini output to a Gemini CLI project and verify skill activation