### PR TITLE
feat(dist): multi-platform distribution with release artifacts, npm installer, and plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "owner": "Mathews-Tom",
+  "plugins": [
+    {
+      "name": "armory",
+      "repository": "https://github.com/Mathews-Tom/armory",
+      "description": "Production-grade skills, agents, hooks, rules, and commands for Claude Code"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "armory",
+  "version": "0.2.0",
+  "description": "Production-grade skills, agents, hooks, rules, and commands for Claude Code — 92 packages across 7 types",
+  "author": {
+    "name": "Mathews-Tom",
+    "url": "https://github.com/Mathews-Tom"
+  },
+  "homepage": "https://github.com/Mathews-Tom/armory",
+  "repository": "https://github.com/Mathews-Tom/armory",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "agents",
+    "code-review",
+    "security",
+    "testing",
+    "architecture",
+    "research",
+    "content",
+    "hooks",
+    "rules"
+  ]
+}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,8 +30,17 @@ jobs:
           python scripts/generate_manifest.py
           git diff --exit-code manifest.yaml
 
-      - name: Validate adapter generation
+      - name: Generate and validate adapters
         run: python scripts/generate_adapters.py --validate
+
+      - name: Package adapter artifacts
+        run: |
+          mkdir -p dist
+          cd adapters/cursor && tar -czf ../../dist/armory-cursor.tar.gz .cursor && cd ../..
+          cd adapters/codex && tar -czf ../../dist/armory-codex.tar.gz AGENTS.md standards agents workflows skills && cd ../..
+          cd adapters/gemini && tar -czf ../../dist/armory-gemini.tar.gz .gemini && cd ../..
+          echo "Adapter artifacts:"
+          ls -lh dist/armory-*.tar.gz
 
       - name: Package all items
         run: |

--- a/README.md
+++ b/README.md
@@ -378,39 +378,63 @@ Output lands in `adapters/{platform}/` (gitignored — generated, not source).
 | **Utilities** | —                                        | —                     | Wrapped as `.gemini/skills/`            |
 | **Presets**   | —                                        | —                     | —                                       |
 
-### Use with Cursor
+### Quick Install (no Python required)
 
-Copy the generated `.cursor/` directory into your project root:
+Download pre-built adapter packages from the latest release:
+
+```bash
+# Cursor
+npx @anthropic-armory/installer --target cursor
+
+# Codex
+npx @anthropic-armory/installer --target codex
+
+# Gemini
+npx @anthropic-armory/installer --target gemini --dir /path/to/project
+```
+
+Or download directly from [GitHub Releases](../../releases):
+
+```bash
+# Cursor — extract .cursor/ into your project root
+curl -sL https://github.com/Mathews-Tom/armory/releases/download/latest/armory-cursor.tar.gz | tar -xz
+
+# Codex — extract AGENTS.md + subdirectories into project root
+curl -sL https://github.com/Mathews-Tom/armory/releases/download/latest/armory-codex.tar.gz | tar -xz
+
+# Gemini — extract .gemini/ into your project root
+curl -sL https://github.com/Mathews-Tom/armory/releases/download/latest/armory-gemini.tar.gz | tar -xz
+```
+
+### Install via Python (with TUI)
+
+The Python installer supports all targets with `--target`:
+
+```bash
+uv run scripts/install.py --target cursor --project-dir /path/to/project
+uv run scripts/install.py --target codex --project-dir /path/to/project
+uv run scripts/install.py --target gemini --project-dir /path/to/project
+```
+
+### Generate Locally
+
+Generate adapter output from source (requires Python 3.12):
 
 ```bash
 uv run scripts/generate_adapters.py --platform cursor
-cp -r adapters/cursor/.cursor /path/to/your/project/
-```
-
-Rules with `alwaysApply: true` (project standards) load on every prompt. Skills and agents load when Cursor matches the description or glob pattern.
-
-### Use with OpenAI Codex
-
-Copy the generated Codex directory to your project root:
-
-```bash
 uv run scripts/generate_adapters.py --platform codex
-cp adapters/codex/AGENTS.md /path/to/your/project/
-cp -r adapters/codex/{standards,agents,workflows,skills} /path/to/your/project/
-```
-
-The root `AGENTS.md` is a condensed index under the 32 KiB budget. Full content is in subdirectory `AGENTS.md` files, loaded via Codex's hierarchical discovery when the working directory matches.
-
-### Use with Gemini CLI
-
-Copy the generated `.gemini/` directory into your project root:
-
-```bash
 uv run scripts/generate_adapters.py --platform gemini
-cp -r adapters/gemini/.gemini /path/to/your/project/
 ```
 
-Skills are a near 1:1 copy (references, scripts, and assets included). Rules become sections in `GEMINI.md`. Commands are converted to TOML format. Agents are markdown files with cleaned frontmatter.
+Output lands in `adapters/{platform}/` (gitignored — generated, not source).
+
+### Platform Details
+
+**Cursor**: Rules with `alwaysApply: true` (project standards) load on every prompt. Skills and agents load when Cursor matches the description or glob pattern.
+
+**Codex**: The root `AGENTS.md` is a condensed index under the 32 KiB budget. Full content is in subdirectory `AGENTS.md` files, loaded via Codex's hierarchical discovery.
+
+**Gemini**: Skills are a near 1:1 copy (references, scripts, and assets included). Rules become sections in `GEMINI.md`. Commands are converted to TOML format.
 
 ### What's Lost
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,13 @@
+# @anthropic-armory/installer
+
+Install armory AI agent packages for Cursor, Codex, and Gemini.
+
+## Usage
+
+```bash
+npx @anthropic-armory/installer --target cursor
+npx @anthropic-armory/installer --target codex
+npx @anthropic-armory/installer --target gemini --dir /path/to/project
+```
+
+Downloads pre-built adapter packages from the armory GitHub releases and extracts them into your project.

--- a/npm/bin/install.js
+++ b/npm/bin/install.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execSync } = require("child_process");
+
+const TARGETS = {
+  cursor: "armory-cursor.tar.gz",
+  codex: "armory-codex.tar.gz",
+  gemini: "armory-gemini.tar.gz",
+};
+
+const MAX_REDIRECTS = 3;
+
+function parseArgs(argv) {
+  const args = { target: null, dir: process.cwd(), repo: "Mathews-Tom/armory", tag: "latest" };
+  for (let i = 2; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--target":
+        args.target = argv[++i];
+        break;
+      case "--dir":
+        args.dir = argv[++i];
+        break;
+      case "--repo":
+        args.repo = argv[++i];
+        break;
+      case "--tag":
+        args.tag = argv[++i];
+        break;
+      case "--help":
+      case "-h":
+        printUsage();
+        process.exit(0);
+      default:
+        fatal(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  return args;
+}
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "Usage: armory-install --target <cursor|codex|gemini|claude> [options]",
+      "",
+      "Options:",
+      "  --target <name>   Target platform (cursor, codex, gemini, claude)",
+      "  --dir <path>      Extraction directory (default: cwd)",
+      "  --repo <owner/name> GitHub repository (default: Mathews-Tom/armory)",
+      "  --tag <tag>       Release tag (default: latest)",
+      "  -h, --help        Show this help",
+      "",
+    ].join("\n")
+  );
+}
+
+function fatal(msg) {
+  process.stderr.write(`Error: ${msg}\n`);
+  process.exit(1);
+}
+
+function download(url, dest, redirects) {
+  return new Promise((resolve, reject) => {
+    if (redirects > MAX_REDIRECTS) {
+      return reject(new Error("Too many redirects"));
+    }
+    https
+      .get(url, { headers: { "User-Agent": "armory-installer/0.1.0" } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          process.stderr.write(`  ↳ redirect ${res.statusCode}\n`);
+          return resolve(download(res.headers.location, dest, redirects + 1));
+        }
+        if (res.statusCode === 404) {
+          return reject(new Error(`Release asset not found (404). Verify the release tag and asset name exist at the repository.`));
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+        }
+
+        const totalBytes = parseInt(res.headers["content-length"], 10) || 0;
+        let downloaded = 0;
+        const file = fs.createWriteStream(dest);
+
+        res.on("data", (chunk) => {
+          downloaded += chunk.length;
+          if (totalBytes > 0) {
+            const pct = ((downloaded / totalBytes) * 100).toFixed(0);
+            process.stderr.write(`\r  downloading... ${pct}%`);
+          } else {
+            process.stderr.write(`\r  downloading... ${(downloaded / 1024).toFixed(0)} KB`);
+          }
+        });
+
+        res.pipe(file);
+        file.on("finish", () => {
+          process.stderr.write("\n");
+          file.close(resolve);
+        });
+        file.on("error", (err) => {
+          fs.unlink(dest, () => {});
+          reject(err);
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.target) {
+    fatal("--target is required. Use --help for usage.");
+  }
+
+  if (args.target === "claude") {
+    process.stdout.write(
+      "Claude Code uses skills directly. Install with:\n\n  npx skills add Mathews-Tom/armory\n\n"
+    );
+    process.exit(0);
+  }
+
+  if (!TARGETS[args.target]) {
+    fatal(`Unknown target "${args.target}". Valid targets: cursor, codex, gemini, claude`);
+  }
+
+  const assetName = TARGETS[args.target];
+  const releaseSegment =
+    args.tag === "latest" ? "latest/download" : `download/${args.tag}`;
+  const url = `https://github.com/${args.repo}/releases/${releaseSegment}/${assetName}`;
+  const tmpFile = path.join(os.tmpdir(), `armory-${args.target}-${Date.now()}.tar.gz`);
+  const destDir = path.resolve(args.dir);
+
+  if (!fs.existsSync(destDir)) {
+    fatal(`Directory does not exist: ${destDir}`);
+  }
+
+  process.stderr.write(`Downloading ${assetName} from ${args.repo}@${args.tag}\n`);
+
+  try {
+    await download(url, tmpFile, 0);
+  } catch (err) {
+    fatal(`Download failed: ${err.message}`);
+  }
+
+  process.stderr.write(`Extracting to ${destDir}\n`);
+
+  try {
+    execSync(`tar -xzf "${tmpFile}" -C "${destDir}"`, { stdio: "pipe" });
+  } catch (err) {
+    fs.unlink(tmpFile, () => {});
+    fatal(`Extraction failed: ${err.message}`);
+  }
+
+  // Count extracted files by listing tarball contents
+  let fileCount = 0;
+  try {
+    const listing = execSync(`tar -tzf "${tmpFile}"`, { encoding: "utf8" });
+    fileCount = listing.split("\n").filter((l) => l.trim() && !l.endsWith("/")).length;
+  } catch {
+    fileCount = -1;
+  }
+
+  // Clean up tarball
+  try {
+    fs.unlinkSync(tmpFile);
+  } catch {
+    // non-critical
+  }
+
+  const countMsg = fileCount > 0 ? `${fileCount} files` : "files";
+  process.stdout.write(`Done. Extracted ${countMsg} to ${destDir}\n`);
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@anthropic-armory/installer",
+  "version": "0.1.0",
+  "description": "Cross-platform installer for armory AI agent packages — Cursor, Codex, and Gemini",
+  "license": "MIT",
+  "repository": "https://github.com/Mathews-Tom/armory",
+  "bin": {
+    "armory-install": "bin/install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": ["claude-code", "cursor", "codex", "gemini", "ai-agent", "skills"]
+}

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import stat
 import sys
+import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -546,6 +547,58 @@ def filter_by_profile(
 
 
 # ---------------------------------------------------------------------------
+# Platform adapter installation
+# ---------------------------------------------------------------------------
+
+_PLATFORM_COPY_MAP: dict[str, str] = {
+    "cursor": ".cursor",
+    "gemini": ".gemini",
+}
+
+
+def install_to_platform(target: str, project_dir: Path) -> int:
+    """Generate adapter output and copy to project directory for non-Claude targets."""
+    from scripts.generate_adapters import _ADAPTERS, load_packages
+
+    packages = load_packages()
+    total = sum(len(pkgs) for pkgs in packages.values())
+    if total == 0:
+        console.print("[red]No packages found.[/red]")
+        return 1
+
+    adapter_cls = _ADAPTERS[target]
+    tmp_dir = tempfile.mkdtemp(prefix="armory-adapter-")
+    tmp_path = Path(tmp_dir)
+
+    try:
+        adapter = adapter_cls(tmp_path, dry_run=False)
+        adapter.generate(packages)
+
+        if target in _PLATFORM_COPY_MAP:
+            src = tmp_path / _PLATFORM_COPY_MAP[target]
+            dst = project_dir / _PLATFORM_COPY_MAP[target]
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+        elif target == "codex":
+            # Copy AGENTS.md and subdirectories to project root
+            for item in tmp_path.iterdir():
+                dst = project_dir / item.name
+                if item.is_dir():
+                    if dst.exists():
+                        shutil.rmtree(dst)
+                    shutil.copytree(item, dst)
+                else:
+                    shutil.copy2(item, dst)
+
+        console.print(f"[green]Installed {target} adapter to {project_dir}[/green]")
+        console.print(f"  {adapter.report()}")
+        return 0
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -570,7 +623,22 @@ def main() -> int:
         "--profile",
         help="Install packages matching a profile from profiles.yaml",
     )
+    parser.add_argument(
+        "--target",
+        choices=["claude", "cursor", "codex", "gemini"],
+        default="claude",
+        help="Target platform (default: claude)",
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Project directory for non-Claude targets (default: current directory)",
+    )
     args = parser.parse_args()
+
+    if args.target != "claude":
+        return install_to_platform(args.target, args.project_dir)
 
     console.print(Panel("armory installer", border_style="blue"))
 


### PR DESCRIPTION
## Summary

- Add Claude marketplace plugin manifest for `/plugin install armory` support
- Add `--target` and `--project-dir` flags to the Python installer for cross-platform installation
- Add zero-dependency npm installer for Cursor/Codex/Gemini users who don't have Python
- Package adapter output as release artifacts (`armory-cursor.tar.gz`, `armory-codex.tar.gz`, `armory-gemini.tar.gz`)
- Update README with three installation paths: npx, curl, and Python TUI

## Plugin Manifest (`.claude-plugin/`)

Two files for Claude Code plugin directory listing:

- **`plugin.json`**: Required manifest with name, version, description, author, repository, license, and keywords. Enables discovery via `/plugin install armory` once accepted into the official directory.
- **`marketplace.json`**: Optional index file for marketplace aggregation.

## Multi-Target Installer (`scripts/install.py`)

Two new CLI flags:

| Flag | Description | Default |
|------|-------------|---------|
| `--target` | Platform: `claude`, `cursor`, `codex`, `gemini` | `claude` |
| `--project-dir` | Destination directory for non-Claude targets | Current working directory |

When `--target` is not `claude`:
1. Generates adapter output via `generate_adapters.py` into a temp directory
2. Copies the platform-specific output to the project directory
3. Prints a summary and exits (no TUI selection flow)

The default `--target claude` path is completely unchanged — same TUI, same `~/.claude/` destination.

```bash
uv run scripts/install.py --target cursor --project-dir /path/to/project
uv run scripts/install.py --target codex
uv run scripts/install.py --target gemini --project-dir ~/my-project
```

## npm Installer (`npm/`)

Zero-dependency Node.js CLI for users who don't have Python 3.12:

```bash
npx @anthropic-armory/installer --target cursor
npx @anthropic-armory/installer --target codex --dir /path/to/project
npx @anthropic-armory/installer --target gemini
```

Implementation:
- Downloads platform-specific tarball from GitHub releases using built-in `https` module
- Follows up to 3 redirects (GitHub sends 302 to CDN)
- Extracts via `tar -xzf` using `child_process.execSync`
- Reports file count and extraction path
- Cleans up temp files in all exit paths
- `--target claude` exits early with a message to use `npx skills add` instead

No external dependencies — uses only Node.js built-in modules (`https`, `fs`, `path`, `os`, `child_process`).

## Release Artifacts (`.github/workflows/package.yml`)

New CI step between adapter validation and package creation:

1. Generates adapter output (already validated by the preceding step)
2. Creates three tarballs in `dist/`:
   - `armory-cursor.tar.gz` — contains `.cursor/` directory tree (rules + commands)
   - `armory-codex.tar.gz` — contains `AGENTS.md` + `standards/`, `agents/`, `workflows/`, `skills/` subdirectories
   - `armory-gemini.tar.gz` — contains `.gemini/` directory tree (skills, agents, commands, GEMINI.md)
3. Tarballs are included in both versioned releases and the rolling `latest` release via the existing `dist/*` glob

Users can now `curl -sL` the tarballs directly from GitHub releases without cloning the repo.

## README Updates

The Cross-Platform Adapters section now documents three installation paths in priority order:

1. **Quick Install** (`npx @anthropic-armory/installer --target <platform>`) — zero dependencies
2. **Direct Download** (`curl | tar`) — from GitHub releases
3. **Python TUI** (`uv run scripts/install.py --target <platform>`) — for Python users
4. **Local Generation** (`uv run scripts/generate_adapters.py`) — for developers customizing output

Platform details (Cursor alwaysApply behavior, Codex hierarchical discovery, Gemini 1:1 skills) consolidated into a single section.

## Test plan

- [x] `uv run scripts/install.py --help` — shows `--target` and `--project-dir` flags
- [x] `uv run scripts/install.py --target cursor --project-dir /tmp/test` — generates and copies 77 files to `.cursor/`
- [x] `node npm/bin/install.js --help` — shows usage with all flags
- [x] `node npm/bin/install.js --target claude` — exits with `npx skills add` message
- [x] `.claude-plugin/plugin.json` validates as valid JSON
- [x] `.claude-plugin/marketplace.json` validates as valid JSON
- [x] `uv run python -m pytest tests/ -q` — 205 existing tests pass
- [ ] Manual: verify `armory-cursor.tar.gz` appears in GitHub release after merge
- [ ] Manual: verify `npx @anthropic-armory/installer --target cursor` downloads and extracts (requires published npm package + release artifacts)