### PR TITLE
feat(ci): add quality enforcement gates for packages, frontmatter, references, and adapters

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -54,6 +54,50 @@ jobs:
       - name: Validate eval cases schema
         run: python scripts/validate_evals.py
 
+      - name: Validate frontmatter
+        run: python scripts/validate_frontmatter.py
+
+      - name: Validate file references
+        run: python scripts/validate_references.py
+
+      - name: Evaluate package quality
+        if: github.event_name == 'pull_request'
+        run: |
+          TYPE_DIRS="skills agents hooks rules commands utilities presets"
+          DEFINITION_MAP="skills:SKILL.md agents:AGENT.md hooks:HOOK.md rules:RULE.md commands:COMMAND.md utilities:UTILITY.md presets:PRESET.md"
+
+          changed_packages=""
+          for mapping in $DEFINITION_MAP; do
+            type_dir="${mapping%%:*}"
+            def_file="${mapping#*:}"
+            matches=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- "${type_dir}/" \
+              | grep "${def_file}" \
+              | sed "s|${type_dir}/\([^/]*\)/.*|\1|" \
+              | sort -u)
+            for pkg in $matches; do
+              changed_packages="${changed_packages} ${type_dir}/${pkg}"
+            done
+          done
+
+          if [ -z "$changed_packages" ]; then
+            echo "No changed packages to evaluate"
+            exit 0
+          fi
+
+          failed=0
+          for pkg_path in $changed_packages; do
+            echo "Evaluating ${pkg_path}..."
+            if ! python scripts/evaluate_package.py --path "${pkg_path}" --threshold 70; then
+              failed=$((failed + 1))
+            fi
+          done
+
+          if [ "$failed" -gt 0 ]; then
+            echo ""
+            echo "FAILED: ${failed} package(s) below quality threshold"
+            exit 1
+          fi
+
       - name: Check eval coverage for changed packages
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,9 @@ jobs:
           python scripts/generate_manifest.py
           git diff --exit-code manifest.yaml
 
+      - name: Validate adapter generation
+        run: python scripts/generate_adapters.py --validate
+
       - name: Package all items
         run: |
           mkdir -p dist

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -88,12 +88,10 @@ packages:
       and pricing comparison matrices, market positioning maps, and moat/defensibility assessment. Uses WebSearch to identify
       direct, indirect, and potential competitors across Product Hunt, G2, Capterra, and Crunchbase. Produces structured reports
       with force scorecards, feature gap analysis, pricing positioning, white space identification, and strategic recommendations.
-      Use this skill when you need to analyze competitors, compare product features, evaluate market positioning, assess competitive
-      threats, build a competitive matrix, run a Porter''s Five Forces analysis, identify competitive moats, map the competitive
-      landscape, evaluate market defensibility, or perform a pricing comparison. Triggers on: "competitive analysis", "competitor
-      comparison", "competitive landscape", "Porter''s Five Forces", "feature comparison matrix", "pricing analysis", "market
-      positioning", "moat assessment", "competitive threat", "defensibility analysis", "who are the competitors", "compare
-      competitors", "competitive intelligence", "rival analysis", "market rivalry", "competitive positioning map".'
+      Triggers on: "competitive analysis", "competitor comparison", "competitive landscape", "Porter''s Five Forces", "feature
+      comparison matrix", "pricing analysis", "market positioning", "moat assessment", "competitive threat", "defensibility
+      analysis", "compare competitors", "competitive intelligence". Use this skill when analyzing competitors, comparing features,
+      or evaluating market positioning and defensibility.'
     path: skills/competitive-analyzer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/competitive-analyzer/SKILL.md
     complements:
@@ -288,16 +286,12 @@ packages:
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/linkedin-post-style/SKILL.md
   - name: literature-review
     version: 1.0.0
-    description: 'Systematic literature review workflow for surveying, synthesizing, and analyzing a body of academic research
-      across a defined topic or research question. Covers the full review lifecycle: defining scope and inclusion criteria,
-      searching academic databases (arXiv via arxiv-search utility, Semantic Scholar, Google Scholar via web search), screening
-      and filtering results, extracting structured findings, thematic synthesis, gap identification, and producing a structured
-      review document with proper citations. Use this skill when you need to survey a research area, map the landscape of
-      a topic, identify research gaps, build a bibliography, compare methodologies across studies, write a related work section,
-      conduct a systematic review, perform a scoping review, or synthesize findings across multiple papers. Triggers on: "literature
-      review", "survey the literature", "what has been published on", "research landscape", "related work", "systematic review",
-      "scoping review", "map the research on", "what do we know about", "synthesize the research", "compare approaches to",
-      "bibliography on", "find papers about", "review the state of the art", "what are the key papers on", "research gap analysis".'
+    description: 'Systematic literature review workflow for surveying, synthesizing, and analyzing academic research. Covers
+      the full lifecycle: scope definition, searching academic databases (arXiv, Semantic Scholar, Google Scholar), screening,
+      structured extraction, thematic synthesis, gap identification, and producing a cited review document. Triggers on: "literature
+      review", "survey the literature", "research landscape", "related work", "systematic review", "scoping review", "synthesize
+      the research", "bibliography on", "find papers about", "review the state of the art", "research gap analysis". Use this
+      skill when surveying a research area, mapping a topic landscape, identifying gaps, or writing a related work section.'
     path: skills/literature-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/literature-review/SKILL.md
     complements:
@@ -396,17 +390,11 @@ packages:
     version: 1.3.0
     description: 'Evaluate Claude Code package quality across 6 weighted dimensions: frontmatter quality, trigger coverage,
       structural completeness, content depth, consistency and integrity, and CONTRIBUTING.md compliance. Covers all 7 package
-      types: skills, agents, hooks, rules, commands, utilities, and presets. Each type has type-specific quality signals that
-      refine D3 and D4 scoring. Produces scored audit reports with severity-classified findings and actionable recommendations.
-      Two modes: (1) Quick Audit — single package, full per-dimension report with weighted scoring; (2) Full Audit — all packages
-      in repo, comparative ranking table plus per-package summaries, optionally filtered by type. Triggers on: "evaluate package",
-      "evaluate skill", "audit agent quality", "score this hook", "rate this rule", "evaluate command", "check utility quality",
-      "assess preset", "package quality", "package audit", "audit skill quality", "score skill", "skill review", "check skill
-      completeness", "rate this skill", "skill quality check", "grade skill", "assess skill", "skill audit", "how good is
-      this skill", "SKILL.md feedback", "how good is this agent", "AGENT.md feedback". Use this skill when reviewing Claude
-      Code packages before deployment, comparing package quality across a repo, or diagnosing why a skill fails to activate
-      on relevant queries. NOT for evaluating or improving LLM prompts — use prompt-lab instead. NOT for reviewing pull requests
-      — use pr-review instead.'
+      types with type-specific signals. Produces scored audit reports with severity-classified findings. Two modes: Quick
+      Audit (single package, full report) and Full Audit (all packages, ranking table). Triggers on: "evaluate package", "audit
+      agent quality", "score this hook", "package quality", "package audit", "skill review", "skill quality check", "how good
+      is this skill", "AGENT.md feedback". Use this skill when reviewing packages before deployment or diagnosing activation
+      failures. NOT for LLM prompts (use prompt-lab) or PRs (use pr-review).'
     path: skills/package-evaluator
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/package-evaluator/SKILL.md
   - name: plan-review

--- a/scripts/evaluate_package.py
+++ b/scripts/evaluate_package.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Standalone CI-compatible package quality evaluator.
+
+Scores packages across 6 dimensions and fails if the score is below
+threshold or any CRITICAL finding exists.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml
+
+from scripts.frontmatter import extract_body, extract_version, parse_frontmatter, validate_version
+from scripts.package_types import REPO_ROOT, TYPES, PackageType
+
+DIMENSION_NAMES = [
+    "D1 Frontmatter Quality",
+    "D2 Trigger Coverage",
+    "D3 Structural Completeness",
+    "D4 Content Depth",
+    "D5 Consistency",
+    "D6 Compliance",
+]
+
+MAX_SCORES: dict[str, int] = {
+    "D1 Frontmatter Quality": 20,
+    "D2 Trigger Coverage": 18,
+    "D3 Structural Completeness": 20,
+    "D4 Content Depth": 22,
+    "D5 Consistency": 12,
+    "D6 Compliance": 8,
+}
+
+
+def _count_quoted_triggers(description: str) -> int:
+    """Count quoted trigger phrases like "some trigger" in description."""
+    return len(re.findall(r'"[^"]{2,}"', description))
+
+
+def _has_trigger_phrases(description: str) -> bool:
+    """Check if description contains 'Trigger' or quoted trigger patterns."""
+    if "Trigger" in description:
+        return True
+    return _count_quoted_triggers(description) > 0
+
+
+def _has_use_clause(description: str) -> bool:
+    """Check for 'Use this' or 'Use when' clause."""
+    return bool(re.search(r"Use\s+(this|when)", description))
+
+
+def _body_word_count(body: str) -> int:
+    return len(body.split())
+
+
+def _has_heading_pattern(body: str, pattern: str) -> bool:
+    return bool(re.search(rf"^#+\s+.*({pattern})", body, re.MULTILINE | re.IGNORECASE))
+
+
+def _has_code_blocks(body: str) -> bool:
+    return "```" in body
+
+
+def _has_tables(body: str) -> bool:
+    return bool(re.search(r"\|---", body))
+
+
+def _has_numbered_lists(body: str) -> bool:
+    return bool(re.search(r"^\s*\d+\.\s+", body, re.MULTILINE))
+
+
+def _is_kebab_case(name: str) -> bool:
+    return bool(re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name))
+
+
+def _has_cross_package_refs(body: str) -> bool:
+    return "../" in body
+
+
+def _has_references_dir(pkg_dir: Path) -> bool:
+    ref_dir = pkg_dir / "references"
+    if not ref_dir.is_dir():
+        return False
+    return any(ref_dir.iterdir())
+
+
+def evaluate_package(
+    pkg_dir: Path, pkg_type: PackageType,
+) -> dict[str, object]:
+    """Evaluate a single package and return scoring results."""
+    name = pkg_dir.name
+    definition = pkg_dir / pkg_type.definition_file
+
+    scores: dict[str, int] = {d: 0 for d in DIMENSION_NAMES}
+    findings: list[dict[str, str]] = []
+
+    # --- Parse frontmatter and body ---
+    meta: dict[str, object] | None = None
+    body = ""
+    description = ""
+    version_str = ""
+    yaml_valid = False
+
+    if not definition.exists():
+        findings.append({"severity": "CRITICAL", "message": f"Missing definition file {pkg_type.definition_file}"})
+    else:
+        content = definition.read_text(encoding="utf-8")
+        try:
+            meta = parse_frontmatter(content)
+            yaml_valid = True
+            body = extract_body(content)
+            description = str(meta.get("description", "")) if isinstance(meta, dict) else ""
+            version_str = extract_version(meta) if isinstance(meta, dict) else ""
+        except (ValueError, yaml.YAMLError) as exc:
+            findings.append({"severity": "CRITICAL", "message": f"Invalid YAML frontmatter: {exc}"})
+
+    # Check required frontmatter fields
+    if meta is not None and isinstance(meta, dict):
+        for field in pkg_type.required_frontmatter:
+            if not meta.get(field):
+                findings.append({"severity": "CRITICAL", "message": f"Missing required frontmatter field: {field}"})
+
+    # ========== D1: Frontmatter Quality (20) ==========
+    desc_len = len(description)
+    if 200 <= desc_len <= 1024:
+        scores["D1 Frontmatter Quality"] += 10
+    elif 50 <= desc_len < 200:
+        scores["D1 Frontmatter Quality"] += 5
+    else:
+        findings.append({"severity": "HIGH", "message": f"Description length {desc_len} outside ideal range (200-1024)"})
+
+    if _has_trigger_phrases(description):
+        scores["D1 Frontmatter Quality"] += 5
+    else:
+        findings.append({"severity": "HIGH", "message": "No trigger phrases in description"})
+
+    if _has_use_clause(description):
+        scores["D1 Frontmatter Quality"] += 5
+
+    # ========== D2: Trigger Coverage (18) ==========
+    trigger_count = _count_quoted_triggers(description)
+    if trigger_count >= 6:
+        scores["D2 Trigger Coverage"] = 18
+    elif trigger_count >= 3:
+        scores["D2 Trigger Coverage"] = 12
+    elif trigger_count >= 1:
+        scores["D2 Trigger Coverage"] = 6
+    else:
+        findings.append({"severity": "HIGH", "message": "No quoted trigger phrases found"})
+
+    # ========== D3: Structural Completeness (20) ==========
+    if _has_heading_pattern(body, r"Step|Phase|Workflow|Stage"):
+        scores["D3 Structural Completeness"] += 8
+    else:
+        findings.append({"severity": "HIGH", "message": "No workflow/phases section found"})
+
+    if _has_heading_pattern(body, r"Error|Troubleshoot"):
+        scores["D3 Structural Completeness"] += 4
+
+    if _has_heading_pattern(body, r"Output"):
+        scores["D3 Structural Completeness"] += 4
+
+    if _has_references_dir(pkg_dir):
+        scores["D3 Structural Completeness"] += 4
+
+    # ========== D4: Content Depth (22) ==========
+    wc = _body_word_count(body)
+    if wc > 500:
+        scores["D4 Content Depth"] += 10
+    elif wc > 200:
+        scores["D4 Content Depth"] += 5
+
+    if _has_code_blocks(body):
+        scores["D4 Content Depth"] += 4
+
+    if _has_tables(body):
+        scores["D4 Content Depth"] += 4
+
+    if _has_numbered_lists(body):
+        scores["D4 Content Depth"] += 4
+
+    # ========== D5: Consistency & Integrity (12) ==========
+    fm_name = str(meta.get("name", "")) if isinstance(meta, dict) else ""
+    if fm_name == name:
+        scores["D5 Consistency"] += 6
+    else:
+        findings.append({"severity": "CRITICAL", "message": f"Frontmatter name '{fm_name}' does not match directory '{name}'"})
+
+    if not _has_cross_package_refs(body):
+        scores["D5 Consistency"] += 3
+
+    if version_str and validate_version(version_str):
+        scores["D5 Consistency"] += 3
+
+    # ========== D6: CONTRIBUTING Compliance (8) ==========
+    if _is_kebab_case(name):
+        scores["D6 Compliance"] += 4
+
+    if len(name) <= 64:
+        scores["D6 Compliance"] += 2
+
+    if yaml_valid:
+        scores["D6 Compliance"] += 2
+
+    # --- Compute totals ---
+    total = sum(scores.values())
+    max_total = sum(MAX_SCORES.values())
+
+    has_critical = any(f["severity"] == "CRITICAL" for f in findings)
+    if has_critical:
+        capped = int(max_total * 0.4)
+        total = min(total, capped)
+
+    percentage = int(total / max_total * 100)
+
+    return {
+        "name": name,
+        "type": pkg_type.key,
+        "scores": scores,
+        "max_scores": dict(MAX_SCORES),
+        "total": total,
+        "percentage": percentage,
+        "status": "FAIL" if has_critical else "PASS",
+        "findings": findings,
+    }
+
+
+def evaluate_all(threshold: int) -> list[dict[str, object]]:
+    """Evaluate all packages across all types."""
+    results: list[dict[str, object]] = []
+    for pkg_type in TYPES.values():
+        type_dir = pkg_type.repo_dir
+        if not type_dir.exists():
+            continue
+        for pkg_dir in sorted(type_dir.iterdir()):
+            if not pkg_dir.is_dir() or pkg_dir.name.startswith("."):
+                continue
+            definition = pkg_dir / pkg_type.definition_file
+            if not definition.exists():
+                continue
+            result = evaluate_package(pkg_dir, pkg_type)
+            if result["percentage"] < threshold:  # type: ignore[operator]
+                result["status"] = "FAIL"
+            results.append(result)
+    return results
+
+
+def evaluate_single(path: str, threshold: int) -> list[dict[str, object]]:
+    """Evaluate a single package by path."""
+    from scripts.package_types import detect_type_from_path
+
+    pkg_dir = Path(path).resolve()
+    if not pkg_dir.is_dir():
+        pkg_dir = REPO_ROOT / path
+    if not pkg_dir.is_dir():
+        print(f"Error: path '{path}' is not a valid directory", file=sys.stderr)
+        sys.exit(1)
+
+    pkg_type = detect_type_from_path(pkg_dir)
+    result = evaluate_package(pkg_dir, pkg_type)
+    if result["percentage"] < threshold:  # type: ignore[operator]
+        result["status"] = "FAIL"
+    return [result]
+
+
+def print_text(results: list[dict[str, object]]) -> None:
+    """Print results in human-readable text format."""
+    for r in results:
+        scores = r["scores"]
+        max_scores = r["max_scores"]
+        assert isinstance(scores, dict)
+        assert isinstance(max_scores, dict)
+
+        print(f"Package: {r['name']} ({r['type']})")
+        for dim in DIMENSION_NAMES:
+            label = f"  {dim}:"
+            value = f"{scores[dim]}/{max_scores[dim]}"
+            print(f"{label:<36s}{value:>6s}")
+        print(f"  {'Overall:':<34s}{r['total']}/{sum(max_scores.values())} ({r['percentage']}%)")
+        print(f"  Status: {r['status']}")
+        if r["findings"]:
+            findings = r["findings"]
+            assert isinstance(findings, list)
+            for f in findings:
+                assert isinstance(f, dict)
+                print(f"    [{f['severity']}] {f['message']}")
+        print()
+
+    passed = sum(1 for r in results if r["status"] == "PASS")
+    failed = len(results) - passed
+    print(f"Summary: {len(results)} packages evaluated, {passed} passed, {failed} failed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate package quality")
+    parser.add_argument("--path", type=str, help="Evaluate a single package by path")
+    parser.add_argument("--threshold", type=int, default=70, help="Minimum passing score (default: 70)")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Output JSON instead of text")
+    args = parser.parse_args()
+
+    if args.path:
+        results = evaluate_single(args.path, args.threshold)
+    else:
+        results = evaluate_all(args.threshold)
+
+    if args.json_output:
+        print(json.dumps(results, indent=2))
+    else:
+        print_text(results)
+
+    has_failure = any(r["status"] == "FAIL" for r in results)
+    return 1 if has_failure else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_adapters.py
+++ b/scripts/generate_adapters.py
@@ -237,6 +237,10 @@ class AdapterGenerator(ABC):
         """Return summary of files written."""
         return f"{self.platform}: {len(self._files_written)} files"
 
+    def validate(self) -> list[str]:
+        """Validate generated output. Returns list of error messages."""
+        return []
+
 
 # ---------------------------------------------------------------------------
 # Cursor adapter
@@ -296,6 +300,20 @@ class CursorAdapter(AdapterGenerator):
         body = inline_references(pkg)
 
         return "\n".join(fm_parts) + "\n\n" + body
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        for path in self._files_written:
+            if not path.exists() or path.suffix != ".mdc":
+                continue
+            content = path.read_text(encoding="utf-8")
+            if not content.startswith("---"):
+                errors.append(f"cursor: {path.name} missing YAML frontmatter")
+                continue
+            # Check alwaysApply is present and boolean-valued
+            if "alwaysApply:" not in content:
+                errors.append(f"cursor: {path.name} missing alwaysApply field")
+        return errors
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +426,25 @@ class CodexAdapter(AdapterGenerator):
             print(f"  codex: root AGENTS.md is {size:,} bytes ({pct:.0f}% of 32 KiB budget)", file=sys.stderr)
 
         self._write(self.output_dir / "AGENTS.md", root_content)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        root = self.output_dir / "AGENTS.md"
+        if root.exists():
+            size = len(root.read_bytes())
+            if size > self.SIZE_BUDGET_BYTES:
+                errors.append(
+                    f"codex: root AGENTS.md exceeds 32 KiB budget ({size:,} bytes)"
+                )
+        # Verify subdirectory files exist
+        for subdir in ("standards", "agents", "workflows", "skills"):
+            sub_file = self.output_dir / subdir / "AGENTS.md"
+            if not sub_file.exists() and root.exists():
+                # Only flag if root references it
+                root_text = root.read_text(encoding="utf-8") if root.exists() else ""
+                if f"`{subdir}/AGENTS.md`" in root_text:
+                    errors.append(f"codex: {subdir}/AGENTS.md referenced but not found")
+        return errors
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +569,31 @@ class GeminiAdapter(AdapterGenerator):
         ]
         return "\n".join(lines)
 
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        claude_fields = {"type", "model", "color", "hook", "command", "utility", "preset"}
+        gemini_dir = self.output_dir / ".gemini"
+        skills_dir = gemini_dir / "skills"
+        if not skills_dir.is_dir():
+            return errors
+        for skill_dir in sorted(skills_dir.iterdir()):
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            content = skill_md.read_text(encoding="utf-8")
+            try:
+                fm = parse_frontmatter(content)
+            except (ValueError, Exception):
+                errors.append(f"gemini: {skill_dir.name}/SKILL.md has invalid frontmatter")
+                continue
+            if isinstance(fm, dict):
+                leaked = claude_fields & set(fm.keys())
+                if leaked:
+                    errors.append(
+                        f"gemini: {skill_dir.name}/SKILL.md has Claude-specific fields: {leaked}"
+                    )
+        return errors
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -586,6 +648,11 @@ def main() -> int:
         default=REPO_ROOT / "adapters",
         help="Output root directory (default: adapters/)",
     )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate generated output after generation.",
+    )
     args = parser.parse_args()
 
     # Load packages
@@ -602,6 +669,7 @@ def main() -> int:
     platforms = [args.platform] if args.platform else list(_ADAPTERS.keys())
 
     # Generate
+    adapters: list[AdapterGenerator] = []
     for platform in platforms:
         adapter_cls = _ADAPTERS[platform]
         platform_dir = args.output_dir / platform
@@ -609,6 +677,19 @@ def main() -> int:
         print(f"\n{'[dry-run] ' if args.dry_run else ''}Generating {platform}...")
         adapter.generate(packages)
         print(f"  {adapter.report()}")
+        adapters.append(adapter)
+
+    # Validate
+    if args.validate and not args.dry_run:
+        all_errors: list[str] = []
+        for adapter in adapters:
+            all_errors.extend(adapter.validate())
+        if all_errors:
+            print(f"\nValidation FAILED: {len(all_errors)} error(s):", file=sys.stderr)
+            for err in all_errors:
+                print(f"  {err}", file=sys.stderr)
+            return 1
+        print(f"\nValidation passed for {len(adapters)} platform(s)")
 
     return 0
 

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate type-specific frontmatter fields across all packages."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml
+
+from scripts.frontmatter import extract_version, parse_frontmatter, validate_version
+from scripts.package_types import TYPES, PackageType
+
+VALID_MODELS = {"opus", "sonnet", "haiku"}
+NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+
+def validate_name(meta: dict, pkg_dir_name: str, prefix: str) -> list[str]:
+    """Validate the name field matches directory name, kebab-case, max 64 chars."""
+    errors: list[str] = []
+    name = meta.get("name", "")
+    if not isinstance(name, str) or not name:
+        errors.append(f"{prefix}: name must be a non-empty string")
+        return errors
+    if name != pkg_dir_name:
+        errors.append(f"{prefix}: name '{name}' does not match directory name '{pkg_dir_name}'")
+    if not NAME_PATTERN.match(name):
+        errors.append(f"{prefix}: name '{name}' must be kebab-case")
+    if len(name) > 64:
+        errors.append(f"{prefix}: name exceeds 64 characters ({len(name)})")
+    return errors
+
+
+def validate_description(meta: dict, prefix: str) -> list[str]:
+    """Validate description is a non-empty string between 50 and 1024 characters."""
+    errors: list[str] = []
+    desc = meta.get("description", "")
+    if not isinstance(desc, str) or not desc:
+        errors.append(f"{prefix}: description must be a non-empty string")
+        return errors
+    if len(desc) < 50:
+        errors.append(f"{prefix}: description too short ({len(desc)} chars, minimum 50)")
+    if len(desc) > 1024:
+        errors.append(f"{prefix}: description too long ({len(desc)} chars, maximum 1024)")
+    return errors
+
+
+def validate_agent(meta: dict, prefix: str) -> list[str]:
+    """Validate agent-specific fields."""
+    errors: list[str] = []
+    model = meta.get("model", "")
+    if model not in VALID_MODELS:
+        errors.append(f"{prefix}: model must be opus, sonnet, or haiku, got '{model}'")
+    color = meta.get("color", "")
+    if not isinstance(color, str) or not color:
+        errors.append(f"{prefix}: color must be a non-empty string")
+    return errors
+
+
+def validate_hook(meta: dict, prefix: str) -> list[str]:
+    """Validate hook-specific fields."""
+    errors: list[str] = []
+    hook = meta.get("hook")
+    if not isinstance(hook, dict):
+        errors.append(f"{prefix}: hook must be a dict")
+        return errors
+    events = hook.get("events")
+    if not isinstance(events, list) or len(events) == 0:
+        errors.append(f"{prefix}: hook.events must be a non-empty list")
+    handler = hook.get("handler")
+    if not isinstance(handler, dict):
+        errors.append(f"{prefix}: hook.handler must be a dict")
+    else:
+        if not handler.get("type"):
+            errors.append(f"{prefix}: hook.handler.type is required")
+        if not handler.get("command"):
+            errors.append(f"{prefix}: hook.handler.command is required")
+    return errors
+
+
+def validate_command(meta: dict, prefix: str) -> list[str]:
+    """Validate command-specific fields."""
+    command = meta.get("command")
+    if not isinstance(command, dict):
+        return [f"{prefix}: command must be a dict"]
+    return []
+
+
+def validate_utility(meta: dict, prefix: str) -> list[str]:
+    """Validate utility-specific fields."""
+    errors: list[str] = []
+    utility = meta.get("utility")
+    if not isinstance(utility, dict):
+        errors.append(f"{prefix}: utility must be a dict")
+        return errors
+    runtime = utility.get("runtime", "")
+    if not isinstance(runtime, str) or not runtime:
+        errors.append(f"{prefix}: utility.runtime must be a non-empty string")
+    return errors
+
+
+def validate_preset(meta: dict, prefix: str) -> list[str]:
+    """Validate preset-specific fields."""
+    errors: list[str] = []
+    preset = meta.get("preset")
+    if not isinstance(preset, dict):
+        errors.append(f"{prefix}: preset must be a dict")
+        return errors
+    packages = preset.get("packages")
+    if isinstance(packages, dict):
+        # Dict form: {skills: [...], hooks: [...], ...}
+        if not any(packages.values()):
+            errors.append(f"{prefix}: preset.packages must contain at least one package")
+    elif isinstance(packages, list):
+        if len(packages) == 0:
+            errors.append(f"{prefix}: preset.packages must be a non-empty list")
+    else:
+        errors.append(f"{prefix}: preset.packages must be a list or dict")
+    return errors
+
+
+_TYPE_VALIDATORS = {
+    "agent": validate_agent,
+    "hook": validate_hook,
+    "command": validate_command,
+    "utility": validate_utility,
+    "preset": validate_preset,
+}
+
+
+def validate_package(pkg_dir: Path, pkg_type: PackageType) -> list[str]:
+    """Validate frontmatter for a single package."""
+    definition = pkg_dir / pkg_type.definition_file
+    if not definition.exists():
+        return []
+
+    prefix = f"{pkg_type.key}/{pkg_dir.name}"
+    errors: list[str] = []
+
+    try:
+        text = definition.read_text(encoding="utf-8")
+        meta = parse_frontmatter(text)
+    except (ValueError, yaml.YAMLError) as e:
+        return [f"{prefix}: invalid frontmatter: {e}"]
+
+    if not isinstance(meta, dict):
+        return [f"{prefix}: frontmatter must be a YAML mapping"]
+
+    # Required fields presence check
+    for field in pkg_type.required_frontmatter:
+        val = meta.get(field)
+        if val is None or (isinstance(val, str) and not val):
+            errors.append(f"{prefix}: required field '{field}' is missing or empty")
+
+    # Name validation
+    errors.extend(validate_name(meta, pkg_dir.name, prefix))
+
+    # Version validation
+    version = extract_version(meta)
+    if not version:
+        errors.append(f"{prefix}: version is missing")
+    elif not validate_version(version):
+        errors.append(f"{prefix}: version '{version}' is not valid semver (X.Y.Z)")
+
+    # Description validation
+    errors.extend(validate_description(meta, prefix))
+
+    # Type-specific validation
+    validator = _TYPE_VALIDATORS.get(pkg_type.key)
+    if validator:
+        errors.extend(validator(meta, prefix))
+
+    return errors
+
+
+def main() -> int:
+    """Validate frontmatter across all package types."""
+    all_errors: list[str] = []
+    total = 0
+    type_count = 0
+
+    for pkg_type in TYPES.values():
+        type_dir = pkg_type.repo_dir
+        if not type_dir.exists():
+            continue
+
+        validated = 0
+        for pkg_dir in sorted(type_dir.iterdir()):
+            if not pkg_dir.is_dir():
+                continue
+            definition = pkg_dir / pkg_type.definition_file
+            if not definition.exists():
+                continue
+
+            errors = validate_package(pkg_dir, pkg_type)
+            all_errors.extend(errors)
+            validated += 1
+
+        if validated > 0:
+            total += validated
+            type_count += 1
+
+    if all_errors:
+        print(f"FAILED: {len(all_errors)} error(s):", file=sys.stderr)
+        for error in all_errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {total} packages across {type_count} types — all passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate that file references in package definition bodies exist on disk."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.frontmatter import extract_body
+from scripts.package_types import TYPES, PackageType
+
+# Matches references/ and assets/ paths (directories packages actually ship)
+_REF_PATTERN = re.compile(r"(?:references|assets)/[a-zA-Z0-9_.-]+")
+# Matches ../ followed by a known package directory pattern (actual cross-package refs)
+_CROSS_PKG_PATTERN = re.compile(
+    r"\.\./(?:skills|agents|hooks|rules|commands|utilities|presets)/"
+)
+
+
+def _strip_code_blocks(body: str) -> str:
+    """Remove fenced code blocks to avoid false positives from examples."""
+    return re.sub(r"```[\s\S]*?```", "", body)
+
+
+def extract_references(body: str) -> list[str]:
+    """Extract file references from definition body, excluding code blocks."""
+    cleaned = _strip_code_blocks(body)
+    return _REF_PATTERN.findall(cleaned)
+
+
+def validate_pkg_references(pkg_dir: Path, pkg_type: PackageType) -> list[str]:
+    """Validate file references for a single package."""
+    definition = pkg_dir / pkg_type.definition_file
+    if not definition.exists():
+        return []
+
+    pkg_name = pkg_dir.name
+    errors: list[str] = []
+
+    text = definition.read_text(encoding="utf-8")
+    body = extract_body(text)
+
+    # Check for cross-package references (../skills/, ../agents/, etc.)
+    if _CROSS_PKG_PATTERN.search(body):
+        errors.append(f"{pkg_name}: cross-package reference violates self-containment")
+
+    # Validate each reference exists on disk
+    refs = extract_references(body)
+    seen: set[str] = set()
+    for ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        target = pkg_dir / ref
+        if not target.exists():
+            errors.append(f"{pkg_name}: {ref} not found")
+
+    return errors
+
+
+def main() -> int:
+    """Validate all file references across package types."""
+    all_errors: list[str] = []
+    total = 0
+
+    for pkg_type in TYPES.values():
+        type_dir = pkg_type.repo_dir
+        if not type_dir.exists():
+            continue
+
+        for pkg_dir in sorted(type_dir.iterdir()):
+            if not pkg_dir.is_dir():
+                continue
+            definition = pkg_dir / pkg_type.definition_file
+            if not definition.exists():
+                continue
+
+            errors = validate_pkg_references(pkg_dir, pkg_type)
+            all_errors.extend(errors)
+            total += 1
+
+    if all_errors:
+        print(f"FAILED: {len(all_errors)} error(s):", file=sys.stderr)
+        for error in all_errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {total} packages — all references intact")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/competitive-analyzer/SKILL.md
+++ b/skills/competitive-analyzer/SKILL.md
@@ -7,17 +7,13 @@ description: >
   identify direct, indirect, and potential competitors across Product Hunt,
   G2, Capterra, and Crunchbase. Produces structured reports with force
   scorecards, feature gap analysis, pricing positioning, white space
-  identification, and strategic recommendations. Use this skill when you
-  need to analyze competitors, compare product features, evaluate market
-  positioning, assess competitive threats, build a competitive matrix,
-  run a Porter's Five Forces analysis, identify competitive moats, map
-  the competitive landscape, evaluate market defensibility, or perform
-  a pricing comparison. Triggers on: "competitive analysis", "competitor
-  comparison", "competitive landscape", "Porter's Five Forces", "feature
-  comparison matrix", "pricing analysis", "market positioning", "moat
-  assessment", "competitive threat", "defensibility analysis", "who are
-  the competitors", "compare competitors", "competitive intelligence",
-  "rival analysis", "market rivalry", "competitive positioning map".
+  identification, and strategic recommendations. Triggers on: "competitive
+  analysis", "competitor comparison", "competitive landscape", "Porter's
+  Five Forces", "feature comparison matrix", "pricing analysis", "market
+  positioning", "moat assessment", "competitive threat", "defensibility
+  analysis", "compare competitors", "competitive intelligence". Use this
+  skill when analyzing competitors, comparing features, or evaluating
+  market positioning and defensibility.
 metadata:
   version: 1.0.0
   complements:

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -2,21 +2,14 @@
 name: literature-review
 description: >
   Systematic literature review workflow for surveying, synthesizing, and analyzing
-  a body of academic research across a defined topic or research question. Covers
-  the full review lifecycle: defining scope and inclusion criteria, searching
-  academic databases (arXiv via arxiv-search utility, Semantic Scholar, Google
-  Scholar via web search), screening and filtering results, extracting structured
-  findings, thematic synthesis, gap identification, and producing a structured
-  review document with proper citations. Use this skill when you need to survey
-  a research area, map the landscape of a topic, identify research gaps, build
-  a bibliography, compare methodologies across studies, write a related work
-  section, conduct a systematic review, perform a scoping review, or synthesize
-  findings across multiple papers. Triggers on: "literature review", "survey
-  the literature", "what has been published on", "research landscape", "related
-  work", "systematic review", "scoping review", "map the research on", "what
-  do we know about", "synthesize the research", "compare approaches to",
-  "bibliography on", "find papers about", "review the state of the art",
-  "what are the key papers on", "research gap analysis".
+  academic research. Covers the full lifecycle: scope definition, searching academic
+  databases (arXiv, Semantic Scholar, Google Scholar), screening, structured extraction,
+  thematic synthesis, gap identification, and producing a cited review document.
+  Triggers on: "literature review", "survey the literature", "research landscape",
+  "related work", "systematic review", "scoping review", "synthesize the research",
+  "bibliography on", "find papers about", "review the state of the art", "research
+  gap analysis". Use this skill when surveying a research area, mapping a topic
+  landscape, identifying gaps, or writing a related work section.
 metadata:
   version: 1.0.0
   complements:

--- a/skills/package-evaluator/SKILL.md
+++ b/skills/package-evaluator/SKILL.md
@@ -3,22 +3,13 @@ name: package-evaluator
 description: >
   Evaluate Claude Code package quality across 6 weighted dimensions: frontmatter quality,
   trigger coverage, structural completeness, content depth, consistency and integrity,
-  and CONTRIBUTING.md compliance. Covers all 7 package types: skills, agents, hooks, rules,
-  commands, utilities, and presets. Each type has type-specific quality signals that refine
-  D3 and D4 scoring. Produces scored audit reports with severity-classified findings and
-  actionable recommendations. Two modes: (1) Quick Audit — single package, full per-dimension
-  report with weighted scoring; (2) Full Audit — all packages in repo, comparative ranking
-  table plus per-package summaries, optionally filtered by type. Triggers on: "evaluate
-  package", "evaluate skill", "audit agent quality", "score this hook", "rate this rule",
-  "evaluate command", "check utility quality", "assess preset", "package quality",
-  "package audit", "audit skill quality", "score skill", "skill review", "check skill
-  completeness", "rate this skill", "skill quality check", "grade skill", "assess skill",
-  "skill audit", "how good is this skill", "SKILL.md feedback", "how good is this agent",
-  "AGENT.md feedback". Use this skill when reviewing Claude Code packages before deployment,
-  comparing package quality across a repo, or diagnosing why a skill fails to activate on
-  relevant queries.
-  NOT for evaluating or improving LLM prompts — use prompt-lab instead.
-  NOT for reviewing pull requests — use pr-review instead.
+  and CONTRIBUTING.md compliance. Covers all 7 package types with type-specific signals.
+  Produces scored audit reports with severity-classified findings. Two modes: Quick Audit
+  (single package, full report) and Full Audit (all packages, ranking table). Triggers on:
+  "evaluate package", "audit agent quality", "score this hook", "package quality", "package
+  audit", "skill review", "skill quality check", "how good is this skill", "AGENT.md
+  feedback". Use this skill when reviewing packages before deployment or diagnosing
+  activation failures. NOT for LLM prompts (use prompt-lab) or PRs (use pr-review).
 metadata:
   version: 1.3.0
 ---


### PR DESCRIPTION
## Summary

- Add 3 new validation scripts enforcing package quality, frontmatter correctness, and reference integrity across all 92 packages
- Add `--validate` flag to adapter generator for post-generation output verification
- Integrate all validators into CI pipelines (PR gate + push-to-main)
- Fix 3 pre-existing description-length violations caught by the new validators

## New Scripts

### `scripts/validate_references.py`
Scans every package definition body for file references (`references/*.md`, `assets/*.png`) and verifies they exist on disk. Fenced code blocks are excluded to avoid false positives from example commands. Cross-package paths (`../skills/`, `../agents/`) are flagged as self-containment violations.

```bash
uv run scripts/validate_references.py
# Validated 92 packages — all references intact
```

### `scripts/validate_frontmatter.py`
Enforces type-specific frontmatter fields across all 7 package types:
- **All types**: name matches directory, kebab-case, max 64 chars, semver version, description 50-1024 chars
- **Agents**: `model` must be `opus`/`sonnet`/`haiku`, `color` required
- **Hooks**: `hook.events` (non-empty list) + `hook.handler` (dict with `type` and `command`)
- **Commands**: `command` dict required
- **Utilities**: `utility.runtime` string required
- **Presets**: `preset.packages` dict or list required

```bash
uv run scripts/validate_frontmatter.py
# Validated 92 packages across 7 types — all passed
```

### `scripts/evaluate_package.py`
6-dimension quality scorer matching the package-evaluator skill rubric:

| Dimension | Weight | Signals |
|-----------|--------|---------|
| D1 Frontmatter Quality | 20% | Description length, trigger phrases, "Use when" clause |
| D2 Trigger Coverage | 18% | Quoted trigger phrase count (6+ = full score) |
| D3 Structural Completeness | 20% | Workflow headings, error/output sections, references/ dir |
| D4 Content Depth | 22% | Word count, code blocks, tables, numbered lists |
| D5 Consistency | 12% | Name match, no cross-package refs, valid version |
| D6 Compliance | 8% | Kebab-case, length limit, valid YAML |

CRITICAL findings (missing definition, invalid YAML, name mismatch) cap the score at 40%.

```bash
uv run scripts/evaluate_package.py                          # All packages
uv run scripts/evaluate_package.py --path skills/pr-review   # Single package
uv run scripts/evaluate_package.py --threshold 70 --json     # CI mode
```

## Adapter Validation (`--validate` flag)

Each adapter now implements a `validate()` method:
- **Cursor**: verifies `.mdc` files have YAML frontmatter with `alwaysApply` field
- **Codex**: checks root `AGENTS.md` stays under 32 KiB budget, verifies referenced subdirectory files exist
- **Gemini**: detects Claude-specific fields (`type`, `model`, `color`, `hook`, etc.) leaked into skill frontmatter

```bash
uv run scripts/generate_adapters.py --validate
# Validation passed for 3 platform(s)
```

## CI Integration

### `evals.yml` (PR gate + push to main)
Three new required steps added after eval schema validation:
1. **Validate frontmatter** — blocks malformed packages from merging
2. **Validate file references** — blocks broken reference links
3. **Evaluate package quality** — runs evaluator on changed packages in PRs, fails below 70% threshold

### `package.yml` (push to main + tags)
One new step before packaging:
- **Validate adapter generation** — runs `generate_adapters.py --validate` to catch malformed adapter output

## Pre-existing Fixes

Three skill descriptions exceeded the 1024-character CONTRIBUTING.md limit:
- `competitive-analyzer`: 1189 → 874 chars (condensed trigger list)
- `literature-review`: 1204 → 756 chars (condensed lifecycle description)
- `package-evaluator`: 1460 → 787 chars (condensed mode descriptions and trigger list)

Manifest regenerated to reflect updated descriptions.

## Test plan

- [x] `uv run scripts/validate_references.py` — 92 packages, all references intact
- [x] `uv run scripts/validate_frontmatter.py` — 92 packages across 7 types, all passed
- [x] `uv run scripts/evaluate_package.py --path skills/pr-review` — 96/100 PASS
- [x] `uv run scripts/generate_adapters.py --validate` — 3 platforms validated
- [x] `uv run python -m pytest tests/ -q` — 205 existing tests pass
- [x] `uv run scripts/validate_evals.py` — all eval schemas valid
- [x] `uv run scripts/generate_manifest.py` + `git diff --exit-code manifest.yaml` — manifest in sync