### PR TITLE
feat(discovery): structured metadata, CLI search, role-based profiles, and multi-type package library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ name: my-skill-name
 description: What this skill does in plain language.
 metadata:
   version: 1.0.0
+  category: development
+  tags: [keyword1, keyword2, keyword3]
+  difficulty: intermediate
 ---
 ```
 
@@ -215,6 +218,42 @@ description: >
 ```yaml
 description: "Review architecture and provide feedback."
 ```
+
+## Metadata Fields
+
+Every package should include `category`, `tags`, and `difficulty` under `metadata:` in frontmatter.
+
+### Category
+
+Assign one category from the table below:
+
+| Category        | Use For                                                    |
+| --------------- | ---------------------------------------------------------- |
+| `development`   | Coding tools, build, debug, test, IDE integration          |
+| `review`        | Code review, PR review, quality checks, auditing           |
+| `security`      | Security scanning, secrets detection, vulnerability checks |
+| `research`      | Literature review, academic research, critique             |
+| `content`       | Writing, presentations, video, publishing                  |
+| `business`      | Idea validation, market sizing, feasibility, proposals     |
+| `visualization` | Diagrams, images, video rendering, visual artifacts        |
+| `operations`    | Release, deployment, CI/CD, git workflow, presets           |
+| `data`          | SQL, database, migration, benchmarks                       |
+
+### Tags
+
+Add 3-6 lowercase kebab-case tags that help users discover the package. Include:
+
+- Domain keywords (e.g., `sql`, `python`, `security`)
+- Action verbs (e.g., `code-review`, `test-generation`)
+- Technology names (e.g., `pytest`, `manim`, `remotion`)
+
+### Difficulty
+
+| Level          | Criteria                                                   |
+| -------------- | ---------------------------------------------------------- |
+| `beginner`     | Simple single-purpose tools, minimal setup                 |
+| `intermediate` | Multi-step workflows, some domain knowledge needed         |
+| `advanced`     | Complex multi-phase analysis, deep domain expertise needed |
 
 ## Quality Gate — Skill Evaluator
 

--- a/agents/code-reviewer/AGENT.md
+++ b/agents/code-reviewer/AGENT.md
@@ -1,26 +1,27 @@
 ---
 name: code-reviewer
 type: agent
-description: >
-  Multi-phase code review agent with severity-ranked findings across naming
-  conventions, cyclomatic complexity, error handling, DRY violations, security
-  surface, and test coverage gaps. Produces structured reports with
-  CRITICAL/HIGH/MEDIUM/LOW classification and file:line references.
-  Triggers on: "review code", "code review", "check code quality",
-  "audit code", "review my code", "code quality check", "lint my code",
-  "find code issues". Use this agent when code has been written or modified
+description: 'Multi-phase code review agent with severity-ranked findings across naming
+  conventions, cyclomatic complexity, error handling, DRY violations, security surface,
+  and test coverage gaps. Produces structured reports with CRITICAL/HIGH/MEDIUM/LOW
+  classification and file:line references. Triggers on: "review code", "code review",
+  "check code quality", "audit code", "review my code", "code quality check", "lint
+  my code", "find code issues". Use this agent when code has been written or modified
   and needs systematic quality review before commit or merge.
+
+  '
 model: sonnet
 color: blue
 metadata:
   version: 1.0.0
-  category: code-quality
+  category: review
   execution_phase: post-write
   priority: 100
   enabled: true
-  language_targets: ["*"]
+  language_targets: ['*']
+  tags: [code-review, quality, severity-ranking, sonnet]
+  difficulty: intermediate
 ---
-
 # Code Reviewer
 
 Multi-phase code quality review producing severity-ranked findings with

--- a/agents/codebase-auditor/AGENT.md
+++ b/agents/codebase-auditor/AGENT.md
@@ -1,29 +1,30 @@
 ---
 name: codebase-auditor
 type: agent
-description: >
-  Unified multi-dimensional codebase quality assessment that spawns specialized
-  review agents in parallel and aggregates findings into a single prioritized
-  report. Covers code quality, security vulnerabilities, secret detection,
-  architectural concerns, dependency health, and test coverage gaps.
-  Triggers on: "audit the codebase", "full quality check", "comprehensive
-  review", "audit everything", "run all checks", "codebase health check",
-  "quality assessment", "audit this repo", "check everything before release",
-  "multi-dimensional review". Use this agent when a broad quality assessment
+description: 'Unified multi-dimensional codebase quality assessment that spawns specialized
+  review agents in parallel and aggregates findings into a single prioritized report.
+  Covers code quality, security vulnerabilities, secret detection, architectural concerns,
+  dependency health, and test coverage gaps. Triggers on: "audit the codebase", "full
+  quality check", "comprehensive review", "audit everything", "run all checks", "codebase
+  health check", "quality assessment", "audit this repo", "check everything before
+  release", "multi-dimensional review". Use this agent when a broad quality assessment
   across multiple dimensions is needed rather than a single focused review.
+
+  '
 model: sonnet
 color: red
 metadata:
   version: 1.0.0
-  category: quality
+  category: review
   execution_phase: on-demand
   priority: 80
   enabled: true
   orchestrates:
     skills: [architecture-reviewer, dependency-audit]
     agents: [code-reviewer, security-reviewer, secret-scanner]
+  tags: [audit, codebase, quality, sonnet]
+  difficulty: intermediate
 ---
-
 # Codebase Auditor
 
 Unified quality assessment that orchestrates specialized agents and skills to

--- a/agents/content-strategist/AGENT.md
+++ b/agents/content-strategist/AGENT.md
@@ -1,18 +1,18 @@
 ---
 name: content-strategist
 type: agent
-description: >
-  Technical content creation and adaptation engine that transforms topics,
-  research, and source material into channel-optimized content across multiple
-  formats. Orchestrates research, writing, slide generation, PDF production,
-  and humanization into a unified content pipeline. Produces LinkedIn posts,
-  blog articles, HTML slide decks, and PDF reports from a single brief.
-  Triggers on: "create content for", "write a LinkedIn post about",
-  "turn this into a blog post", "build a slide deck on", "content strategy for",
-  "repurpose this for", "adapt this content", "write about this topic",
-  "create a presentation on", "multi-channel content for".
-  Use this agent when content needs to be created, adapted, or distributed
-  across multiple channels or formats from a single topic or source.
+description: 'Technical content creation and adaptation engine that transforms topics,
+  research, and source material into channel-optimized content across multiple formats.
+  Orchestrates research, writing, slide generation, PDF production, and humanization
+  into a unified content pipeline. Produces LinkedIn posts, blog articles, HTML slide
+  decks, and PDF reports from a single brief. Triggers on: "create content for", "write
+  a LinkedIn post about", "turn this into a blog post", "build a slide deck on", "content
+  strategy for", "repurpose this for", "adapt this content", "write about this topic",
+  "create a presentation on", "multi-channel content for". Use this agent when content
+  needs to be created, adapted, or distributed across multiple channels or formats
+  from a single topic or source.
+
+  '
 model: sonnet
 color: pink
 metadata:
@@ -22,10 +22,12 @@ metadata:
   priority: 70
   enabled: true
   orchestrates:
-    skills: [linkedin-post-style, humanize, html-presentation, md-to-pdf, tavily, youtube-analysis]
+    skills: [linkedin-post-style, humanize, html-presentation, md-to-pdf, tavily,
+      youtube-analysis]
     agents: []
+  tags: [content, strategy, planning, sonnet]
+  difficulty: intermediate
 ---
-
 # Content Strategist
 
 Transforms topics and source material into channel-optimized content across

--- a/agents/full-stack-builder/AGENT.md
+++ b/agents/full-stack-builder/AGENT.md
@@ -1,16 +1,17 @@
 ---
 name: full-stack-builder
 type: agent
-description: >
-  End-to-end implementation agent that takes an architecture document or feature
-  spec and delivers production-ready code with tests, API documentation, and
-  security validation. Orchestrates quality skills throughout the build process
+description: 'End-to-end implementation agent that takes an architecture document
+  or feature spec and delivers production-ready code with tests, API documentation,
+  and security validation. Orchestrates quality skills throughout the build process
   rather than bolting them on at the end. Covers project scaffolding, incremental
-  implementation sprints, and pre-delivery review gates.
-  Triggers on: "build this feature", "implement the spec", "scaffold a new project",
-  "full-stack implementation", "build from architecture doc", "implement end to end",
-  "create the app", "build it out". Use this agent when a complete implementation
-  from spec to production-ready code is needed across multiple components.
+  implementation sprints, and pre-delivery review gates. Triggers on: "build this
+  feature", "implement the spec", "scaffold a new project", "full-stack implementation",
+  "build from architecture doc", "implement end to end", "create the app", "build
+  it out". Use this agent when a complete implementation from spec to production-ready
+  code is needed across multiple components.
+
+  '
 model: opus
 color: blue
 metadata:
@@ -22,8 +23,9 @@ metadata:
   orchestrates:
     skills: [test-harness, api-docs-generator, pre-landing-review, pr-review, code-refiner]
     commands: [security-scan]
+  tags: [full-stack, implementation, development, opus]
+  difficulty: intermediate
 ---
-
 # Full-Stack Builder
 
 End-to-end implementation agent that transforms architecture documents and feature

--- a/agents/idea-scout/AGENT.md
+++ b/agents/idea-scout/AGENT.md
@@ -1,16 +1,17 @@
 ---
 name: idea-scout
 type: agent
-description: >
-  Business idea validation pipeline that orchestrates parallel market research,
-  competitive analysis, and feasibility assessment to produce a scored validation
-  report with GO/CAUTION/NO-GO verdict. Constructs a Lean Canvas, synthesizes
-  SWOT and PESTLE frameworks, and recommends low-cost experiments to test
-  highest-risk assumptions. Provides honest assessment backed by quantified data.
-  Triggers on: "validate this idea", "is this idea viable", "business idea assessment",
-  "market validation", "evaluate this business concept", "idea feasibility check",
-  "should I build this", "startup idea review". Use this agent when a business idea
-  needs structured validation across market, competitive, and feasibility dimensions.
+description: 'Business idea validation pipeline that orchestrates parallel market
+  research, competitive analysis, and feasibility assessment to produce a scored validation
+  report with GO/CAUTION/NO-GO verdict. Constructs a Lean Canvas, synthesizes SWOT
+  and PESTLE frameworks, and recommends low-cost experiments to test highest-risk
+  assumptions. Provides honest assessment backed by quantified data. Triggers on:
+  "validate this idea", "is this idea viable", "business idea assessment", "market
+  validation", "evaluate this business concept", "idea feasibility check", "should
+  I build this", "startup idea review". Use this agent when a business idea needs
+  structured validation across market, competitive, and feasibility dimensions.
+
+  '
 model: opus
 color: teal
 metadata:
@@ -20,9 +21,11 @@ metadata:
   priority: 85
   enabled: true
   orchestrates:
-    skills: [idea-validator, competitive-analyzer, market-analyzer, feasibility-assessor, tavily]
+    skills: [idea-validator, competitive-analyzer, market-analyzer, feasibility-assessor,
+      tavily]
+  tags: [ideas, research, validation, opus]
+  difficulty: intermediate
 ---
-
 # Idea Scout
 
 Business idea validation pipeline that orchestrates parallel research agents to

--- a/agents/media-producer/AGENT.md
+++ b/agents/media-producer/AGENT.md
@@ -1,18 +1,18 @@
 ---
 name: media-producer
 type: agent
-description: >
-  Visual and video asset creation with intelligent format routing. Analyzes
-  concepts and automatically selects the optimal output format — static images,
-  architecture diagrams, animated explainers, motion graphics, interactive
-  dashboards, or slide presentations. Orchestrates specialized production skills
-  and provides styling guidance for consistent, high-quality visual output.
-  Triggers on: "create a visual for", "make a diagram of", "generate a video
-  explaining", "build a presentation about", "visualize this architecture",
-  "produce an infographic for", "animate this concept", "create slides for",
-  "make a product demo video", "design a visual showing".
-  Use this agent when a concept needs to become a visual or video asset and the
-  user has not specified a single production skill by name.
+description: 'Visual and video asset creation with intelligent format routing. Analyzes
+  concepts and automatically selects the optimal output format — static images, architecture
+  diagrams, animated explainers, motion graphics, interactive dashboards, or slide
+  presentations. Orchestrates specialized production skills and provides styling guidance
+  for consistent, high-quality visual output. Triggers on: "create a visual for",
+  "make a diagram of", "generate a video explaining", "build a presentation about",
+  "visualize this architecture", "produce an infographic for", "animate this concept",
+  "create slides for", "make a product demo video", "design a visual showing". Use
+  this agent when a concept needs to become a visual or video asset and the user has
+  not specified a single production skill by name.
+
+  '
 model: sonnet
 color: magenta
 metadata:
@@ -22,16 +22,12 @@ metadata:
   priority: 70
   enabled: true
   orchestrates:
-    skills:
-      - concept-to-image
-      - concept-to-video
-      - remotion-video
-      - architecture-diagram
-      - html-presentation
-      - static-web-artifacts-builder
+    skills: [concept-to-image, concept-to-video, remotion-video, architecture-diagram,
+      html-presentation, static-web-artifacts-builder]
     agents: []
+  tags: [media, production, content, sonnet]
+  difficulty: intermediate
 ---
-
 # Media Producer
 
 Visual and video asset creation with intelligent format routing. Analyzes what

--- a/agents/project-architect/AGENT.md
+++ b/agents/project-architect/AGENT.md
@@ -1,30 +1,32 @@
 ---
 name: project-architect
 type: agent
-description: >
-  System architecture agent that conducts phased requirements discovery and
-  produces production-ready architecture documents with technology stack
-  justification, Mermaid diagrams, data flow design, and implementation phases.
-  Gathers business context before proposing technical solutions.
-  Triggers on: "architect this system", "design the architecture", "system
-  design for", "technical architecture", "help me architect", "design a
-  system for", "create architecture document", "what tech stack should I use",
-  "architecture discovery", "system design session", "design this project",
-  "architect a solution". Use this agent when starting a new project or major
-  feature that needs structured requirements gathering and architecture design.
+description: 'System architecture agent that conducts phased requirements discovery
+  and produces production-ready architecture documents with technology stack justification,
+  Mermaid diagrams, data flow design, and implementation phases. Gathers business
+  context before proposing technical solutions. Triggers on: "architect this system",
+  "design the architecture", "system design for", "technical architecture", "help
+  me architect", "design a system for", "create architecture document", "what tech
+  stack should I use", "architecture discovery", "system design session", "design
+  this project", "architect a solution". Use this agent when starting a new project
+  or major feature that needs structured requirements gathering and architecture design.
+
+  '
 model: opus
 color: purple
 metadata:
   version: 1.0.0
-  category: architecture
+  category: review
   execution_phase: on-demand
   priority: 70
   enabled: true
   orchestrates:
-    skills: [architecture-diagram, architecture-reviewer, adr-writer, feasibility-assessor, tavily]
+    skills: [architecture-diagram, architecture-reviewer, adr-writer, feasibility-assessor,
+      tavily]
     agents: []
+  tags: [architecture, design, planning, opus]
+  difficulty: advanced
 ---
-
 # Project Architect
 
 Conducts structured requirements discovery through phased questioning, then

--- a/agents/project-planner/AGENT.md
+++ b/agents/project-planner/AGENT.md
@@ -1,30 +1,31 @@
 ---
 name: project-planner
 type: agent
-description: >
-  Task breakdown and project planning agent that decomposes work into
-  dependency-mapped items with three-point estimates, milestones, and risk
-  tracking. Produces actionable project plans with parallelization flags
-  and realistic timelines calibrated against historical data.
-  Triggers on: "plan this project", "break down the work", "create a project
-  plan", "estimate the timeline", "task breakdown", "what are the milestones",
-  "decompose this into tasks", "how long will this take", "plan the
-  implementation", "scope this work". Use this agent when a structured project
-  plan with task dependencies, estimates, and risk assessment is needed rather
-  than ad-hoc task listing.
+description: 'Task breakdown and project planning agent that decomposes work into
+  dependency-mapped items with three-point estimates, milestones, and risk tracking.
+  Produces actionable project plans with parallelization flags and realistic timelines
+  calibrated against historical data. Triggers on: "plan this project", "break down
+  the work", "create a project plan", "estimate the timeline", "task breakdown", "what
+  are the milestones", "decompose this into tasks", "how long will this take", "plan
+  the implementation", "scope this work". Use this agent when a structured project
+  plan with task dependencies, estimates, and risk assessment is needed rather than
+  ad-hoc task listing.
+
+  '
 model: sonnet
 color: cyan
 metadata:
   version: 1.0.0
-  category: planning
+  category: development
   execution_phase: on-demand
   priority: 70
   enabled: true
   orchestrates:
     skills: [task-decomposer, estimate-calibrator, plan-review, engineering-retro]
     agents: []
+  tags: [planning, decomposition, estimation, sonnet]
+  difficulty: intermediate
 ---
-
 # Project Planner
 
 Task breakdown and project planning agent that produces dependency-mapped work

--- a/agents/proposal-writer/AGENT.md
+++ b/agents/proposal-writer/AGENT.md
@@ -1,18 +1,18 @@
 ---
 name: proposal-writer
 type: agent
-description: >
-  Technical proposal generation with ROI calculation, three-tier pricing, and
-  business-value framing. Gathers project scope and client context, models
-  return on investment with calibrated estimates, structures a Problem-Agitate-Solve
-  narrative, and produces a complete proposal document with optional PDF export.
-  Triggers on: "write a proposal", "draft a proposal", "create a project proposal",
-  "generate a proposal for", "proposal with pricing tiers", "ROI proposal",
-  "client proposal with estimates", "proposal with cost breakdown",
-  "prepare a bid", "scope and pricing document".
-  Use this agent when a structured client-facing proposal with pricing, ROI
-  modeling, and professional formatting is needed — not for internal planning
+description: 'Technical proposal generation with ROI calculation, three-tier pricing,
+  and business-value framing. Gathers project scope and client context, models return
+  on investment with calibrated estimates, structures a Problem-Agitate-Solve narrative,
+  and produces a complete proposal document with optional PDF export. Triggers on:
+  "write a proposal", "draft a proposal", "create a project proposal", "generate a
+  proposal for", "proposal with pricing tiers", "ROI proposal", "client proposal with
+  estimates", "proposal with cost breakdown", "prepare a bid", "scope and pricing
+  document". Use this agent when a structured client-facing proposal with pricing,
+  ROI modeling, and professional formatting is needed — not for internal planning
   documents or architecture decisions.
+
+  '
 model: opus
 color: orange
 metadata:
@@ -24,8 +24,9 @@ metadata:
   orchestrates:
     skills: [md-to-pdf, estimate-calibrator, architecture-diagram]
     agents: []
+  tags: [proposals, writing, business, opus]
+  difficulty: intermediate
 ---
-
 # Proposal Writer
 
 Technical proposal generation that combines ROI modeling, calibrated estimates,

--- a/agents/release-captain/AGENT.md
+++ b/agents/release-captain/AGENT.md
@@ -1,29 +1,30 @@
 ---
 name: release-captain
 type: agent
-description: >
-  Ship lifecycle manager that drives code from branch to PR through quality
-  gates, secret scanning, changelog generation, and dependency audits. Blocks
-  on failing tests or CRITICAL findings. Produces versioned commits, changelog
-  entries, and opens the pull request with full traceability.
-  Triggers on: "ship this", "create a release", "open a PR", "prepare for
-  release", "cut a release", "ship it", "ready to merge", "open pull request",
-  "release this branch", "time to ship". Use this agent when code is ready to
-  ship and needs quality gates, changelog, and PR creation rather than further
-  development.
+description: 'Ship lifecycle manager that drives code from branch to PR through quality
+  gates, secret scanning, changelog generation, and dependency audits. Blocks on failing
+  tests or CRITICAL findings. Produces versioned commits, changelog entries, and opens
+  the pull request with full traceability. Triggers on: "ship this", "create a release",
+  "open a PR", "prepare for release", "cut a release", "ship it", "ready to merge",
+  "open pull request", "release this branch", "time to ship". Use this agent when
+  code is ready to ship and needs quality gates, changelog, and PR creation rather
+  than further development.
+
+  '
 model: sonnet
 color: yellow
 metadata:
   version: 1.0.0
-  category: release
+  category: operations
   execution_phase: on-demand
   priority: 75
   enabled: true
   orchestrates:
     skills: [ship-workflow, changelog-composer, pre-landing-review, pr-review, dependency-audit]
     agents: [secret-scanner]
+  tags: [release, deployment, ci-cd, sonnet]
+  difficulty: intermediate
 ---
-
 # Release Captain
 
 Ship lifecycle manager that orchestrates quality gates, secret scanning,

--- a/agents/research-analyst/AGENT.md
+++ b/agents/research-analyst/AGENT.md
@@ -1,17 +1,17 @@
 ---
 name: research-analyst
 type: agent
-description: >
-  Deep research agent that conducts multi-source investigation and produces
-  structured synthesis reports. Spawns parallel research agents across web,
-  academic, video, and document sources, cross-references findings, identifies
-  gaps and contradictions, and delivers cited analysis with confidence ratings.
-  Triggers on: "research this topic", "investigate", "deep dive into",
-  "what does the research say about", "survey the landscape", "analyze this
-  space", "comprehensive research on", "gather evidence for", "research
-  report on", "explore the state of", "literature survey", "multi-source
-  analysis". Use this agent when a thorough investigation across multiple
-  source types is needed rather than a quick web search or single-source lookup.
+description: 'Deep research agent that conducts multi-source investigation and produces
+  structured synthesis reports. Spawns parallel research agents across web, academic,
+  video, and document sources, cross-references findings, identifies gaps and contradictions,
+  and delivers cited analysis with confidence ratings. Triggers on: "research this
+  topic", "investigate", "deep dive into", "what does the research say about", "survey
+  the landscape", "analyze this space", "comprehensive research on", "gather evidence
+  for", "research report on", "explore the state of", "literature survey", "multi-source
+  analysis". Use this agent when a thorough investigation across multiple source types
+  is needed rather than a quick web search or single-source lookup.
+
+  '
 model: opus
 color: green
 metadata:
@@ -23,8 +23,9 @@ metadata:
   orchestrates:
     skills: [literature-review, tavily, youtube-analysis, competitive-analyzer, to-markdown]
     agents: []
+  tags: [research, analysis, synthesis, opus]
+  difficulty: advanced
 ---
-
 # Research Analyst
 
 Multi-source research agent that investigates topics across web, academic,

--- a/agents/secret-scanner/AGENT.md
+++ b/agents/secret-scanner/AGENT.md
@@ -1,16 +1,16 @@
 ---
 name: secret-scanner
 type: agent
-description: >
-  Pre-commit secret detection agent scanning for hardcoded API keys, passwords,
-  tokens, connection strings, private keys, and high-entropy strings. Detects
-  known provider key patterns (AWS, GitHub, Slack, Stripe, Google, Azure),
-  .env values leaked into source code, and PEM-encoded private keys. Designed
-  for fast pre-commit gating with zero false-negative tolerance. Triggers on:
-  "scan for secrets", "check for hardcoded keys", "secret detection",
-  "credential scan", "find leaked keys", "check for passwords in code",
-  "pre-commit secret check". Use this agent when code is about to be
-  committed and needs a secrets gate.
+description: 'Pre-commit secret detection agent scanning for hardcoded API keys, passwords,
+  tokens, connection strings, private keys, and high-entropy strings. Detects known
+  provider key patterns (AWS, GitHub, Slack, Stripe, Google, Azure), .env values leaked
+  into source code, and PEM-encoded private keys. Designed for fast pre-commit gating
+  with zero false-negative tolerance. Triggers on: "scan for secrets", "check for
+  hardcoded keys", "secret detection", "credential scan", "find leaked keys", "check
+  for passwords in code", "pre-commit secret check". Use this agent when code is about
+  to be committed and needs a secrets gate.
+
+  '
 model: haiku
 color: red
 metadata:
@@ -19,9 +19,10 @@ metadata:
   execution_phase: pre-commit
   priority: 200
   enabled: true
-  language_targets: ["*"]
+  language_targets: ['*']
+  tags: [secrets, scanning, security, haiku]
+  difficulty: intermediate
 ---
-
 # Secret Scanner
 
 Pre-commit credential detection scanning for hardcoded secrets, known

--- a/agents/security-reviewer/AGENT.md
+++ b/agents/security-reviewer/AGENT.md
@@ -1,15 +1,15 @@
 ---
 name: security-reviewer
 type: agent
-description: >
-  Vulnerability scanner for OWASP Top 10 patterns including SQL injection,
-  cross-site scripting (XSS), broken authentication, insecure deserialization,
-  path traversal, SSRF, and security misconfiguration. Produces severity-ranked
-  findings with exploit scenarios and remediation guidance. Triggers on:
-  "security review", "scan for vulnerabilities", "check security",
-  "audit security", "find security issues", "OWASP scan", "vulnerability check",
-  "security analysis". Use this agent when code needs security-focused review
-  for injection, authentication, or data exposure vulnerabilities.
+description: 'Vulnerability scanner for OWASP Top 10 patterns including SQL injection,
+  cross-site scripting (XSS), broken authentication, insecure deserialization, path
+  traversal, SSRF, and security misconfiguration. Produces severity-ranked findings
+  with exploit scenarios and remediation guidance. Triggers on: "security review",
+  "scan for vulnerabilities", "check security", "audit security", "find security issues",
+  "OWASP scan", "vulnerability check", "security analysis". Use this agent when code
+  needs security-focused review for injection, authentication, or data exposure vulnerabilities.
+
+  '
 model: sonnet
 color: red
 metadata:
@@ -18,9 +18,10 @@ metadata:
   execution_phase: post-write
   priority: 90
   enabled: true
-  language_targets: ["*.py", "*.ts", "*.js", "*.go", "*.java"]
+  language_targets: ['*.py', '*.ts', '*.js', '*.go', '*.java']
+  tags: [security, review, vulnerabilities, sonnet]
+  difficulty: advanced
 ---
-
 # Security Reviewer
 
 OWASP Top 10 vulnerability scanner producing severity-ranked findings with

--- a/agents/team-lead/AGENT.md
+++ b/agents/team-lead/AGENT.md
@@ -1,40 +1,33 @@
 ---
 name: team-lead
 type: agent
-description: >
-  Meta-orchestrator agent that analyzes complex requests, decomposes them into
-  agent-sized tasks, delegates to specialized agents, manages sequencing and
-  parallelism, and synthesizes results into unified deliverables. Acts as the
-  intelligent router and coordinator across the full agent team.
-  Triggers on: "handle this end to end", "take care of everything",
-  "coordinate the team", "manage this project", "orchestrate this work",
-  "delegate this across agents", "team lead", "run the full pipeline",
-  "I need the whole workflow", "end to end", "full lifecycle".
-  Use this agent when a task spans multiple agent domains and needs
-  coordination rather than a single focused agent.
+description: 'Meta-orchestrator agent that analyzes complex requests, decomposes them
+  into agent-sized tasks, delegates to specialized agents, manages sequencing and
+  parallelism, and synthesizes results into unified deliverables. Acts as the intelligent
+  router and coordinator across the full agent team. Triggers on: "handle this end
+  to end", "take care of everything", "coordinate the team", "manage this project",
+  "orchestrate this work", "delegate this across agents", "team lead", "run the full
+  pipeline", "I need the whole workflow", "end to end", "full lifecycle". Use this
+  agent when a task spans multiple agent domains and needs coordination rather than
+  a single focused agent.
+
+  '
 model: opus
 color: gold
 metadata:
   version: 1.0.0
-  category: orchestration
+  category: operations
   execution_phase: on-demand
   priority: 50
   enabled: true
   orchestrates:
     skills: []
-    agents:
-      - project-architect
-      - project-planner
-      - research-analyst
-      - proposal-writer
-      - full-stack-builder
-      - content-strategist
-      - release-captain
-      - codebase-auditor
-      - idea-scout
-      - media-producer
+    agents: [project-architect, project-planner, research-analyst, proposal-writer,
+      full-stack-builder, content-strategist, release-captain, codebase-auditor, idea-scout,
+      media-producer]
+  tags: [orchestration, delegation, multi-agent, opus]
+  difficulty: advanced
 ---
-
 # Team Lead
 
 Meta-orchestrator that decomposes complex, multi-domain requests into

--- a/commands/refactor/COMMAND.md
+++ b/commands/refactor/COMMAND.md
@@ -1,22 +1,25 @@
 ---
 name: refactor
 type: command
-description: >
-  Code simplification workflow that identifies and cleans recently modified files.
-  Uses git diff to find changed files, analyzes cyclomatic complexity, detects
-  duplicated logic, simplifies nested conditionals, extracts helpers only when
-  justified, and verifies behavior preservation through tests. Triggers on:
-  "/refactor", "clean up recent changes", "simplify this code", "reduce
-  complexity", "clean before PR", "tidy up my code". Use this command when code
-  works correctly but needs simplification before committing or merging.
+description: 'Code simplification workflow that identifies and cleans recently modified
+  files. Uses git diff to find changed files, analyzes cyclomatic complexity, detects
+  duplicated logic, simplifies nested conditionals, extracts helpers only when justified,
+  and verifies behavior preservation through tests. Triggers on: "/refactor", "clean
+  up recent changes", "simplify this code", "reduce complexity", "clean before PR",
+  "tidy up my code". Use this command when code works correctly but needs simplification
+  before committing or merging.
+
+  '
 metadata:
   version: 1.0.0
+  category: development
+  tags: [refactoring, code-quality, simplification]
+  difficulty: intermediate
 command:
-  syntax: "/refactor [path]"
+  syntax: /refactor [path]
   handler: inline
   dependencies: []
 ---
-
 # Refactor Clean — Code Simplification Workflow
 
 When the user invokes `/refactor [path]`, execute this workflow exactly.

--- a/commands/security-scan/COMMAND.md
+++ b/commands/security-scan/COMMAND.md
@@ -1,23 +1,25 @@
 ---
 name: security-scan
 type: command
-description: >
-  Security audit workflow that scans a codebase path or scope for vulnerabilities
-  across six categories: hardcoded secrets, input validation, authentication and
-  authorization logic, dependency vulnerabilities, HTTP security headers, and
-  misconfiguration. Produces severity-ranked findings with remediation guidance.
-  Triggers on: "/security-scan", "scan for vulnerabilities", "security audit this
-  code", "check for hardcoded secrets", "find security issues", "vulnerability
-  scan". Use this command when auditing code for security issues before deployment
-  or during review.
+description: 'Security audit workflow that scans a codebase path or scope for vulnerabilities
+  across six categories: hardcoded secrets, input validation, authentication and authorization
+  logic, dependency vulnerabilities, HTTP security headers, and misconfiguration.
+  Produces severity-ranked findings with remediation guidance. Triggers on: "/security-scan",
+  "scan for vulnerabilities", "security audit this code", "check for hardcoded secrets",
+  "find security issues", "vulnerability scan". Use this command when auditing code
+  for security issues before deployment or during review.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [security, scanning, vulnerabilities, audit]
+  difficulty: intermediate
 command:
-  syntax: "/security-scan [path-or-scope]"
+  syntax: /security-scan [path-or-scope]
   handler: inline
   dependencies: []
 ---
-
 # Security Scan — Vulnerability Audit Workflow
 
 When the user invokes `/security-scan [path-or-scope]`, execute this workflow exactly.

--- a/commands/tdd/COMMAND.md
+++ b/commands/tdd/COMMAND.md
@@ -1,23 +1,25 @@
 ---
 name: tdd
 type: command
-description: >
-  Test-driven development workflow for functions, modules, or features. Guides
-  Claude through the red-green-refactor cycle: understand requirements, write a
-  failing test first, implement minimal code to pass, refactor, repeat. Enforces
-  test-first discipline with rules for naming, assertion specificity, edge case
-  generation, and cycle termination. Triggers on: "/tdd", "test-driven", "write
-  tests first", "red green refactor", "TDD workflow", "test first development".
-  Use this command when starting implementation work where tests should drive
-  the design.
+description: 'Test-driven development workflow for functions, modules, or features.
+  Guides Claude through the red-green-refactor cycle: understand requirements, write
+  a failing test first, implement minimal code to pass, refactor, repeat. Enforces
+  test-first discipline with rules for naming, assertion specificity, edge case generation,
+  and cycle termination. Triggers on: "/tdd", "test-driven", "write tests first",
+  "red green refactor", "TDD workflow", "test first development". Use this command
+  when starting implementation work where tests should drive the design.
+
+  '
 metadata:
   version: 1.0.0
+  category: development
+  tags: [tdd, testing, red-green-refactor, test-first]
+  difficulty: intermediate
 command:
-  syntax: "/tdd [function-or-module]"
+  syntax: /tdd [function-or-module]
   handler: inline
   dependencies: []
 ---
-
 # TDD — Test-Driven Development Workflow
 
 When the user invokes `/tdd [target]`, execute this workflow exactly.

--- a/hooks/cost-tracker/HOOK.md
+++ b/hooks/cost-tracker/HOOK.md
@@ -1,24 +1,23 @@
 ---
 name: cost-tracker
 type: hook
-description: >
-  Logs session cost and token usage to a CSV file after each Claude Code session
-  completes. Fires on the Stop event, reads cost and token data from the session
+description: 'Logs session cost and token usage to a CSV file after each Claude Code
+  session completes. Fires on the Stop event, reads cost and token data from the session
   summary JSON on stdin, and appends a row to ~/.claude/cost-log.csv. Use this hook
-  when you want to track API spending over time, identify expensive sessions, or
-  generate usage reports from the CSV data.
+  when you want to track API spending over time, identify expensive sessions, or generate
+  usage reports from the CSV data.
+
+  '
 metadata:
   version: 1.0.0
+  category: operations
+  tags: [cost, tokens, usage, logging]
+  difficulty: beginner
 hook:
-  events:
-    - Stop
-  matcher: ""
-  handler:
-    type: command
-    command: "bash handler.sh"
-    timeout_ms: 5000
+  events: [Stop]
+  matcher: ''
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
 ---
-
 # cost-tracker
 
 Records session cost and token usage to a local CSV file.

--- a/hooks/git-protection/HOOK.md
+++ b/hooks/git-protection/HOOK.md
@@ -1,25 +1,24 @@
 ---
 name: git-protection
 type: hook
-description: >
-  Blocks dangerous git operations that can cause irreversible data loss. Intercepts
-  Bash tool invocations before execution and inspects the command string for destructive
-  patterns: force-push (push --force / push -f), hard reset (reset --hard), deletion of
-  main/master branches (branch -D main/master), and aggressive clean (clean -fd). Use
-  this hook when working in repositories where accidental destructive git commands could
-  wipe uncommitted work or rewrite shared history.
+description: 'Blocks dangerous git operations that can cause irreversible data loss.
+  Intercepts Bash tool invocations before execution and inspects the command string
+  for destructive patterns: force-push (push --force / push -f), hard reset (reset
+  --hard), deletion of main/master branches (branch -D main/master), and aggressive
+  clean (clean -fd). Use this hook when working in repositories where accidental destructive
+  git commands could wipe uncommitted work or rewrite shared history.
+
+  '
 metadata:
   version: 1.0.0
+  category: operations
+  tags: [git, branch-protection, safety, hooks]
+  difficulty: beginner
 hook:
-  events:
-    - PreToolUse
-  matcher: "Bash"
-  handler:
-    type: command
-    command: "bash handler.sh"
-    timeout_ms: 5000
+  events: [PreToolUse]
+  matcher: Bash
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
 ---
-
 # git-protection
 
 Prevents destructive git operations from executing through Claude Code.

--- a/hooks/pre-edit-backup/HOOK.md
+++ b/hooks/pre-edit-backup/HOOK.md
@@ -1,24 +1,24 @@
 ---
 name: pre-edit-backup
 type: hook
-description: >
-  Creates a backup copy of any file before Claude Code edits it. Fires on PreToolUse
-  for the Edit tool, reads the file_path from the tool input JSON, and copies the
-  original file to ~/.claude/backups/ with a timestamped filename. Maintains a maximum
-  of 20 backup files by deleting the oldest when the limit is exceeded. Use this hook
-  when you want a local safety net for file edits that goes beyond git history.
+description: 'Creates a backup copy of any file before Claude Code edits it. Fires
+  on PreToolUse for the Edit tool, reads the file_path from the tool input JSON, and
+  copies the original file to ~/.claude/backups/ with a timestamped filename. Maintains
+  a maximum of 20 backup files by deleting the oldest when the limit is exceeded.
+  Use this hook when you want a local safety net for file edits that goes beyond git
+  history.
+
+  '
 metadata:
   version: 1.0.0
+  category: operations
+  tags: [backup, files, safety, pre-edit]
+  difficulty: beginner
 hook:
-  events:
-    - PreToolUse
-  matcher: "Edit"
-  handler:
-    type: command
-    command: "bash handler.sh"
-    timeout_ms: 5000
+  events: [PreToolUse]
+  matcher: Edit
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
 ---
-
 # pre-edit-backup
 
 Automatically backs up files before they are modified by the Edit tool.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,6 +10,13 @@ packages:
       "design decision", "technical decision". Use this skill when an architectural or technical decision needs to be documented.'
     path: skills/adr-writer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/adr-writer/SKILL.md
+    tags:
+    - architecture
+    - decision-record
+    - documentation
+    - adr
+    category: operations
+    difficulty: intermediate
   - name: agent-builder
     version: 1.1.0
     description: Build AI agents and automate Claude Code programmatically using the Claude Agent SDK and headless CLI mode.
@@ -20,6 +27,13 @@ packages:
       config — no API keys required.
     path: skills/agent-builder
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/agent-builder/SKILL.md
+    tags:
+    - agent-sdk
+    - headless
+    - automation
+    - mcp
+    category: development
+    difficulty: intermediate
   - name: api-docs-generator
     version: 1.1.0
     description: 'Audits and enhances API documentation for FastAPI and REST endpoints. Identifies missing descriptions, incomplete
@@ -29,6 +43,13 @@ packages:
       documentation", "response documentation". Use this skill when API endpoints need documentation or documentation audit.'
     path: skills/api-docs-generator
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/api-docs-generator/SKILL.md
+    tags:
+    - api
+    - documentation
+    - openapi
+    - fastapi
+    category: review
+    difficulty: intermediate
   - name: architecture-diagram
     version: 1.1.0
     description: 'Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons,
@@ -39,6 +60,13 @@ packages:
       instead.'
     path: skills/architecture-diagram
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/architecture-diagram/SKILL.md
+    tags:
+    - architecture
+    - diagram
+    - visualization
+    - svg
+    category: review
+    difficulty: intermediate
   - name: architecture-reviewer
     version: 1.1.0
     description: 'Architecture reviews across 7 dimensions: structural integrity, scalability, enterprise readiness (SOC2/HIPAA/GDPR/PCI-DSS),
@@ -51,6 +79,13 @@ packages:
       use architecture-diagram instead.'
     path: skills/architecture-reviewer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/architecture-reviewer/SKILL.md
+    tags:
+    - architecture
+    - scalability
+    - enterprise
+    - security-audit
+    category: review
+    difficulty: advanced
   - name: benchmark-runner
     version: 1.1.0
     description: 'Designs structured benchmarks for comparing algorithms, models, or implementations. Selects appropriate
@@ -61,6 +96,13 @@ packages:
       skill when comparing two or more implementations, algorithms, or models.'
     path: skills/benchmark-runner
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/benchmark-runner/SKILL.md
+    tags:
+    - benchmarking
+    - performance
+    - comparison
+    - metrics
+    category: data
+    difficulty: intermediate
   - name: changelog-composer
     version: 1.1.0
     description: 'Generates structured changelogs and release notes from git history and PR descriptions. Classifies changes
@@ -71,6 +113,13 @@ packages:
       users.'
     path: skills/changelog-composer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/changelog-composer/SKILL.md
+    tags:
+    - changelog
+    - release-notes
+    - git-history
+    - versioning
+    category: content
+    difficulty: intermediate
   - name: code-refiner
     version: 1.1.0
     description: 'Deep code simplification, refactoring, and quality refinement. Analyzes structural complexity, anti-patterns,
@@ -82,6 +131,13 @@ packages:
       code smells.'
     path: skills/code-refiner
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/code-refiner/SKILL.md
+    tags:
+    - refactoring
+    - code-quality
+    - simplification
+    - readability
+    category: review
+    difficulty: intermediate
   - name: competitive-analyzer
     version: 1.0.0
     description: 'Systematic competitive landscape analysis covering Porter''s Five Forces, competitor discovery, feature
@@ -99,6 +155,13 @@ packages:
     - tavily
     - web-fetch
     - idea-validator
+    tags:
+    - competitive-analysis
+    - market
+    - porters-five-forces
+    - positioning
+    category: business
+    difficulty: advanced
   - name: concept-to-image
     version: 1.2.0
     description: 'Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG
@@ -111,6 +174,13 @@ packages:
       use static-web-artifacts-builder instead.'
     path: skills/concept-to-image
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/concept-to-image/SKILL.md
+    tags:
+    - image-generation
+    - html-to-png
+    - svg
+    - visual-design
+    category: business
+    difficulty: intermediate
   - name: concept-to-video
     version: 1.1.0
     description: 'Turn any concept into an animated explainer video using Manim (Python). Use whenever the user wants animated
@@ -123,6 +193,13 @@ packages:
       For branded motion graphics or React-based video, use remotion-video instead.'
     path: skills/concept-to-video
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/concept-to-video/SKILL.md
+    tags:
+    - video
+    - manim
+    - animation
+    - explainer
+    category: visualization
+    difficulty: advanced
   - name: debug-investigator
     version: 1.1.0
     description: 'Hypothesis-driven debugging methodology: ranked hypotheses with confirming/refuting tests, git bisect strategy,
@@ -134,6 +211,13 @@ packages:
       reasoning or problem decomposition without a specific error — the model handles general reasoning natively.'
     path: skills/debug-investigator
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/debug-investigator/SKILL.md
+    tags:
+    - debugging
+    - root-cause
+    - hypothesis
+    - bisect
+    category: development
+    difficulty: intermediate
   - name: dependency-audit
     version: 1.1.0
     description: 'Audits project dependencies for license compliance, maintenance health, security vulnerabilities, and bloat.
@@ -144,12 +228,26 @@ packages:
       Use this skill when reviewing project dependencies for risk.'
     path: skills/dependency-audit
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/dependency-audit/SKILL.md
+    tags:
+    - dependencies
+    - vulnerabilities
+    - licenses
+    - supply-chain
+    category: review
+    difficulty: intermediate
   - name: doc-condenser
     version: 1.1.0
     description: 'DEPRECATED: The base model handles document condensation and summarization natively at high quality. This
       skill no longer provides meaningful uplift. Retained for reference only.'
     path: skills/doc-condenser
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/doc-condenser/SKILL.md
+    tags:
+    - documentation
+    - summarization
+    - technical-writing
+    - conciseness
+    category: review
+    difficulty: beginner
   - name: engineering-retro
     version: 1.0.0
     description: Git-based engineering retrospective analyzing commit history, PR patterns, and development velocity over
@@ -159,6 +257,13 @@ packages:
       24h, 14d, 30d) and monorepo path scoping.
     path: skills/engineering-retro
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/engineering-retro/SKILL.md
+    tags:
+    - retrospective
+    - velocity
+    - git-analysis
+    - sprint
+    category: review
+    difficulty: intermediate
   - name: estimate-calibrator
     version: 1.1.0
     description: 'Produces calibrated three-point estimates (best/likely/worst case) with explicit unknowns, confidence intervals,
@@ -170,6 +275,13 @@ packages:
       uncertainty.'
     path: skills/estimate-calibrator
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/estimate-calibrator/SKILL.md
+    tags:
+    - estimation
+    - pert
+    - confidence-interval
+    - planning
+    category: development
+    difficulty: intermediate
   - name: feasibility-assessor
     version: 1.0.0
     description: 'Evaluate whether a business idea, product concept, or feature is technically buildable and financially viable.
@@ -180,6 +292,13 @@ packages:
       whether a business idea, feature, or product is worth pursuing from financial and technical perspectives.'
     path: skills/feasibility-assessor
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/feasibility-assessor/SKILL.md
+    tags:
+    - feasibility
+    - unit-economics
+    - viability
+    - business-case
+    category: review
+    difficulty: advanced
     complements:
     - idea-validator
   - name: filesystem
@@ -193,6 +312,13 @@ packages:
       codebases, or managing directories.'
     path: skills/filesystem
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/filesystem/SKILL.md
+    tags:
+    - files
+    - directories
+    - search
+    - navigation
+    category: content
+    difficulty: beginner
   - name: github
     version: 1.1.0
     description: 'GitHub CLI operations via `gh` for issues, pull requests, CI/Actions, releases, repos, search, gists, and
@@ -205,6 +331,13 @@ packages:
       GitHub operations". Also triggers when the user pastes a GitHub URL.'
     path: skills/github
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/github/SKILL.md
+    tags:
+    - github
+    - cli
+    - issues
+    - pull-requests
+    category: review
+    difficulty: intermediate
   - name: gpu-optimizer
     version: 1.1.0
     description: Expert GPU optimization for modern consumer GPUs (8-24GB VRAM). Use this skill when you need to optimize
@@ -214,6 +347,13 @@ packages:
       and RAPIDS frameworks.
     path: skills/gpu-optimizer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/gpu-optimizer/SKILL.md
+    tags:
+    - gpu
+    - cuda
+    - vram
+    - pytorch
+    category: data
+    difficulty: advanced
   - name: html-presentation
     version: 1.1.0
     description: Convert any document, outline, or content into a polished, self-contained HTML slide presentation. Use this
@@ -226,6 +366,13 @@ packages:
       content structure if not already specified.
     path: skills/html-presentation
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/html-presentation/SKILL.md
+    tags:
+    - slides
+    - presentation
+    - reveal-js
+    - html
+    category: visualization
+    difficulty: intermediate
   - name: humanize
     version: 1.0.0
     description: Detect and remove AI-generated writing patterns from text while preserving semantic meaning and factual accuracy.
@@ -236,6 +383,13 @@ packages:
       AI tells, checking if text sounds AI-generated, or requesting a "human pass" on content.
     path: skills/humanize
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/humanize/SKILL.md
+    tags:
+    - writing
+    - ai-detection
+    - natural-language
+    - rewriting
+    category: review
+    difficulty: intermediate
   - name: idea-validator
     version: 1.0.0
     description: 'Comprehensive business idea validation orchestrator that delegates parallel research to sub-agents and synthesizes
@@ -253,6 +407,13 @@ packages:
     - market-analyzer
     - competitive-analyzer
     - feasibility-assessor
+    tags:
+    - idea-validation
+    - lean-canvas
+    - jtbd
+    - swot
+    category: review
+    difficulty: advanced
   - name: immune
     version: 1.0.0
     description: 'Hybrid adaptive memory system with two complementary memories: Cheatsheet (positive patterns injected before
@@ -263,6 +424,13 @@ packages:
       code review or PR review — use pr-review instead. NOT for security audits of repositories — use repo-sentinel instead.'
     path: skills/immune
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/immune/SKILL.md
+    tags:
+    - memory
+    - error-detection
+    - antibodies
+    - adaptive
+    category: review
+    difficulty: intermediate
   - name: lightpanda-browser
     version: 1.0.0
     description: Lightweight headless browser automation using Lightpanda as the backend engine with agent-browser CLI. 9x
@@ -273,6 +441,13 @@ packages:
       speed and resource efficiency matter more than visual fidelity.
     path: skills/lightpanda-browser
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/lightpanda-browser/SKILL.md
+    tags:
+    - browser
+    - headless
+    - scraping
+    - lightweight
+    category: visualization
+    difficulty: beginner
   - name: linkedin-post-style
     version: 1.2.1
     description: Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored, and
@@ -284,6 +459,13 @@ packages:
       Mermaid diagrams), custom images (via concept-to-image), or animations (via concept-to-video).
     path: skills/linkedin-post-style
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/linkedin-post-style/SKILL.md
+    tags:
+    - linkedin
+    - social-media
+    - writing
+    - content
+    category: review
+    difficulty: intermediate
   - name: literature-review
     version: 1.0.0
     description: 'Systematic literature review workflow for surveying, synthesizing, and analyzing academic research. Covers
@@ -299,6 +481,13 @@ packages:
     - research-critique
     - manuscript-review
     - manuscript-provenance
+    tags:
+    - academic
+    - literature
+    - synthesis
+    - citations
+    category: review
+    difficulty: intermediate
   - name: manuscript-provenance
     version: 1.1.0
     description: 'Computational provenance audit verifying that every number, table, figure, ordering, and terminology in
@@ -310,6 +499,13 @@ packages:
       outputs.'
     path: skills/manuscript-provenance
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-provenance/SKILL.md
+    tags:
+    - provenance
+    - reproducibility
+    - computational
+    - verification
+    category: review
+    difficulty: advanced
     complements:
     - literature-review
   - name: manuscript-review
@@ -324,6 +520,13 @@ packages:
       was asked about.
     path: skills/manuscript-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/manuscript-review/SKILL.md
+    tags:
+    - manuscript
+    - pre-publication
+    - citation-hygiene
+    - submission
+    category: review
+    difficulty: advanced
     complements:
     - literature-review
   - name: market-analyzer
@@ -338,6 +541,13 @@ packages:
       with sourced data.'
     path: skills/market-analyzer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/market-analyzer/SKILL.md
+    tags:
+    - market-sizing
+    - tam-sam-som
+    - trends
+    - industry
+    category: research
+    difficulty: intermediate
     complements:
     - competitive-analyzer
     - idea-validator
@@ -352,6 +562,13 @@ packages:
       too big or running out of context when MCPs are active.'
     path: skills/mcp-to-skill
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/mcp-to-skill/SKILL.md
+    tags:
+    - mcp
+    - skill-conversion
+    - context-optimization
+    - token-reduction
+    category: data
+    difficulty: intermediate
   - name: md-to-pdf
     version: 1.2.0
     description: 'Convert Markdown files to professionally styled PDF documents with full support for Mermaid diagrams, LaTeX/KaTeX
@@ -363,6 +580,13 @@ packages:
       PDF", "can you make a PDF from this markdown".'
     path: skills/md-to-pdf
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/md-to-pdf/SKILL.md
+    tags:
+    - pdf
+    - markdown
+    - mermaid
+    - latex
+    category: visualization
+    difficulty: intermediate
   - name: migration-risk-analyzer
     version: 1.1.0
     description: 'Analyzes database migration scripts for risk: lock contention, downtime estimation, rollback strategy, and
@@ -373,6 +597,13 @@ packages:
       before deployment.'
     path: skills/migration-risk-analyzer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/migration-risk-analyzer/SKILL.md
+    tags:
+    - database
+    - migration
+    - ddl
+    - rollback
+    category: review
+    difficulty: advanced
   - name: notebooklm
     version: 1.1.0
     description: 'Complete API for Google NotebookLM — full programmatic access including features not in the web UI. Create
@@ -386,6 +617,13 @@ packages:
       uses /notebooklm.'
     path: skills/notebooklm
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/notebooklm/SKILL.md
+    tags:
+    - notebooklm
+    - podcast
+    - flashcards
+    - source-analysis
+    category: research
+    difficulty: intermediate
   - name: package-evaluator
     version: 1.3.0
     description: 'Evaluate Claude Code package quality across 6 weighted dimensions: frontmatter quality, trigger coverage,
@@ -397,6 +635,13 @@ packages:
       failures. NOT for LLM prompts (use prompt-lab) or PRs (use pr-review).'
     path: skills/package-evaluator
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/package-evaluator/SKILL.md
+    tags:
+    - quality
+    - audit
+    - scoring
+    - frontmatter
+    category: review
+    difficulty: intermediate
   - name: plan-review
     version: 1.0.0
     description: Pre-implementation plan audit that stress-tests scope, assumptions, risks, and failure modes before code
@@ -406,6 +651,13 @@ packages:
       review.
     path: skills/plan-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/plan-review/SKILL.md
+    tags:
+    - plan-audit
+    - scope
+    - risk-assessment
+    - assumptions
+    category: review
+    difficulty: intermediate
   - name: pr-review
     version: 1.1.0
     description: 'Pull request and code review with diff-based routing across five dimensions: code quality and guideline
@@ -417,6 +669,13 @@ packages:
       when reviewing code before commit or merge, checking PR quality, or when the user asks for feedback on recent modifications.'
     path: skills/pr-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/pr-review/SKILL.md
+    tags:
+    - code-review
+    - pull-request
+    - quality
+    - diff-analysis
+    category: review
+    difficulty: intermediate
   - name: pre-landing-review
     version: 1.0.0
     description: Gate-oriented safety audit for code changes before landing, using a structured checklist with two-pass severity
@@ -425,6 +684,13 @@ packages:
       "is this safe to land", "pre-landing review", "safety check before merge", "run the checklist", "gate check", "/pre-landing-review".
     path: skills/pre-landing-review
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/pre-landing-review/SKILL.md
+    tags:
+    - pre-merge
+    - safety-gate
+    - code-review
+    - checklist
+    category: review
+    difficulty: intermediate
   - name: prompt-lab
     version: 1.1.0
     description: 'Systematic LLM prompt engineering: analyzes existing prompts for failure modes, generates structured variants
@@ -436,6 +702,13 @@ packages:
       instead.'
     path: skills/prompt-lab
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/prompt-lab/SKILL.md
+    tags:
+    - prompt-engineering
+    - evaluation
+    - few-shot
+    - chain-of-thought
+    category: development
+    difficulty: intermediate
   - name: qa-systematic
     version: 1.0.0
     description: Systematic web application QA testing with structured issue taxonomy, health scoring, and regression tracking.
@@ -444,6 +717,13 @@ packages:
       test", "full QA", "/qa-systematic". Supports full, quick, and regression modes.
     path: skills/qa-systematic
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/qa-systematic/SKILL.md
+    tags:
+    - qa
+    - testing
+    - browser
+    - regression
+    category: development
+    difficulty: advanced
   - name: rag-auditor
     version: 1.1.0
     description: 'Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across retrieval and generation stages.
@@ -455,12 +735,26 @@ packages:
       instead.'
     path: skills/rag-auditor
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/rag-auditor/SKILL.md
+    tags:
+    - rag
+    - retrieval
+    - hallucination
+    - grounding
+    category: review
+    difficulty: advanced
   - name: regex-builder
     version: 1.1.0
     description: 'DEPRECATED: The base model generates, explains, and tests regex patterns natively with high accuracy. This
       skill no longer provides meaningful uplift. Retained for reference only.'
     path: skills/regex-builder
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/regex-builder/SKILL.md
+    tags:
+    - regex
+    - pattern-matching
+    - testing
+    - validation
+    category: development
+    difficulty: beginner
   - name: remotion-video
     version: 1.1.0
     description: 'Create production-grade motion graphics and videos using Remotion (React). Use whenever the user wants branded
@@ -473,6 +767,13 @@ packages:
       rendering, use concept-to-video (Manim) instead.'
     path: skills/remotion-video
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/remotion-video/SKILL.md
+    tags:
+    - video
+    - react
+    - remotion
+    - motion-graphics
+    category: business
+    difficulty: advanced
   - name: repo-sentinel
     version: 1.1.0
     description: 'Full security audit and enforcement for public repositories across 12 attack surfaces: git history, source
@@ -486,6 +787,13 @@ packages:
       between internal and public.'
     path: skills/repo-sentinel
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/repo-sentinel/SKILL.md
+    tags:
+    - security
+    - public-repo
+    - secret-scanning
+    - audit
+    category: review
+    difficulty: advanced
   - name: research-critique
     version: 1.0.0
     description: 'Critical analysis of research papers, academic manuscripts, preprints, and technical studies — evaluating
@@ -498,6 +806,13 @@ packages:
       or contribution — not formatting, citation hygiene, or submission readiness (use manuscript-review for those).'
     path: skills/research-critique
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/research-critique/SKILL.md
+    tags:
+    - research
+    - methodology
+    - claims-evidence
+    - peer-review
+    category: review
+    difficulty: intermediate
     complements:
     - literature-review
   - name: sequential-thinking
@@ -506,6 +821,13 @@ packages:
       sequential chain-of-thought reasoning that replaced the Sequential Thinking MCP server.'
     path: skills/sequential-thinking
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/sequential-thinking/SKILL.md
+    tags:
+    - reasoning
+    - chain-of-thought
+    - analysis
+    - problem-solving
+    category: development
+    difficulty: intermediate
   - name: ship-workflow
     version: 1.0.0
     description: Automated release pipeline that merges main, runs tests, performs pre-landing review, bumps version, updates
@@ -514,16 +836,32 @@ packages:
       release", "/ship-workflow". Handles the full lifecycle from pre-flight checks through PR creation.
     path: skills/ship-workflow
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/ship-workflow/SKILL.md
+    tags:
+    - release
+    - ci-cd
+    - pull-request
+    - changelog
+    category: review
+    difficulty: intermediate
   - name: skill-library
-    version: 1.0.0
-    description: 'Agent-native catalog and installer for armory skills. Browse, search, install, update, sync, and remove
-      skills from the armory collection without leaving your agent session. Triggers on: "list available skills", "install
-      skill", "pull skill", "what skills are available", "update my skills", "search skills for", "skill catalog", "armory
-      list", "armory install", "armory search", "remove skill", "uninstall skill", "/library list", "/library use", "/library
-      remove", "show me armory skills", "get the architecture-reviewer skill", "do I have the latest skills". Use this skill
-      when the user wants to discover, install, update, or remove armory skills from within an agent session.'
+    version: 2.0.0
+    description: 'Agent-native catalog and installer for armory packages across all 7 types: skills, agents, hooks, rules,
+      commands, utilities, and presets. Browse, search, install, update, sync, and remove packages without leaving your agent
+      session. Supports type filtering and profile-based bundles. Triggers on: "list available packages", "install skill",
+      "install agent", "pull skill", "what packages are available", "update my skills", "search packages for", "package catalog",
+      "armory list", "armory install", "armory search", "remove skill", "/library list", "/library use", "/library remove",
+      "/library profiles", "show me armory packages". Use this skill when discovering, installing, updating, or removing armory
+      packages within a session.'
     path: skills/skill-library
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/skill-library/SKILL.md
+    tags:
+    - armory
+    - catalog
+    - install
+    - package-management
+    - discovery
+    category: operations
+    difficulty: beginner
   - name: sql-optimizer
     version: 1.1.0
     description: 'Analyzes SQL queries for performance issues: missing indexes, N+1 patterns, suboptimal joins, full table
@@ -533,6 +871,13 @@ packages:
       "index strategy". Use this skill when given a SQL query that needs performance analysis or optimization.'
     path: skills/sql-optimizer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/sql-optimizer/SKILL.md
+    tags:
+    - sql
+    - performance
+    - database
+    - optimization
+    category: data
+    difficulty: intermediate
   - name: static-web-artifacts-builder
     version: 1.1.0
     description: 'Build elaborate, self-contained static HTML artifacts opened in a browser — interactive diagrams, architecture
@@ -543,6 +888,13 @@ packages:
       use concept-to-image instead.'
     path: skills/static-web-artifacts-builder
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/static-web-artifacts-builder/SKILL.md
+    tags:
+    - html
+    - interactive
+    - dashboard
+    - svg
+    category: visualization
+    difficulty: intermediate
   - name: task-decomposer
     version: 1.1.0
     description: 'Produces structured phased task boards from feature requests: dependency-mapped work items with parallelization
@@ -553,6 +905,13 @@ packages:
       estimates, PERT calculations, or confidence intervals — use estimate-calibrator instead.'
     path: skills/task-decomposer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/task-decomposer/SKILL.md
+    tags:
+    - task-breakdown
+    - dependencies
+    - planning
+    - phased
+    category: development
+    difficulty: intermediate
   - name: tavily
     version: 1.1.0
     description: 'AI-optimized web search via Tavily API. Use this skill when no specific URL is provided and the user needs
@@ -562,6 +921,13 @@ packages:
       for that. Tavily returns clean, AI-ready snippets optimized for search-first intent.'
     path: skills/tavily
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/tavily/SKILL.md
+    tags:
+    - web-search
+    - research
+    - real-time
+    - ai-optimized
+    category: research
+    difficulty: beginner
     complements:
     - competitive-analyzer
   - name: test-harness
@@ -574,6 +940,13 @@ packages:
       asked to produce tests.'
     path: skills/test-harness
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/test-harness/SKILL.md
+    tags:
+    - testing
+    - pytest
+    - test-generation
+    - python
+    category: development
+    difficulty: intermediate
   - name: to-markdown
     version: 1.0.0
     description: 'Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX), Excel (XLSX), PowerPoint (PPTX), HTML,
@@ -585,6 +958,13 @@ packages:
       "read this PDF", "get contents of", "parse this document", "ingest for RAG".'
     path: skills/to-markdown
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/to-markdown/SKILL.md
+    tags:
+    - conversion
+    - markdown
+    - document-ingestion
+    - pdf
+    category: visualization
+    difficulty: beginner
   - name: web-fetch
     version: 1.1.0
     description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch MCP server (fetch_html,
@@ -596,6 +976,13 @@ packages:
       text". NOT for web searches without a URL — use tavily for that.'
     path: skills/web-fetch
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/web-fetch/SKILL.md
+    tags:
+    - http
+    - curl
+    - api
+    - web-content
+    category: content
+    difficulty: beginner
     complements:
     - competitive-analyzer
   - name: youtube-analysis
@@ -609,6 +996,12 @@ packages:
       or youtu.be.'
     path: skills/youtube-analysis
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/youtube-analysis/SKILL.md
+    tags:
+    - youtube
+    - analysis
+    - skill
+    category: visualization
+    difficulty: intermediate
   - name: youtube-search
     version: 1.1.0
     description: 'Search YouTube by keyword and return structured video metadata (title, URL, channel, views, duration, upload
@@ -619,6 +1012,12 @@ packages:
       trending, popular videos about, latest videos on, youtube discovery, or uses /yt-search.'
     path: skills/youtube-search
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/youtube-search/SKILL.md
+    tags:
+    - youtube
+    - search
+    - skill
+    category: research
+    difficulty: beginner
   agents:
   - name: code-reviewer
     version: 1.0.0
@@ -630,6 +1029,13 @@ packages:
     path: agents/code-reviewer
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/code-reviewer/AGENT.md
     model: sonnet
+    tags:
+    - code-review
+    - quality
+    - severity-ranking
+    - sonnet
+    category: review
+    difficulty: intermediate
   - name: codebase-auditor
     version: 1.0.0
     description: 'Unified multi-dimensional codebase quality assessment that spawns specialized review agents in parallel
@@ -641,6 +1047,13 @@ packages:
     path: agents/codebase-auditor
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/codebase-auditor/AGENT.md
     model: sonnet
+    tags:
+    - audit
+    - codebase
+    - quality
+    - sonnet
+    category: review
+    difficulty: intermediate
   - name: content-strategist
     version: 1.0.0
     description: 'Technical content creation and adaptation engine that transforms topics, research, and source material into
@@ -653,6 +1066,13 @@ packages:
     path: agents/content-strategist
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/content-strategist/AGENT.md
     model: sonnet
+    tags:
+    - content
+    - strategy
+    - planning
+    - sonnet
+    category: content
+    difficulty: intermediate
   - name: full-stack-builder
     version: 1.0.0
     description: 'End-to-end implementation agent that takes an architecture document or feature spec and delivers production-ready
@@ -664,6 +1084,13 @@ packages:
     path: agents/full-stack-builder
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/full-stack-builder/AGENT.md
     model: opus
+    tags:
+    - full-stack
+    - implementation
+    - development
+    - opus
+    category: development
+    difficulty: intermediate
   - name: idea-scout
     version: 1.0.0
     description: 'Business idea validation pipeline that orchestrates parallel market research, competitive analysis, and
@@ -676,6 +1103,13 @@ packages:
     path: agents/idea-scout
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/idea-scout/AGENT.md
     model: opus
+    tags:
+    - ideas
+    - research
+    - validation
+    - opus
+    category: research
+    difficulty: intermediate
   - name: media-producer
     version: 1.0.0
     description: 'Visual and video asset creation with intelligent format routing. Analyzes concepts and automatically selects
@@ -688,6 +1122,13 @@ packages:
     path: agents/media-producer
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/media-producer/AGENT.md
     model: sonnet
+    tags:
+    - media
+    - production
+    - content
+    - sonnet
+    category: content
+    difficulty: intermediate
   - name: project-architect
     version: 1.0.0
     description: 'System architecture agent that conducts phased requirements discovery and produces production-ready architecture
@@ -700,6 +1141,13 @@ packages:
     path: agents/project-architect
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/project-architect/AGENT.md
     model: opus
+    tags:
+    - architecture
+    - design
+    - planning
+    - opus
+    category: review
+    difficulty: advanced
   - name: project-planner
     version: 1.0.0
     description: 'Task breakdown and project planning agent that decomposes work into dependency-mapped items with three-point
@@ -711,6 +1159,13 @@ packages:
     path: agents/project-planner
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/project-planner/AGENT.md
     model: sonnet
+    tags:
+    - planning
+    - decomposition
+    - estimation
+    - sonnet
+    category: development
+    difficulty: intermediate
   - name: proposal-writer
     version: 1.0.0
     description: 'Technical proposal generation with ROI calculation, three-tier pricing, and business-value framing. Gathers
@@ -723,6 +1178,13 @@ packages:
     path: agents/proposal-writer
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/proposal-writer/AGENT.md
     model: opus
+    tags:
+    - proposals
+    - writing
+    - business
+    - opus
+    category: content
+    difficulty: intermediate
   - name: release-captain
     version: 1.0.0
     description: 'Ship lifecycle manager that drives code from branch to PR through quality gates, secret scanning, changelog
@@ -734,6 +1196,13 @@ packages:
     path: agents/release-captain
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/release-captain/AGENT.md
     model: sonnet
+    tags:
+    - release
+    - deployment
+    - ci-cd
+    - sonnet
+    category: operations
+    difficulty: intermediate
   - name: research-analyst
     version: 1.0.0
     description: 'Deep research agent that conducts multi-source investigation and produces structured synthesis reports.
@@ -746,6 +1215,13 @@ packages:
     path: agents/research-analyst
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/research-analyst/AGENT.md
     model: opus
+    tags:
+    - research
+    - analysis
+    - synthesis
+    - opus
+    category: research
+    difficulty: advanced
   - name: secret-scanner
     version: 1.0.0
     description: 'Pre-commit secret detection agent scanning for hardcoded API keys, passwords, tokens, connection strings,
@@ -757,6 +1233,13 @@ packages:
     path: agents/secret-scanner
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/secret-scanner/AGENT.md
     model: haiku
+    tags:
+    - secrets
+    - scanning
+    - security
+    - haiku
+    category: security
+    difficulty: intermediate
   - name: security-reviewer
     version: 1.0.0
     description: 'Vulnerability scanner for OWASP Top 10 patterns including SQL injection, cross-site scripting (XSS), broken
@@ -767,6 +1250,13 @@ packages:
     path: agents/security-reviewer
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/security-reviewer/AGENT.md
     model: sonnet
+    tags:
+    - security
+    - review
+    - vulnerabilities
+    - sonnet
+    category: security
+    difficulty: advanced
   - name: team-lead
     version: 1.0.0
     description: 'Meta-orchestrator agent that analyzes complex requests, decomposes them into agent-sized tasks, delegates
@@ -778,6 +1268,13 @@ packages:
     path: agents/team-lead
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/team-lead/AGENT.md
     model: opus
+    tags:
+    - orchestration
+    - delegation
+    - multi-agent
+    - opus
+    category: operations
+    difficulty: advanced
   hooks:
   - name: cost-tracker
     version: 1.0.0
@@ -789,6 +1286,13 @@ packages:
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/cost-tracker/HOOK.md
     events:
     - Stop
+    tags:
+    - cost
+    - tokens
+    - usage
+    - logging
+    category: operations
+    difficulty: beginner
   - name: git-protection
     version: 1.0.0
     description: 'Blocks dangerous git operations that can cause irreversible data loss. Intercepts Bash tool invocations
@@ -800,6 +1304,13 @@ packages:
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/git-protection/HOOK.md
     events:
     - PreToolUse
+    tags:
+    - git
+    - branch-protection
+    - safety
+    - hooks
+    category: operations
+    difficulty: beginner
   - name: pre-edit-backup
     version: 1.0.0
     description: Creates a backup copy of any file before Claude Code edits it. Fires on PreToolUse for the Edit tool, reads
@@ -810,6 +1321,13 @@ packages:
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/pre-edit-backup/HOOK.md
     events:
     - PreToolUse
+    tags:
+    - backup
+    - files
+    - safety
+    - pre-edit
+    category: operations
+    difficulty: beginner
   rules:
   - name: commit-standards
     version: 1.0.0
@@ -822,6 +1340,13 @@ packages:
     path: rules/commit-standards
     source: https://github.com/Mathews-Tom/armory/blob/main/rules/commit-standards/RULE.md
     scope: global
+    tags:
+    - commits
+    - conventional
+    - git
+    - branch-naming
+    category: content
+    difficulty: beginner
   - name: security-standards
     version: 1.0.0
     description: Defines security standards for application development including secret management (environment variables,
@@ -834,6 +1359,13 @@ packages:
     path: rules/security-standards
     source: https://github.com/Mathews-Tom/armory/blob/main/rules/security-standards/RULE.md
     scope: global
+    tags:
+    - security
+    - secrets
+    - input-validation
+    - authentication
+    category: security
+    difficulty: beginner
   - name: test-standards
     version: 1.0.0
     description: Defines testing standards including coverage thresholds (80% overall, 90% new code, 95% critical paths),
@@ -845,6 +1377,13 @@ packages:
     path: rules/test-standards
     source: https://github.com/Mathews-Tom/armory/blob/main/rules/test-standards/RULE.md
     scope: global
+    tags:
+    - testing
+    - coverage
+    - pytest
+    - ci
+    category: review
+    difficulty: beginner
   commands:
   - name: refactor
     version: 1.0.0
@@ -855,6 +1394,12 @@ packages:
       but needs simplification before committing or merging.'
     path: commands/refactor
     source: https://github.com/Mathews-Tom/armory/blob/main/commands/refactor/COMMAND.md
+    tags:
+    - refactoring
+    - code-quality
+    - simplification
+    category: development
+    difficulty: intermediate
   - name: security-scan
     version: 1.0.0
     description: 'Security audit workflow that scans a codebase path or scope for vulnerabilities across six categories: hardcoded
@@ -864,6 +1409,13 @@ packages:
       scan". Use this command when auditing code for security issues before deployment or during review.'
     path: commands/security-scan
     source: https://github.com/Mathews-Tom/armory/blob/main/commands/security-scan/COMMAND.md
+    tags:
+    - security
+    - scanning
+    - vulnerabilities
+    - audit
+    category: review
+    difficulty: intermediate
   - name: tdd
     version: 1.0.0
     description: 'Test-driven development workflow for functions, modules, or features. Guides Claude through the red-green-refactor
@@ -873,6 +1425,13 @@ packages:
       this command when starting implementation work where tests should drive the design.'
     path: commands/tdd
     source: https://github.com/Mathews-Tom/armory/blob/main/commands/tdd/COMMAND.md
+    tags:
+    - tdd
+    - testing
+    - red-green-refactor
+    - test-first
+    category: development
+    difficulty: intermediate
   utilities:
   - name: arxiv-search
     version: 1.0.0
@@ -888,6 +1447,13 @@ packages:
     complements:
     - literature-review
     - research-critique
+    tags:
+    - arxiv
+    - academic
+    - papers
+    - search
+    category: review
+    difficulty: beginner
   - name: dependency-tree
     version: 1.0.0
     description: Parses project dependency configuration files (pyproject.toml, package.json, go.mod) and prints a formatted
@@ -897,6 +1463,13 @@ packages:
     path: utilities/dependency-tree
     source: https://github.com/Mathews-Tom/armory/blob/main/utilities/dependency-tree/UTILITY.md
     runtime: python
+    tags:
+    - dependencies
+    - tree
+    - analysis
+    - packages
+    category: visualization
+    difficulty: intermediate
   - name: test-coverage-report
     version: 1.0.0
     description: Summarizes test coverage for recently changed files by comparing git diffs against existing test files. Runs
@@ -906,6 +1479,13 @@ packages:
     path: utilities/test-coverage-report
     source: https://github.com/Mathews-Tom/armory/blob/main/utilities/test-coverage-report/UTILITY.md
     runtime: python
+    tags:
+    - coverage
+    - testing
+    - reports
+    - metrics
+    category: review
+    difficulty: intermediate
   presets:
   - name: ai-builder
     version: 1.0.0
@@ -917,6 +1497,13 @@ packages:
       MCP development, RAG pipeline construction, and inference optimization workflows.
     path: presets/ai-builder
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/ai-builder/PRESET.md
+    tags:
+    - ai
+    - agent
+    - development
+    - toolkit
+    category: review
+    difficulty: intermediate
   - name: biz-validation
     version: 1.1.0
     description: 'DEPRECATED: Superseded by the idea-scout agent, which orchestrates the same skills (market-analyzer, competitive-analyzer,
@@ -924,6 +1511,13 @@ packages:
       Use idea-scout agent instead.'
     path: presets/biz-validation
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/biz-validation/PRESET.md
+    tags:
+    - business
+    - validation
+    - market
+    - feasibility
+    category: research
+    difficulty: intermediate
   - name: content-ops
     version: 1.1.0
     description: 'DEPRECATED: Superseded by the content-strategist agent, which orchestrates content skills (humanize, linkedin-post-style,
@@ -931,6 +1525,13 @@ packages:
       quality passes. Use content-strategist agent instead.'
     path: presets/content-ops
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/content-ops/PRESET.md
+    tags:
+    - content
+    - writing
+    - publishing
+    - workflow
+    category: review
+    difficulty: intermediate
   - name: core
     version: 1.0.0
     description: 'Essential packages for every Claude Code user. Bundles pull request review, code refinement, pre-landing
@@ -940,6 +1541,13 @@ packages:
       protected branches, and enforce consistent commit messages.'
     path: presets/core
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/core/PRESET.md
+    tags:
+    - essential
+    - baseline
+    - review
+    - git
+    category: review
+    difficulty: intermediate
   - name: eng-ops
     version: 1.1.0
     description: 'DEPRECATED: Superseded by the release-captain and full-stack-builder agents. release-captain orchestrates
@@ -947,6 +1555,13 @@ packages:
       implementation with test-harness, code-refiner, and api-docs-generator. Use these agents instead.'
     path: presets/eng-ops
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/eng-ops/PRESET.md
+    tags:
+    - engineering
+    - operations
+    - ci-cd
+    - release
+    category: review
+    difficulty: intermediate
   - name: media-craft
     version: 1.1.0
     description: 'DEPRECATED: Superseded by the media-producer agent, which orchestrates the same skills (concept-to-image,
@@ -954,6 +1569,13 @@ packages:
       format routing based on content type. Use media-producer agent instead.'
     path: presets/media-craft
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/media-craft/PRESET.md
+    tags:
+    - media
+    - video
+    - visualization
+    - design
+    category: visualization
+    difficulty: intermediate
   - name: python-strict
     version: 1.0.0
     description: 'Full-stack Python enforcement preset. Extends the core review-commit lifecycle with test-driven development,
@@ -963,6 +1585,13 @@ packages:
       install.'
     path: presets/python-strict
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/python-strict/PRESET.md
+    tags:
+    - python
+    - typing
+    - testing
+    - strict
+    category: review
+    difficulty: intermediate
   - name: research
     version: 1.1.0
     description: 'DEPRECATED: Superseded by the research-analyst agent, which orchestrates literature-review, tavily, youtube-analysis,
@@ -970,6 +1599,13 @@ packages:
       synthesis. Use research-analyst agent instead.'
     path: presets/research
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/research/PRESET.md
+    tags:
+    - research
+    - academic
+    - literature
+    - analysis
+    category: review
+    difficulty: intermediate
   - name: sec-strict
     version: 1.0.0
     description: Security-focused preset for projects requiring audit-grade protection. Extends the core review-commit lifecycle
@@ -979,3 +1615,10 @@ packages:
       and commands.
     path: presets/sec-strict
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/sec-strict/PRESET.md
+    tags:
+    - security
+    - scanning
+    - secrets
+    - strict
+    category: review
+    difficulty: intermediate

--- a/presets/ai-builder/PRESET.md
+++ b/presets/ai-builder/PRESET.md
@@ -1,30 +1,33 @@
 ---
 name: ai-builder
 type: preset
-description: >
-  AI development toolkit for building, testing, and optimizing LLM-powered systems in Claude
-  Code. Bundles agent development, prompt engineering, GPU and inference optimization, RAG
-  pipeline auditing, MCP server conversion, and notebook generation into a single install.
-  Covers the full AI workflow from designing prompts through building agents, optimizing GPU
-  utilization, auditing retrieval quality, and extending tool integrations. Use this preset
-  when setting up an AI development environment, machine learning toolkit, or LLM tools
-  workspace. Relevant for agent development, MCP development, RAG pipeline construction,
-  and inference optimization workflows.
+description: 'AI development toolkit for building, testing, and optimizing LLM-powered
+  systems in Claude Code. Bundles agent development, prompt engineering, GPU and inference
+  optimization, RAG pipeline auditing, MCP server conversion, and notebook generation
+  into a single install. Covers the full AI workflow from designing prompts through
+  building agents, optimizing GPU utilization, auditing retrieval quality, and extending
+  tool integrations. Use this preset when setting up an AI development environment,
+  machine learning toolkit, or LLM tools workspace. Relevant for agent development,
+  MCP development, RAG pipeline construction, and inference optimization workflows.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [ai, agent, development, toolkit]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: agent-builder
-      - name: prompt-lab
-      - name: gpu-optimizer
-      - name: rag-auditor
-      - name: mcp-to-skill
-      - name: notebooklm
+    - {name: agent-builder}
+    - {name: prompt-lab}
+    - {name: gpu-optimizer}
+    - {name: rag-auditor}
+    - {name: mcp-to-skill}
+    - {name: notebooklm}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # AI Builder
 
 End-to-end toolkit for developing, optimizing, and validating AI-powered systems.

--- a/presets/biz-validation/PRESET.md
+++ b/presets/biz-validation/PRESET.md
@@ -1,21 +1,26 @@
 ---
 name: biz-validation
-description: "DEPRECATED: Superseded by the idea-scout agent, which orchestrates the same skills (market-analyzer, competitive-analyzer, feasibility-assessor, idea-validator) with parallel research delegation, weighted scoring, and GO/CAUTION/NO-GO verdicts. Use idea-scout agent instead."
+description: 'DEPRECATED: Superseded by the idea-scout agent, which orchestrates the
+  same skills (market-analyzer, competitive-analyzer, feasibility-assessor, idea-validator)
+  with parallel research delegation, weighted scoring, and GO/CAUTION/NO-GO verdicts.
+  Use idea-scout agent instead.'
 type: preset
 metadata:
   version: 1.1.0
   status: deprecated
+  category: research
+  tags: [business, validation, market, feasibility]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: market-analyzer
-      - name: competitive-analyzer
-      - name: feasibility-assessor
-      - name: idea-validator
+    - {name: market-analyzer}
+    - {name: competitive-analyzer}
+    - {name: feasibility-assessor}
+    - {name: idea-validator}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Biz Validation
 
 > **DEPRECATED** — The `idea-scout` agent supersedes this preset. It orchestrates the

--- a/presets/content-ops/PRESET.md
+++ b/presets/content-ops/PRESET.md
@@ -1,25 +1,30 @@
 ---
 name: content-ops
 type: preset
-description: "DEPRECATED: Superseded by the content-strategist agent, which orchestrates content skills (humanize, linkedin-post-style, html-presentation, md-to-pdf, tavily, youtube-analysis) with per-channel adaptation, audience-aware tone, and automated quality passes. Use content-strategist agent instead."
+description: 'DEPRECATED: Superseded by the content-strategist agent, which orchestrates
+  content skills (humanize, linkedin-post-style, html-presentation, md-to-pdf, tavily,
+  youtube-analysis) with per-channel adaptation, audience-aware tone, and automated
+  quality passes. Use content-strategist agent instead.'
 metadata:
   version: 1.1.0
   status: deprecated
+  category: review
+  tags: [content, writing, publishing, workflow]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: humanize
-      - name: linkedin-post-style
-      - name: manuscript-review
-      - name: manuscript-provenance
-      - name: changelog-composer
-      - name: md-to-pdf
-      - name: doc-condenser
-      - name: to-markdown
+    - {name: humanize}
+    - {name: linkedin-post-style}
+    - {name: manuscript-review}
+    - {name: manuscript-provenance}
+    - {name: changelog-composer}
+    - {name: md-to-pdf}
+    - {name: doc-condenser}
+    - {name: to-markdown}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Content Ops
 
 > **DEPRECATED** — The `content-strategist` agent supersedes this preset. It creates and

--- a/presets/core/PRESET.md
+++ b/presets/core/PRESET.md
@@ -1,30 +1,33 @@
 ---
 name: core
 type: preset
-description: >
-  Essential packages for every Claude Code user. Bundles pull request review, code
-  refinement, pre-landing checks, git branch protection, and commit message standards
-  into a single install. Use this preset when setting up a new project or onboarding a
-  teammate who needs a reliable baseline without opinionated language-specific tooling.
-  Covers the review-commit lifecycle: review changes, refine code quality, verify
-  pre-merge readiness, prevent force-pushes to protected branches, and enforce
+description: 'Essential packages for every Claude Code user. Bundles pull request
+  review, code refinement, pre-landing checks, git branch protection, and commit message
+  standards into a single install. Use this preset when setting up a new project or
+  onboarding a teammate who needs a reliable baseline without opinionated language-specific
+  tooling. Covers the review-commit lifecycle: review changes, refine code quality,
+  verify pre-merge readiness, prevent force-pushes to protected branches, and enforce
   consistent commit messages.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [essential, baseline, review, git]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: pr-review
-      - name: code-refiner
-      - name: pre-landing-review
+    - {name: pr-review}
+    - {name: code-refiner}
+    - {name: pre-landing-review}
     hooks:
-      - name: git-protection
+    - {name: git-protection}
     rules:
-      - name: commit-standards
+    - {name: commit-standards}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Core Preset
 
 A minimal, opinionated baseline for Claude Code projects. Installs five packages that

--- a/presets/eng-ops/PRESET.md
+++ b/presets/eng-ops/PRESET.md
@@ -1,25 +1,30 @@
 ---
 name: eng-ops
 type: preset
-description: "DEPRECATED: Superseded by the release-captain and full-stack-builder agents. release-captain orchestrates ship-workflow, changelog-composer, pre-landing-review, dependency-audit with quality gates. full-stack-builder handles implementation with test-harness, code-refiner, and api-docs-generator. Use these agents instead."
+description: 'DEPRECATED: Superseded by the release-captain and full-stack-builder
+  agents. release-captain orchestrates ship-workflow, changelog-composer, pre-landing-review,
+  dependency-audit with quality gates. full-stack-builder handles implementation with
+  test-harness, code-refiner, and api-docs-generator. Use these agents instead.'
 metadata:
   version: 1.1.0
   status: deprecated
+  category: review
+  tags: [engineering, operations, ci-cd, release]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: ship-workflow
-      - name: qa-systematic
-      - name: test-harness
-      - name: benchmark-runner
-      - name: migration-risk-analyzer
-      - name: estimate-calibrator
-      - name: engineering-retro
-      - name: debug-investigator
+    - {name: ship-workflow}
+    - {name: qa-systematic}
+    - {name: test-harness}
+    - {name: benchmark-runner}
+    - {name: migration-risk-analyzer}
+    - {name: estimate-calibrator}
+    - {name: engineering-retro}
+    - {name: debug-investigator}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Eng Ops
 
 > **DEPRECATED** — The `release-captain` and `full-stack-builder` agents supersede this

--- a/presets/media-craft/PRESET.md
+++ b/presets/media-craft/PRESET.md
@@ -1,23 +1,28 @@
 ---
 name: media-craft
 type: preset
-description: "DEPRECATED: Superseded by the media-producer agent, which orchestrates the same skills (concept-to-image, concept-to-video, remotion-video, html-presentation, static-web-artifacts-builder, architecture-diagram) with intelligent format routing based on content type. Use media-producer agent instead."
+description: 'DEPRECATED: Superseded by the media-producer agent, which orchestrates
+  the same skills (concept-to-image, concept-to-video, remotion-video, html-presentation,
+  static-web-artifacts-builder, architecture-diagram) with intelligent format routing
+  based on content type. Use media-producer agent instead.'
 metadata:
   version: 1.1.0
   status: deprecated
+  category: visualization
+  tags: [media, video, visualization, design]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: concept-to-image
-      - name: concept-to-video
-      - name: remotion-video
-      - name: html-presentation
-      - name: static-web-artifacts-builder
-      - name: architecture-diagram
+    - {name: concept-to-image}
+    - {name: concept-to-video}
+    - {name: remotion-video}
+    - {name: html-presentation}
+    - {name: static-web-artifacts-builder}
+    - {name: architecture-diagram}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Media Craft
 
 > **DEPRECATED** — The `media-producer` agent supersedes this preset. It orchestrates the

--- a/presets/python-strict/PRESET.md
+++ b/presets/python-strict/PRESET.md
@@ -1,39 +1,42 @@
 ---
 name: python-strict
 type: preset
-description: >
-  Full-stack Python enforcement preset. Extends the core review-commit lifecycle with
-  test-driven development, automated code review agents, secret scanning, security
-  standards, test coverage rules, and pre-edit backups. Use this preset when working on
-  Python projects that demand strict quality gates: typed codebases, libraries with
-  public APIs, or services handling sensitive data. Bundles 12 packages across skills,
-  agents, rules, hooks, and commands into a single install.
+description: 'Full-stack Python enforcement preset. Extends the core review-commit
+  lifecycle with test-driven development, automated code review agents, secret scanning,
+  security standards, test coverage rules, and pre-edit backups. Use this preset when
+  working on Python projects that demand strict quality gates: typed codebases, libraries
+  with public APIs, or services handling sensitive data. Bundles 12 packages across
+  skills, agents, rules, hooks, and commands into a single install.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [python, typing, testing, strict]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: pr-review
-      - name: code-refiner
-      - name: pre-landing-review
-      - name: test-harness
+    - {name: pr-review}
+    - {name: code-refiner}
+    - {name: pre-landing-review}
+    - {name: test-harness}
     agents:
-      - name: code-reviewer
-      - name: secret-scanner
+    - {name: code-reviewer}
+    - {name: secret-scanner}
     rules:
-      - name: commit-standards
-      - name: test-standards
-      - name: security-standards
+    - {name: commit-standards}
+    - {name: test-standards}
+    - {name: security-standards}
     hooks:
-      - name: git-protection
-      - name: pre-edit-backup
+    - {name: git-protection}
+    - {name: pre-edit-backup}
     commands:
-      - name: tdd
-      - name: refactor
+    - {name: tdd}
+    - {name: refactor}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Python Strict Preset
 
 A comprehensive enforcement stack for Python projects that demand high code quality,

--- a/presets/research/PRESET.md
+++ b/presets/research/PRESET.md
@@ -1,23 +1,28 @@
 ---
 name: research
 type: preset
-description: "DEPRECATED: Superseded by the research-analyst agent, which orchestrates literature-review, tavily, youtube-analysis, competitive-analyzer, and web-fetch with parallel multi-source investigation, cross-referencing, and confidence-rated synthesis. Use research-analyst agent instead."
+description: 'DEPRECATED: Superseded by the research-analyst agent, which orchestrates
+  literature-review, tavily, youtube-analysis, competitive-analyzer, and web-fetch
+  with parallel multi-source investigation, cross-referencing, and confidence-rated
+  synthesis. Use research-analyst agent instead.'
 metadata:
   version: 1.1.0
   status: deprecated
+  category: review
+  tags: [research, academic, literature, analysis]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: literature-review
-      - name: research-critique
-      - name: manuscript-review
-      - name: manuscript-provenance
+    - {name: literature-review}
+    - {name: research-critique}
+    - {name: manuscript-review}
+    - {name: manuscript-provenance}
     utilities:
-      - name: arxiv-search
+    - {name: arxiv-search}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Research Preset
 
 > **DEPRECATED** — The `research-analyst` agent supersedes this preset. It conducts

--- a/presets/sec-strict/PRESET.md
+++ b/presets/sec-strict/PRESET.md
@@ -1,39 +1,43 @@
 ---
 name: sec-strict
 type: preset
-description: >
-  Security-focused preset for projects requiring audit-grade protection. Extends the
-  core review-commit lifecycle with security-specific review agents, secret scanning,
-  dependency vulnerability auditing, repository configuration sentinel, cost tracking,
-  and security coding standards. Use this preset for applications handling sensitive
-  data, regulated environments, or any codebase where security posture is a primary
-  concern. Bundles 12 packages across skills, agents, rules, hooks, and commands.
+description: 'Security-focused preset for projects requiring audit-grade protection.
+  Extends the core review-commit lifecycle with security-specific review agents, secret
+  scanning, dependency vulnerability auditing, repository configuration sentinel,
+  cost tracking, and security coding standards. Use this preset for applications handling
+  sensitive data, regulated environments, or any codebase where security posture is
+  a primary concern. Bundles 12 packages across skills, agents, rules, hooks, and
+  commands.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [security, scanning, secrets, strict]
+  difficulty: intermediate
 preset:
   packages:
     skills:
-      - name: pr-review
-      - name: code-refiner
-      - name: pre-landing-review
-      - name: repo-sentinel
-      - name: dependency-audit
+    - {name: pr-review}
+    - {name: code-refiner}
+    - {name: pre-landing-review}
+    - {name: repo-sentinel}
+    - {name: dependency-audit}
     agents:
-      - name: security-reviewer
-      - name: secret-scanner
-      - name: codebase-auditor
+    - {name: security-reviewer}
+    - {name: secret-scanner}
+    - {name: codebase-auditor}
     rules:
-      - name: security-standards
-      - name: commit-standards
+    - {name: security-standards}
+    - {name: commit-standards}
     hooks:
-      - name: git-protection
-      - name: cost-tracker
+    - {name: git-protection}
+    - {name: cost-tracker}
     commands:
-      - name: security-scan
+    - {name: security-scan}
   compatibility:
     platforms: [darwin, linux]
 ---
-
 # Sec Strict Preset
 
 An audit-grade security stack for projects where security posture is a primary concern.

--- a/profiles.yaml
+++ b/profiles.yaml
@@ -1,15 +1,21 @@
 # Install profiles — curated subsets for different use cases.
+# Use: uv run scripts/install.py --profile <name>
+# List: uv run scripts/install.py --list-profiles
 profiles:
   core:
-    description: Essential skills for every Claude Code user
+    description: Essential review and commit lifecycle for every Claude Code user
     packages:
       skills:
         - pr-review
         - code-refiner
         - pre-landing-review
+      hooks:
+        - git-protection
+      rules:
+        - commit-standards
 
   developer:
-    description: Core plus framework support and review tools
+    description: Core plus testing, debugging, and architecture tools
     includes: [core]
     packages:
       skills:
@@ -17,6 +23,74 @@ profiles:
         - debug-investigator
         - architecture-reviewer
         - github
+
+  python-dev:
+    description: Python development with TDD, type checking, and security
+    includes: [core]
+    packages:
+      skills:
+        - test-harness
+        - debug-investigator
+        - gpu-optimizer
+      commands:
+        - tdd
+      rules:
+        - test-standards
+
+  security-engineer:
+    description: Security auditing, secrets detection, and compliance
+    includes: [core]
+    packages:
+      skills:
+        - repo-sentinel
+        - dependency-audit
+        - pre-landing-review
+      agents:
+        - security-reviewer
+        - secret-scanner
+        - codebase-auditor
+      rules:
+        - security-standards
+      commands:
+        - security-scan
+
+  content-creator:
+    description: Content creation, publishing, and visual production
+    packages:
+      skills:
+        - humanize
+        - linkedin-post-style
+        - html-presentation
+        - md-to-pdf
+        - concept-to-image
+        - concept-to-video
+      agents:
+        - content-strategist
+        - media-producer
+
+  researcher:
+    description: Academic research, literature survey, and analysis
+    packages:
+      skills:
+        - literature-review
+        - research-critique
+        - youtube-analysis
+        - tavily
+        - web-fetch
+      agents:
+        - research-analyst
+
+  business-analyst:
+    description: Idea validation, market sizing, and competitive analysis
+    packages:
+      skills:
+        - idea-validator
+        - market-analyzer
+        - competitive-analyzer
+        - feasibility-assessor
+      agents:
+        - idea-scout
+        - proposal-writer
 
   security:
     description: Core plus security auditing and enforcement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,4 @@ dev = [
 
 [project.scripts]
 armory-install = "scripts.install:main"
+armory-search = "scripts.search:main"

--- a/rules/commit-standards/RULE.md
+++ b/rules/commit-standards/RULE.md
@@ -1,21 +1,25 @@
 ---
 name: commit-standards
 type: rule
-description: >
-  Enforces conventional commit format, branch naming conventions, and commit message structure
-  for consistent version control history. Covers type prefixes (feat, fix, chore, docs, refactor,
-  test, perf, ci, build, style), scope requirements, subject line constraints, body formatting,
-  BREAKING CHANGE footers, and merge/squash policy. Use this rule when writing commit messages,
-  naming branches, preparing pull requests, or establishing git workflow standards. Triggers on
-  "commit message", "branch naming", "conventional commits", "git workflow", "commit format",
-  "merge strategy", "squash commits".
+description: 'Enforces conventional commit format, branch naming conventions, and
+  commit message structure for consistent version control history. Covers type prefixes
+  (feat, fix, chore, docs, refactor, test, perf, ci, build, style), scope requirements,
+  subject line constraints, body formatting, BREAKING CHANGE footers, and merge/squash
+  policy. Use this rule when writing commit messages, naming branches, preparing pull
+  requests, or establishing git workflow standards. Triggers on "commit message",
+  "branch naming", "conventional commits", "git workflow", "commit format", "merge
+  strategy", "squash commits".
+
+  '
 metadata:
   version: 1.0.0
   scope: global
   applies_to:
-    languages: ["*"]
+    languages: ['*']
+  category: content
+  tags: [commits, conventional, git, branch-naming]
+  difficulty: beginner
 ---
-
 # Commit Standards
 
 Standards for commit messages, branch naming, and merge strategy across all repositories.

--- a/rules/security-standards/RULE.md
+++ b/rules/security-standards/RULE.md
@@ -1,22 +1,26 @@
 ---
 name: security-standards
 type: rule
-description: >
-  Defines security standards for application development including secret management (environment
-  variables, vault integration, never hardcode), input validation at system boundaries, authentication
-  and session handling (JWT, refresh tokens, session expiry), HTTP security headers, file upload
-  restrictions, SQL parameterization, dependency scanning, and CORS policy. Use this rule when
-  handling secrets, implementing authentication, validating user input, configuring HTTP security,
-  processing file uploads, or writing database queries. Triggers on "security rules", "secret
-  management", "input validation", "security standards", "JWT handling", "CORS policy",
-  "SQL injection", "file upload security", "dependency scanning", "HTTP headers".
+description: 'Defines security standards for application development including secret
+  management (environment variables, vault integration, never hardcode), input validation
+  at system boundaries, authentication and session handling (JWT, refresh tokens,
+  session expiry), HTTP security headers, file upload restrictions, SQL parameterization,
+  dependency scanning, and CORS policy. Use this rule when handling secrets, implementing
+  authentication, validating user input, configuring HTTP security, processing file
+  uploads, or writing database queries. Triggers on "security rules", "secret management",
+  "input validation", "security standards", "JWT handling", "CORS policy", "SQL injection",
+  "file upload security", "dependency scanning", "HTTP headers".
+
+  '
 metadata:
   version: 1.0.0
   scope: global
   applies_to:
-    languages: ["*"]
+    languages: ['*']
+  category: security
+  tags: [security, secrets, input-validation, authentication]
+  difficulty: beginner
 ---
-
 # Security Standards
 
 Standards for secure application development across all repositories and languages.

--- a/rules/test-standards/RULE.md
+++ b/rules/test-standards/RULE.md
@@ -1,21 +1,25 @@
 ---
 name: test-standards
 type: rule
-description: >
-  Defines testing standards including coverage thresholds (80% overall, 90% new code, 95% critical
-  paths), test naming conventions, structural patterns (arrange-act-assert), test categorization
-  (unit/integration/e2e), fixture management, mock boundaries, and CI gate requirements. Use this
-  rule when writing tests, setting up test infrastructure, reviewing test quality, or defining
-  coverage requirements. Triggers on "test coverage", "testing standards", "test requirements",
-  "coverage thresholds", "unit test", "integration test", "test structure", "arrange act assert",
+description: 'Defines testing standards including coverage thresholds (80% overall,
+  90% new code, 95% critical paths), test naming conventions, structural patterns
+  (arrange-act-assert), test categorization (unit/integration/e2e), fixture management,
+  mock boundaries, and CI gate requirements. Use this rule when writing tests, setting
+  up test infrastructure, reviewing test quality, or defining coverage requirements.
+  Triggers on "test coverage", "testing standards", "test requirements", "coverage
+  thresholds", "unit test", "integration test", "test structure", "arrange act assert",
   "mock boundaries", "test naming".
+
+  '
 metadata:
   version: 1.0.0
   scope: global
   applies_to:
-    languages: ["*"]
+    languages: ['*']
+  category: review
+  tags: [testing, coverage, pytest, ci]
+  difficulty: beginner
 ---
-
 # Test Standards
 
 Standards for test coverage, structure, naming, and CI enforcement across all repositories.

--- a/scripts/backfill_metadata.py
+++ b/scripts/backfill_metadata.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""One-time script to backfill tags, category, and difficulty into package metadata."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.package_types import REPO_ROOT, TYPES
+
+
+# ---------------------------------------------------------------------------
+# Category assignment rules
+# ---------------------------------------------------------------------------
+
+CATEGORY_PATTERNS: list[tuple[list[str], str]] = [
+    (["review", "audit", "quality", "lint"], "review"),
+    (["security", "secret", "vulnerability", "sentinel"], "security"),
+    (["research", "literature", "paper", "academic", "critique"], "research"),
+    (["competitive", "market", "feasibility", "idea", "validator"], "business"),
+    (
+        [
+            "image", "video", "diagram", "presentation", "visual",
+            "html-presentation", "static-web", "remotion",
+        ],
+        "visualization",
+    ),
+    (["humanize", "linkedin", "changelog", "content", "writing"], "content"),
+    (["sql", "migration", "benchmark", "database"], "data"),
+    (["ship", "release", "deploy", "adr", "api-docs", "engineering-retro"], "operations"),
+    (
+        [
+            "debug", "test", "tdd", "gpu", "regex", "filesystem", "github",
+            "agent-builder", "mcp", "prompt",
+        ],
+        "development",
+    ),
+]
+
+TYPE_DEFAULT_CATEGORY: dict[str, str] = {
+    "hook": "operations",
+    "rule": "operations",
+    "command": "development",
+    "utility": "development",
+    "preset": "operations",
+}
+
+VALID_CATEGORIES = {
+    "development", "review", "security", "research", "content",
+    "business", "visualization", "operations", "data",
+}
+
+
+def classify_category(name: str, description: str, pkg_type: str) -> str:
+    """Determine category from package name and description."""
+    haystack = f"{name} {description}".lower()
+    for keywords, category in CATEGORY_PATTERNS:
+        for kw in keywords:
+            if kw in haystack:
+                return category
+    return TYPE_DEFAULT_CATEGORY.get(pkg_type, "development")
+
+
+# ---------------------------------------------------------------------------
+# Tag generation
+# ---------------------------------------------------------------------------
+
+TAG_RULES: dict[str, list[str]] = {
+    # Skills
+    "pr-review": ["code-review", "pull-request", "quality", "diff-analysis"],
+    "code-refiner": ["refactoring", "code-quality", "simplification", "readability"],
+    "pre-landing-review": ["pre-merge", "safety-gate", "code-review", "checklist"],
+    "architecture-reviewer": ["architecture", "scalability", "enterprise", "security-audit"],
+    "architecture-diagram": ["architecture", "diagram", "visualization", "svg"],
+    "debug-investigator": ["debugging", "root-cause", "hypothesis", "bisect"],
+    "test-harness": ["testing", "pytest", "test-generation", "python"],
+    "sql-optimizer": ["sql", "performance", "database", "optimization"],
+    "benchmark-runner": ["benchmarking", "performance", "comparison", "metrics"],
+    "dependency-audit": ["dependencies", "vulnerabilities", "licenses", "supply-chain"],
+    "migration-risk-analyzer": ["database", "migration", "ddl", "rollback"],
+    "ship-workflow": ["release", "ci-cd", "pull-request", "changelog"],
+    "changelog-composer": ["changelog", "release-notes", "git-history", "versioning"],
+    "engineering-retro": ["retrospective", "velocity", "git-analysis", "sprint"],
+    "adr-writer": ["architecture", "decision-record", "documentation", "adr"],
+    "api-docs-generator": ["api", "documentation", "openapi", "fastapi"],
+    "estimate-calibrator": ["estimation", "pert", "confidence-interval", "planning"],
+    "task-decomposer": ["task-breakdown", "dependencies", "planning", "phased"],
+    "plan-review": ["plan-audit", "scope", "risk-assessment", "assumptions"],
+    "competitive-analyzer": ["competitive-analysis", "market", "porters-five-forces", "positioning"],
+    "market-analyzer": ["market-sizing", "tam-sam-som", "trends", "industry"],
+    "feasibility-assessor": ["feasibility", "unit-economics", "viability", "business-case"],
+    "idea-validator": ["idea-validation", "lean-canvas", "jtbd", "swot"],
+    "literature-review": ["academic", "literature", "synthesis", "citations"],
+    "research-critique": ["research", "methodology", "claims-evidence", "peer-review"],
+    "manuscript-review": ["manuscript", "pre-publication", "citation-hygiene", "submission"],
+    "manuscript-provenance": ["provenance", "reproducibility", "computational", "verification"],
+    "concept-to-image": ["image-generation", "html-to-png", "svg", "visual-design"],
+    "concept-to-video": ["video", "manim", "animation", "explainer"],
+    "remotion-video": ["video", "react", "remotion", "motion-graphics"],
+    "html-presentation": ["slides", "presentation", "reveal-js", "html"],
+    "static-web-artifacts-builder": ["html", "interactive", "dashboard", "svg"],
+    "humanize": ["writing", "ai-detection", "natural-language", "rewriting"],
+    "linkedin-post-style": ["linkedin", "social-media", "writing", "content"],
+    "doc-condenser": ["documentation", "summarization", "technical-writing", "conciseness"],
+    "to-markdown": ["conversion", "markdown", "document-ingestion", "pdf"],
+    "md-to-pdf": ["pdf", "markdown", "mermaid", "latex"],
+    "gpu-optimizer": ["gpu", "cuda", "vram", "pytorch"],
+    "regex-builder": ["regex", "pattern-matching", "testing", "validation"],
+    "filesystem": ["files", "directories", "search", "navigation"],
+    "github": ["github", "cli", "issues", "pull-requests"],
+    "agent-builder": ["agent-sdk", "headless", "automation", "mcp"],
+    "mcp-to-skill": ["mcp", "skill-conversion", "context-optimization", "token-reduction"],
+    "prompt-lab": ["prompt-engineering", "evaluation", "few-shot", "chain-of-thought"],
+    "rag-auditor": ["rag", "retrieval", "hallucination", "grounding"],
+    "repo-sentinel": ["security", "public-repo", "secret-scanning", "audit"],
+    "qa-systematic": ["qa", "testing", "browser", "regression"],
+    "sequential-thinking": ["reasoning", "chain-of-thought", "analysis", "problem-solving"],
+    "tavily": ["web-search", "research", "real-time", "ai-optimized"],
+    "web-fetch": ["http", "curl", "api", "web-content"],
+    "lightpanda-browser": ["browser", "headless", "scraping", "lightweight"],
+    "immune": ["memory", "error-detection", "antibodies", "adaptive"],
+    "notebooklm": ["notebooklm", "podcast", "flashcards", "source-analysis"],
+    "skill-library": ["armory", "catalog", "install", "package-management"],
+    "package-evaluator": ["quality", "audit", "scoring", "frontmatter"],
+    # Agents
+    "code-reviewer": ["code-review", "quality", "severity-ranking", "sonnet"],
+    "codebase-auditor": ["audit", "codebase", "quality", "sonnet"],
+    "content-strategist": ["content", "strategy", "planning", "sonnet"],
+    "full-stack-builder": ["full-stack", "implementation", "development", "opus"],
+    "idea-scout": ["ideas", "research", "validation", "opus"],
+    "media-producer": ["media", "production", "content", "sonnet"],
+    "project-architect": ["architecture", "design", "planning", "opus"],
+    "project-planner": ["planning", "decomposition", "estimation", "sonnet"],
+    "proposal-writer": ["proposals", "writing", "business", "opus"],
+    "release-captain": ["release", "deployment", "ci-cd", "sonnet"],
+    "research-analyst": ["research", "analysis", "synthesis", "opus"],
+    "secret-scanner": ["secrets", "scanning", "security", "haiku"],
+    "security-reviewer": ["security", "review", "vulnerabilities", "sonnet"],
+    "team-lead": ["orchestration", "delegation", "multi-agent", "opus"],
+    "test-engineer": ["testing", "test-generation", "coverage", "haiku"],
+    # Hooks
+    "cost-tracker": ["cost", "tokens", "usage", "logging"],
+    "git-protection": ["git", "branch-protection", "safety", "hooks"],
+    "pre-edit-backup": ["backup", "files", "safety", "pre-edit"],
+    # Rules
+    "commit-standards": ["commits", "conventional", "git", "branch-naming"],
+    "security-standards": ["security", "secrets", "input-validation", "authentication"],
+    "test-standards": ["testing", "coverage", "pytest", "ci"],
+    # Commands
+    "refactor": ["refactoring", "code-quality", "simplification"],
+    "security-scan": ["security", "scanning", "vulnerabilities", "audit"],
+    "tdd": ["tdd", "testing", "red-green-refactor", "test-first"],
+    # Utilities
+    "arxiv-search": ["arxiv", "academic", "papers", "search"],
+    "dependency-tree": ["dependencies", "tree", "analysis", "packages"],
+    "test-coverage-report": ["coverage", "testing", "reports", "metrics"],
+    # Presets
+    "ai-builder": ["ai", "agent", "development", "toolkit"],
+    "biz-validation": ["business", "validation", "market", "feasibility"],
+    "content-ops": ["content", "writing", "publishing", "workflow"],
+    "core": ["essential", "baseline", "review", "git"],
+    "eng-ops": ["engineering", "operations", "ci-cd", "release"],
+    "media-craft": ["media", "video", "visualization", "design"],
+    "python-strict": ["python", "typing", "testing", "strict"],
+    "research": ["research", "academic", "literature", "analysis"],
+    "sec-strict": ["security", "scanning", "secrets", "strict"],
+}
+
+
+def generate_tags(name: str, pkg_type: str, meta: dict[str, Any]) -> list[str]:
+    """Generate 3-6 tags for a package."""
+    if name in TAG_RULES:
+        return TAG_RULES[name]
+
+    # Fallback: extract from name and description
+    tags: list[str] = []
+
+    # Add name parts as tags
+    parts = name.split("-")
+    for part in parts:
+        if len(part) > 2:
+            tags.append(part)
+
+    # Add type-derived tag
+    type_tags = {
+        "skill": "skill",
+        "agent": "agent",
+        "hook": "hook",
+        "rule": "rule",
+        "command": "command",
+        "utility": "utility",
+        "preset": "preset",
+    }
+    if pkg_type in type_tags:
+        tags.append(type_tags[pkg_type])
+
+    # For agents, add model tag
+    if pkg_type == "agent":
+        model = meta.get("model", "")
+        if model:
+            tags.append(str(model))
+
+    # Deduplicate and limit
+    seen: set[str] = set()
+    unique: list[str] = []
+    for t in tags:
+        t_lower = t.lower()
+        if t_lower not in seen:
+            seen.add(t_lower)
+            unique.append(t_lower)
+    return unique[:6]
+
+
+# ---------------------------------------------------------------------------
+# Difficulty assignment
+# ---------------------------------------------------------------------------
+
+BEGINNER_PACKAGES = {
+    "filesystem", "regex-builder", "web-fetch", "to-markdown", "doc-condenser",
+    "tavily", "lightpanda-browser", "youtube-search", "arxiv-search",
+    "commit-standards", "test-standards", "security-standards",
+    "cost-tracker", "git-protection", "pre-edit-backup",
+}
+
+ADVANCED_PACKAGES = {
+    "architecture-reviewer", "manuscript-review", "manuscript-provenance",
+    "rag-auditor", "gpu-optimizer", "migration-risk-analyzer", "repo-sentinel",
+    "competitive-analyzer", "idea-validator", "feasibility-assessor",
+    "qa-systematic", "remotion-video", "concept-to-video",
+    "project-architect", "team-lead", "security-reviewer", "research-analyst",
+}
+
+
+def classify_difficulty(name: str) -> str:
+    """Assign difficulty level."""
+    if name in BEGINNER_PACKAGES:
+        return "beginner"
+    if name in ADVANCED_PACKAGES:
+        return "advanced"
+    return "intermediate"
+
+
+# ---------------------------------------------------------------------------
+# File rewriting
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def rewrite_file(path: Path, pkg_type: str) -> dict[str, Any] | None:
+    """Add tags/category/difficulty to a package definition file. Returns added fields or None."""
+    content = path.read_text(encoding="utf-8")
+
+    fm_match = FRONTMATTER_RE.match(content)
+    if not fm_match:
+        print(f"  SKIP {path.relative_to(REPO_ROOT)} — no frontmatter", file=sys.stderr)
+        return None
+
+    fm_raw = fm_match.group(1)
+    body = content[fm_match.end():]
+
+    data: dict[str, Any] = yaml.safe_load(fm_raw) or {}
+
+    name = data.get("name", path.parent.name)
+    description = data.get("description", "")
+
+    # Ensure metadata dict exists
+    if "metadata" not in data or not isinstance(data.get("metadata"), dict):
+        data["metadata"] = {}
+
+    meta = data["metadata"]
+    added: dict[str, Any] = {}
+
+    # Category
+    if "category" not in meta:
+        cat = classify_category(name, description, pkg_type)
+        meta["category"] = cat
+        added["category"] = cat
+
+    # Tags
+    if "tags" not in meta:
+        tags = generate_tags(name, pkg_type, data)
+        meta["tags"] = tags
+        added["tags"] = tags
+
+    # Difficulty
+    if "difficulty" not in meta:
+        diff = classify_difficulty(name)
+        meta["difficulty"] = diff
+        added["difficulty"] = diff
+
+    if not added:
+        return None
+
+    # Reconstruct YAML frontmatter
+    new_fm = yaml.dump(data, default_flow_style=None, sort_keys=False, allow_unicode=True)
+    # Remove trailing newline from yaml.dump before closing ---
+    new_fm = new_fm.rstrip("\n")
+
+    new_content = f"---\n{new_fm}\n---\n{body}"
+    path.write_text(new_content, encoding="utf-8")
+    return added
+
+
+def main() -> None:
+    updated = 0
+
+    for pkg_type_key, pkg_type in TYPES.items():
+        repo_dir = pkg_type.repo_dir
+        if not repo_dir.exists():
+            continue
+
+        for pkg_dir in sorted(repo_dir.iterdir()):
+            if not pkg_dir.is_dir():
+                continue
+            if pkg_dir.name.startswith(".") or pkg_dir.name.startswith("_"):
+                continue
+            if pkg_dir.name == "evals":
+                continue
+
+            def_file = pkg_dir / pkg_type.definition_file
+            if not def_file.exists():
+                continue
+
+            result = rewrite_file(def_file, pkg_type_key)
+            if result is None:
+                continue
+
+            updated += 1
+            rel = def_file.parent.relative_to(REPO_ROOT)
+            parts: list[str] = []
+            if "category" in result:
+                parts.append(f"category: {result['category']}")
+            if "tags" in result:
+                parts.append(f"tags: {result['tags']}")
+            if "difficulty" in result:
+                parts.append(f"difficulty: {result['difficulty']}")
+            print(f"Updated {rel} — {', '.join(parts)}")
+
+    print(f"\nUpdated {updated} packages")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -154,12 +154,21 @@ def collect_packages(pkg_type: PackageType, repo: str) -> list[dict[str, Any]]:
         if extractor:
             entry.update(extractor(meta))
 
-        # Optional complements from metadata
+        # Optional metadata fields: complements, tags, category, difficulty
         metadata = meta.get("metadata")
         if isinstance(metadata, dict):
             complements = metadata.get("complements")
             if isinstance(complements, list) and complements:
                 entry["complements"] = complements
+            tags = metadata.get("tags")
+            if isinstance(tags, list) and tags:
+                entry["tags"] = tags
+            category = metadata.get("category")
+            if isinstance(category, str) and category:
+                entry["category"] = category
+            difficulty = metadata.get("difficulty")
+            if isinstance(difficulty, str) and difficulty:
+                entry["difficulty"] = difficulty
 
         entries.append(entry)
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -624,6 +624,11 @@ def main() -> int:
         help="Install packages matching a profile from profiles.yaml",
     )
     parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="Show available install profiles and exit",
+    )
+    parser.add_argument(
         "--target",
         choices=["claude", "cursor", "codex", "gemini"],
         default="claude",
@@ -636,6 +641,24 @@ def main() -> int:
         help="Project directory for non-Claude targets (default: current directory)",
     )
     args = parser.parse_args()
+
+    if args.list_profiles:
+        profiles = load_profiles()
+        if not profiles:
+            console.print("[red]No profiles found in profiles.yaml[/red]")
+            return 1
+        table = Table(title="Install Profiles", show_lines=False)
+        table.add_column("Profile", style="cyan")
+        table.add_column("Description")
+        table.add_column("Includes", style="dim")
+        for name, profile in profiles.items():
+            includes = ", ".join(profile.get("includes", []))
+            desc = profile.get("description", "")
+            if profile.get("all"):
+                desc += " [bold](all packages)[/bold]"
+            table.add_row(name, desc, includes or "—")
+        console.print(table)
+        return 0
 
     if args.target != "claude":
         return install_to_platform(args.target, args.project_dir)

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""CLI search command for discovering armory packages from manifest.yaml."""
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import argparse
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from scripts.package_types import MANIFEST_PATH, TYPES
+
+PACKAGE_SECTIONS: tuple[str, ...] = tuple(t.manifest_section for t in TYPES.values())
+DEFAULT_LIMIT = 20
+
+console = Console()
+
+
+def load_packages() -> list[dict[str, str | list[str]]]:
+    """Load all packages from manifest.yaml, tagging each with its type."""
+    with open(MANIFEST_PATH) as f:
+        data = yaml.safe_load(f)
+
+    packages_section = data.get("packages", {})
+    results: list[dict[str, str | list[str]]] = []
+
+    for section in PACKAGE_SECTIONS:
+        pkg_type = section.rstrip("s")  # skills -> skill, agents -> agent, etc.
+        for entry in packages_section.get(section, []) or []:
+            entry["type"] = pkg_type
+            results.append(entry)
+
+    return results
+
+
+def score_package(pkg: dict[str, str | list[str]], query: str) -> int:
+    """Score a package against a search query."""
+    q = query.lower()
+    total = 0
+
+    name = str(pkg.get("name", "")).lower()
+    if name == q:
+        total += 10
+    elif q in name or name in q:
+        total += 1
+
+    tags = pkg.get("tags", []) or []
+    if isinstance(tags, str):
+        tags = [tags]
+    for tag in tags:
+        if str(tag).lower() == q:
+            total += 5
+            break
+
+    category = str(pkg.get("category", "")).lower()
+    if category == q:
+        total += 4
+
+    description = str(pkg.get("description", "")).lower()
+    if q in description:
+        total += 2
+
+    return total
+
+
+def filter_packages(
+    packages: list[dict[str, str | list[str]]],
+    *,
+    pkg_type: str | None = None,
+    category: str | None = None,
+    tag: str | None = None,
+) -> list[dict[str, str | list[str]]]:
+    """Apply type/category/tag filters."""
+    results = packages
+    if pkg_type:
+        results = [p for p in results if p.get("type") == pkg_type]
+    if category:
+        cat_lower = category.lower()
+        results = [p for p in results if str(p.get("category", "")).lower() == cat_lower]
+    if tag:
+        tag_lower = tag.lower()
+        filtered: list[dict[str, str | list[str]]] = []
+        for p in results:
+            tags = p.get("tags", []) or []
+            if isinstance(tags, str):
+                tags = [tags]
+            if any(str(t).lower() == tag_lower for t in tags):
+                filtered.append(p)
+        results = filtered
+    return results
+
+
+def truncate(text: str, length: int = 60) -> str:
+    """Truncate text to length, appending ellipsis if needed."""
+    if len(text) <= length:
+        return text
+    return text[: length - 3] + "..."
+
+
+def print_results(
+    packages: list[dict[str, str | list[str]]],
+    query: str,
+    limit: int,
+) -> int:
+    """Score, sort, and print search results. Returns exit code."""
+    scored: list[tuple[int, str, dict[str, str | list[str]]]] = []
+    for pkg in packages:
+        s = score_package(pkg, query)
+        if s > 0:
+            scored.append((s, str(pkg.get("name", "")), pkg))
+
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    scored = scored[:limit]
+
+    if not scored:
+        console.print(f'No results for "{query}".', style="bold red")
+        return 1
+
+    console.print(
+        f'\nSearch results for "{query}" ({len(scored)} matches):\n',
+        style="bold",
+    )
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right", style="dim", width=4)
+    table.add_column("Type", width=8)
+    table.add_column("Name", width=24)
+    table.add_column("Version", width=8)
+    table.add_column("Category", width=14)
+    table.add_column("Score", justify="right", width=5)
+    table.add_column("Description", width=60)
+
+    for i, (s, _, pkg) in enumerate(scored, 1):
+        table.add_row(
+            str(i),
+            str(pkg.get("type", "")),
+            str(pkg.get("name", "")),
+            str(pkg.get("version", "")),
+            str(pkg.get("category", "")),
+            str(s),
+            truncate(str(pkg.get("description", ""))),
+        )
+
+    console.print(table)
+    return 0
+
+
+def list_categories(packages: list[dict[str, str | list[str]]]) -> int:
+    """Print all categories with counts."""
+    counts: Counter[str] = Counter()
+    for pkg in packages:
+        cat = str(pkg.get("category", "")).strip()
+        if cat:
+            counts[cat] += 1
+
+    if not counts:
+        console.print("No categories found in manifest.", style="bold red")
+        return 1
+
+    console.print("\nCategories:", style="bold")
+    for cat, count in sorted(counts.items()):
+        console.print(f"  {cat:<20} ({count:>3} packages)")
+    console.print()
+    return 0
+
+
+def list_tags(packages: list[dict[str, str | list[str]]]) -> int:
+    """Print all tags with counts, sorted by count descending."""
+    counts: Counter[str] = Counter()
+    for pkg in packages:
+        tags = pkg.get("tags", []) or []
+        if isinstance(tags, str):
+            tags = [tags]
+        for tag in tags:
+            t = str(tag).strip()
+            if t:
+                counts[t] += 1
+
+    if not counts:
+        console.print("No tags found in manifest.", style="bold red")
+        return 1
+
+    console.print("\nTags:", style="bold")
+    for tag, count in sorted(counts.items(), key=lambda x: (-x[1], x[0])):
+        console.print(f"  {tag:<20} ({count:>3} packages)")
+    console.print()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="armory-search",
+        description="Search armory packages from manifest.yaml",
+    )
+    parser.add_argument("query", nargs="?", default=None, help="Search keyword")
+    parser.add_argument("--type", dest="pkg_type", choices=list(TYPES.keys()), help="Filter by package type")
+    parser.add_argument("--category", help="Filter by category")
+    parser.add_argument("--tag", help="Filter by tag")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Max results (default: 20)")
+    parser.add_argument("--list-categories", action="store_true", help="Show all categories with counts")
+    parser.add_argument("--list-tags", action="store_true", help="Show all tags with counts")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    packages = load_packages()
+
+    if args.list_categories:
+        sys.exit(list_categories(packages))
+
+    if args.list_tags:
+        sys.exit(list_tags(packages))
+
+    if not args.query:
+        parser.error("a search query is required (or use --list-categories / --list-tags)")
+
+    filtered = filter_packages(
+        packages,
+        pkg_type=args.pkg_type,
+        category=args.category,
+        tag=args.tag,
+    )
+
+    sys.exit(print_results(filtered, args.query, args.limit))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/adr-writer/SKILL.md
+++ b/skills/adr-writer/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: adr-writer
-description: >
-  Generates Architecture Decision Records (ADRs) capturing context, decision rationale,
-  alternatives considered, and projected consequences. Produces numbered, status-tracked
-  documents following the standard ADR format with proper metadata lifecycle.
-  Triggers on: "write an ADR", "document this decision", "architecture decision record",
-  "why did we choose", "capture this decision", "record the decision", "ADR for",
-  "document the architecture", "decision record", "design decision", "technical decision".
-  Use this skill when an architectural or technical decision needs to be documented.
+description: 'Generates Architecture Decision Records (ADRs) capturing context, decision
+  rationale, alternatives considered, and projected consequences. Produces numbered,
+  status-tracked documents following the standard ADR format with proper metadata
+  lifecycle. Triggers on: "write an ADR", "document this decision", "architecture
+  decision record", "why did we choose", "capture this decision", "record the decision",
+  "ADR for", "document the architecture", "decision record", "design decision", "technical
+  decision". Use this skill when an architectural or technical decision needs to be
+  documented.
+
+  '
 metadata:
   version: 1.1.0
+  category: operations
+  tags: [architecture, decision-record, documentation, adr]
+  difficulty: intermediate
 ---
-
 # ADR Writer
 
 Captures architecture decisions in a lightweight, structured format that preserves

--- a/skills/agent-builder/SKILL.md
+++ b/skills/agent-builder/SKILL.md
@@ -1,10 +1,19 @@
 ---
 name: agent-builder
-description: Build AI agents and automate Claude Code programmatically using the Claude Agent SDK and headless CLI mode. Use this skill when you need to build an agent, create a Claude agent, make a bot, work with the agent SDK, run Claude in headless mode, write programmatic agent code, automate with Claude, create an MCP server builder, or query Claude programmatically. Covers the Python SDK, the claude -p headless interface, custom tool creation with SDK MCP servers, hooks for deterministic control, session management, and CLI flag reference. Authentication uses existing ~/.claude/ config — no API keys required.
+description: Build AI agents and automate Claude Code programmatically using the Claude
+  Agent SDK and headless CLI mode. Use this skill when you need to build an agent,
+  create a Claude agent, make a bot, work with the agent SDK, run Claude in headless
+  mode, write programmatic agent code, automate with Claude, create an MCP server
+  builder, or query Claude programmatically. Covers the Python SDK, the claude -p
+  headless interface, custom tool creation with SDK MCP servers, hooks for deterministic
+  control, session management, and CLI flag reference. Authentication uses existing
+  ~/.claude/ config — no API keys required.
 metadata:
   version: 1.1.0
+  category: development
+  tags: [agent-sdk, headless, automation, mcp]
+  difficulty: intermediate
 ---
-
 # Agent Builder - Claude SDK & CLI Expert
 
 **Triggers:**

--- a/skills/api-docs-generator/SKILL.md
+++ b/skills/api-docs-generator/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: api-docs-generator
-description: >
-  Audits and enhances API documentation for FastAPI and REST endpoints. Identifies
-  missing descriptions, incomplete response codes, missing examples, and generates
-  enhanced docstrings, Pydantic model examples, and OpenAPI spec improvements.
-  Triggers on: "generate API docs", "document this API", "OpenAPI for",
-  "add examples to", "improve docstrings", "API documentation audit", "FastAPI docs",
-  "document endpoints", "API reference", "swagger docs", "REST API docs",
-  "endpoint documentation", "response documentation".
-  Use this skill when API endpoints need documentation or documentation audit.
+description: 'Audits and enhances API documentation for FastAPI and REST endpoints.
+  Identifies missing descriptions, incomplete response codes, missing examples, and
+  generates enhanced docstrings, Pydantic model examples, and OpenAPI spec improvements.
+  Triggers on: "generate API docs", "document this API", "OpenAPI for", "add examples
+  to", "improve docstrings", "API documentation audit", "FastAPI docs", "document
+  endpoints", "API reference", "swagger docs", "REST API docs", "endpoint documentation",
+  "response documentation". Use this skill when API endpoints need documentation or
+  documentation audit.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [api, documentation, openapi, fastapi]
+  difficulty: intermediate
 ---
-
 # API Docs Generator
 
 Audits API endpoint documentation for completeness, generates enhanced docstrings with

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: architecture-diagram
-description: >
-  Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline
-  SVG icons, CSS Grid nested container layout, SVG path connection overlays, and color-coded
-  connection legends. Triggers on: "architecture diagram", "infra diagram", "system diagram",
-  "deployment diagram", "network diagram", "topology", "draw architecture", "visualize
-  architecture", "system topology", or any request for visual representation of system
-  components, containment hierarchy, and interconnections. For architecture reviews, audits,
-  critiques, or design assessments, use architecture-reviewer instead.
+description: 'Generate detailed layered architecture diagrams as self-contained HTML
+  artifacts with inline SVG icons, CSS Grid nested container layout, SVG path connection
+  overlays, and color-coded connection legends. Triggers on: "architecture diagram",
+  "infra diagram", "system diagram", "deployment diagram", "network diagram", "topology",
+  "draw architecture", "visualize architecture", "system topology", or any request
+  for visual representation of system components, containment hierarchy, and interconnections.
+  For architecture reviews, audits, critiques, or design assessments, use architecture-reviewer
+  instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [architecture, diagram, visualization, svg]
+  difficulty: intermediate
 ---
-
 # Architecture Diagram Generator
 
 Produces self-contained `.html` files: inline SVG icons, CSS Grid nested zones, JS-driven SVG connection overlay with color-coded semantic line types and arrowhead markers. Zero external dependencies.

--- a/skills/architecture-reviewer/SKILL.md
+++ b/skills/architecture-reviewer/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: architecture-reviewer
-description: >
-  Architecture reviews across 7 dimensions: structural integrity, scalability, enterprise
-  readiness (SOC2/HIPAA/GDPR/PCI-DSS), performance, security, operational excellence, and
-  data architecture. Produces scored reports with prioritized recommendations. Three modes:
-  (1) Codebase review — evidence-based analysis of source code, configs, IaC; (2) Document
-  review — risk-based analysis of design docs, RFCs, specs; (3) Hybrid — drift detection
-  between intent and implementation. Triggers on: "review architecture", "critique design",
-  "audit system", "evaluate codebase", "find design flaws", "assess scalability", "check
-  security", "enterprise readiness", "architecture assessment", "technical due diligence",
-  or when user provides a system design document or codebase and asks for feedback or
-  improvements. For architecture diagrams, visuals, or topology drawings, use
-  architecture-diagram instead.
+description: 'Architecture reviews across 7 dimensions: structural integrity, scalability,
+  enterprise readiness (SOC2/HIPAA/GDPR/PCI-DSS), performance, security, operational
+  excellence, and data architecture. Produces scored reports with prioritized recommendations.
+  Three modes: (1) Codebase review — evidence-based analysis of source code, configs,
+  IaC; (2) Document review — risk-based analysis of design docs, RFCs, specs; (3)
+  Hybrid — drift detection between intent and implementation. Triggers on: "review
+  architecture", "critique design", "audit system", "evaluate codebase", "find design
+  flaws", "assess scalability", "check security", "enterprise readiness", "architecture
+  assessment", "technical due diligence", or when user provides a system design document
+  or codebase and asks for feedback or improvements. For architecture diagrams, visuals,
+  or topology drawings, use architecture-diagram instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [architecture, scalability, enterprise, security-audit]
+  difficulty: advanced
 ---
-
 # Architecture Reviewer
 
 Systematic, framework-driven architecture review skill. Acts as a senior staff/principal

--- a/skills/benchmark-runner/SKILL.md
+++ b/skills/benchmark-runner/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: benchmark-runner
-description: >
-  Designs structured benchmarks for comparing algorithms, models, or implementations.
+description: 'Designs structured benchmarks for comparing algorithms, models, or implementations.
   Selects appropriate metrics (latency, throughput, memory, accuracy), designs representative
-  test cases, captures hardware/software context, produces comparison tables with tradeoff
-  analysis, and includes reproduction instructions.
-  Triggers on: "benchmark", "compare performance", "which is faster", "latency comparison",
-  "memory comparison", "run benchmark", "design benchmark", "compare implementations",
-  "evaluate algorithms", "performance comparison", "throughput test", "speed test".
-  Use this skill when comparing two or more implementations, algorithms, or models.
+  test cases, captures hardware/software context, produces comparison tables with
+  tradeoff analysis, and includes reproduction instructions. Triggers on: "benchmark",
+  "compare performance", "which is faster", "latency comparison", "memory comparison",
+  "run benchmark", "design benchmark", "compare implementations", "evaluate algorithms",
+  "performance comparison", "throughput test", "speed test". Use this skill when comparing
+  two or more implementations, algorithms, or models.
+
+  '
 metadata:
   version: 1.1.0
+  category: data
+  tags: [benchmarking, performance, comparison, metrics]
+  difficulty: intermediate
 ---
-
 # Benchmark Runner
 
 Standardizes performance comparison methodology: metric selection, test case design,

--- a/skills/changelog-composer/SKILL.md
+++ b/skills/changelog-composer/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: changelog-composer
-description: >
-  Generates structured changelogs and release notes from git history and PR descriptions.
-  Classifies changes into breaking, features, fixes, performance, and docs. Filters
-  internal-only changes, detects breaking changes, and produces human-readable entries
-  linked to source PRs.
-  Triggers on: "generate changelog", "write release notes", "compose changelog",
-  "what changed since", "changes since last release", "prepare release",
-  "release notes for", "changelog for", "summarize changes", "diff since tag".
-  Use this skill when preparing a release and needing to summarize changes for users.
+description: 'Generates structured changelogs and release notes from git history and
+  PR descriptions. Classifies changes into breaking, features, fixes, performance,
+  and docs. Filters internal-only changes, detects breaking changes, and produces
+  human-readable entries linked to source PRs. Triggers on: "generate changelog",
+  "write release notes", "compose changelog", "what changed since", "changes since
+  last release", "prepare release", "release notes for", "changelog for", "summarize
+  changes", "diff since tag". Use this skill when preparing a release and needing
+  to summarize changes for users.
+
+  '
 metadata:
   version: 1.1.0
+  category: content
+  tags: [changelog, release-notes, git-history, versioning]
+  difficulty: intermediate
 ---
-
 # Changelog Composer
 
 Transforms raw git history and PR descriptions into polished, audience-appropriate

--- a/skills/code-refiner/SKILL.md
+++ b/skills/code-refiner/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: code-refiner
-description: >
-  Deep code simplification, refactoring, and quality refinement. Analyzes structural complexity,
-  anti-patterns, and readability debt, then applies targeted refactoring preserving exact behavior.
-  Language-agnostic: Python, Go, TypeScript/JavaScript, Rust. Use this skill when the goal is
-  simplification and clarity rather than bug-finding. Triggers on: "simplify this code",
-  "clean up my code", "refactor for clarity", "reduce complexity", "make this more readable",
-  "code quality pass", "tech debt cleanup", "run the code refiner", "simplify recent changes",
-  "this code is messy", "too much nesting", "this function is too long", "clean this up before
-  I PR it", "tidy up my code", cyclomatic complexity, cognitive complexity, code smells.
+description: 'Deep code simplification, refactoring, and quality refinement. Analyzes
+  structural complexity, anti-patterns, and readability debt, then applies targeted
+  refactoring preserving exact behavior. Language-agnostic: Python, Go, TypeScript/JavaScript,
+  Rust. Use this skill when the goal is simplification and clarity rather than bug-finding.
+  Triggers on: "simplify this code", "clean up my code", "refactor for clarity", "reduce
+  complexity", "make this more readable", "code quality pass", "tech debt cleanup",
+  "run the code refiner", "simplify recent changes", "this code is messy", "too much
+  nesting", "this function is too long", "clean this up before I PR it", "tidy up
+  my code", cyclomatic complexity, cognitive complexity, code smells.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [refactoring, code-quality, simplification, readability]
+  difficulty: intermediate
 ---
-
 # Code Refiner
 
 A structured, multi-pass code refinement skill that transforms complex, verbose, or tangled code

--- a/skills/competitive-analyzer/SKILL.md
+++ b/skills/competitive-analyzer/SKILL.md
@@ -1,27 +1,25 @@
 ---
 name: competitive-analyzer
-description: >
-  Systematic competitive landscape analysis covering Porter's Five Forces,
-  competitor discovery, feature and pricing comparison matrices, market
-  positioning maps, and moat/defensibility assessment. Uses WebSearch to
-  identify direct, indirect, and potential competitors across Product Hunt,
-  G2, Capterra, and Crunchbase. Produces structured reports with force
-  scorecards, feature gap analysis, pricing positioning, white space
-  identification, and strategic recommendations. Triggers on: "competitive
-  analysis", "competitor comparison", "competitive landscape", "Porter's
-  Five Forces", "feature comparison matrix", "pricing analysis", "market
-  positioning", "moat assessment", "competitive threat", "defensibility
-  analysis", "compare competitors", "competitive intelligence". Use this
-  skill when analyzing competitors, comparing features, or evaluating
-  market positioning and defensibility.
+description: 'Systematic competitive landscape analysis covering Porter''s Five Forces,
+  competitor discovery, feature and pricing comparison matrices, market positioning
+  maps, and moat/defensibility assessment. Uses WebSearch to identify direct, indirect,
+  and potential competitors across Product Hunt, G2, Capterra, and Crunchbase. Produces
+  structured reports with force scorecards, feature gap analysis, pricing positioning,
+  white space identification, and strategic recommendations. Triggers on: "competitive
+  analysis", "competitor comparison", "competitive landscape", "Porter''s Five Forces",
+  "feature comparison matrix", "pricing analysis", "market positioning", "moat assessment",
+  "competitive threat", "defensibility analysis", "compare competitors", "competitive
+  intelligence". Use this skill when analyzing competitors, comparing features, or
+  evaluating market positioning and defensibility.
+
+  '
 metadata:
   version: 1.0.0
-  complements:
-    - market-analyzer
-    - tavily
-    - web-fetch
+  complements: [market-analyzer, tavily, web-fetch]
+  category: business
+  tags: [competitive-analysis, market, porters-five-forces, positioning]
+  difficulty: advanced
 ---
-
 # Competitive Analyzer
 
 Systematic competitive landscape analysis: discovery, force analysis, feature comparison, pricing, positioning, and defensibility assessment.

--- a/skills/concept-to-image/SKILL.md
+++ b/skills/concept-to-image/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: concept-to-image
-description: >
-  Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG image file.
-  Use this skill when the user explicitly needs an image file output (PNG or SVG). This includes: concept diagrams,
-  flowcharts, comparison charts, process visuals, educational diagrams, social media graphics, data visualizations,
-  posters, cards, badges, icons, logo sketches, or any "make me an image of X" request achievable with HTML/CSS/SVG
-  rather than photographic AI generation. Also trigger when the user has an existing HTML visual and wants to
-  export/convert it to PNG or SVG. Trigger phrases: "create an image of", "export as PNG", "save as SVG",
-  "concept to image", "turn this into an image", "screenshot this HTML", "design a graphic for export".
-  For interactive HTML visuals opened in a browser, use static-web-artifacts-builder instead.
+description: 'Turn any concept, idea, or description into a polished static HTML visual,
+  then export it as a PNG or SVG image file. Use this skill when the user explicitly
+  needs an image file output (PNG or SVG). This includes: concept diagrams, flowcharts,
+  comparison charts, process visuals, educational diagrams, social media graphics,
+  data visualizations, posters, cards, badges, icons, logo sketches, or any "make
+  me an image of X" request achievable with HTML/CSS/SVG rather than photographic
+  AI generation. Also trigger when the user has an existing HTML visual and wants
+  to export/convert it to PNG or SVG. Trigger phrases: "create an image of", "export
+  as PNG", "save as SVG", "concept to image", "turn this into an image", "screenshot
+  this HTML", "design a graphic for export". For interactive HTML visuals opened in
+  a browser, use static-web-artifacts-builder instead.
+
+  '
 metadata:
   version: 1.2.0
+  category: business
+  tags: [image-generation, html-to-png, svg, visual-design]
+  difficulty: intermediate
 ---
-
 # Concept to Image
 
 Creates polished visuals from concepts using HTML/CSS/SVG as a refineable intermediate, then exports to PNG or SVG.

--- a/skills/concept-to-video/SKILL.md
+++ b/skills/concept-to-video/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: concept-to-video
-description: >
-  Turn any concept into an animated explainer video using Manim (Python). Use whenever the user
-  wants animated visualizations, motion graphics, or video output (MP4/GIF) for technical concepts.
-  Covers: architecture animations, data flows, algorithm step-throughs, pipeline explainers,
-  math proofs, comparisons, agent interactions, training loops, image embedding, multi-scene
-  composition. Supports audio overlay via ffmpeg, parametric templates, and subtitles. Works
-  headless — no browser or Node.js required. Also trigger for Manim scene edits or re-renders.
-  Trigger on: "create a video", "animate this", "make an explainer", "concept to video",
-  "manim animation", "show this as a video", "motion graphic", "visualize this process",
-  "add voiceover to video", "animate with audio", or any concept + video/animation request.
-  For branded motion graphics or React-based video, use remotion-video instead.
+description: 'Turn any concept into an animated explainer video using Manim (Python).
+  Use whenever the user wants animated visualizations, motion graphics, or video output
+  (MP4/GIF) for technical concepts. Covers: architecture animations, data flows, algorithm
+  step-throughs, pipeline explainers, math proofs, comparisons, agent interactions,
+  training loops, image embedding, multi-scene composition. Supports audio overlay
+  via ffmpeg, parametric templates, and subtitles. Works headless — no browser or
+  Node.js required. Also trigger for Manim scene edits or re-renders. Trigger on:
+  "create a video", "animate this", "make an explainer", "concept to video", "manim
+  animation", "show this as a video", "motion graphic", "visualize this process",
+  "add voiceover to video", "animate with audio", or any concept + video/animation
+  request. For branded motion graphics or React-based video, use remotion-video instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: visualization
+  tags: [video, manim, animation, explainer]
+  difficulty: advanced
 ---
-
 # Concept to Video
 
 Creates animated explainer videos from concepts using Manim (Python) as a programmatic animation engine.

--- a/skills/debug-investigator/SKILL.md
+++ b/skills/debug-investigator/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: debug-investigator
-description: >
-  Hypothesis-driven debugging methodology: ranked hypotheses with confirming/refuting tests,
-  git bisect strategy, log analysis, instrumentation point planning, and minimal reproduction
-  design. Triggers on: "debug this systematically", "root cause analysis", "bisect this bug",
-  "rank hypotheses for this error", "help me isolate this issue", "create a minimal
-  reproduction", "instrumentation plan for this bug", "why does this keep failing".
-  The differentiator is the structured investigation methodology (hypothesis ranking,
-  bisection strategy, instrumentation points) — use this skill for non-obvious bugs that
-  need systematic investigation, not simple errors the model diagnoses directly.
-  NOT for abstract reasoning or problem decomposition without a specific error — the model
-  handles general reasoning natively.
+description: 'Hypothesis-driven debugging methodology: ranked hypotheses with confirming/refuting
+  tests, git bisect strategy, log analysis, instrumentation point planning, and minimal
+  reproduction design. Triggers on: "debug this systematically", "root cause analysis",
+  "bisect this bug", "rank hypotheses for this error", "help me isolate this issue",
+  "create a minimal reproduction", "instrumentation plan for this bug", "why does
+  this keep failing". The differentiator is the structured investigation methodology
+  (hypothesis ranking, bisection strategy, instrumentation points) — use this skill
+  for non-obvious bugs that need systematic investigation, not simple errors the model
+  diagnoses directly. NOT for abstract reasoning or problem decomposition without
+  a specific error — the model handles general reasoning natively.
+
+  '
 metadata:
   version: 1.1.0
+  category: development
+  tags: [debugging, root-cause, hypothesis, bisect]
+  difficulty: intermediate
 ---
-
 # Debug Investigator
 
 Structured debugging methodology that replaces ad-hoc exploration with hypothesis-driven

--- a/skills/dependency-audit/SKILL.md
+++ b/skills/dependency-audit/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: dependency-audit
-description: >
-  Audits project dependencies for license compliance, maintenance health, security
-  vulnerabilities, and bloat. Analyzes both direct and transitive dependency trees,
-  detects abandoned packages, identifies license conflicts (copyleft, unknown), checks
-  for known CVEs, and finds unused or duplicate dependencies.
-  Triggers on: "audit dependencies", "dependency check", "license check",
-  "dependency health", "abandoned packages", "bloat check", "unused dependencies",
-  "security audit dependencies", "dependency review", "license compliance",
-  "package audit", "supply chain", "dependency risk".
-  Use this skill when reviewing project dependencies for risk.
+description: 'Audits project dependencies for license compliance, maintenance health,
+  security vulnerabilities, and bloat. Analyzes both direct and transitive dependency
+  trees, detects abandoned packages, identifies license conflicts (copyleft, unknown),
+  checks for known CVEs, and finds unused or duplicate dependencies. Triggers on:
+  "audit dependencies", "dependency check", "license check", "dependency health",
+  "abandoned packages", "bloat check", "unused dependencies", "security audit dependencies",
+  "dependency review", "license compliance", "package audit", "supply chain", "dependency
+  risk". Use this skill when reviewing project dependencies for risk.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [dependencies, vulnerabilities, licenses, supply-chain]
+  difficulty: intermediate
 ---
-
 # Dependency Audit
 
 Comprehensive dependency risk assessment: license compatibility analysis, maintenance

--- a/skills/doc-condenser/SKILL.md
+++ b/skills/doc-condenser/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: doc-condenser
-description: "DEPRECATED: The base model handles document condensation and summarization natively at high quality. This skill no longer provides meaningful uplift. Retained for reference only."
+description: 'DEPRECATED: The base model handles document condensation and summarization
+  natively at high quality. This skill no longer provides meaningful uplift. Retained
+  for reference only.'
 metadata:
   version: 1.1.0
   status: deprecated
+  category: review
+  tags: [documentation, summarization, technical-writing, conciseness]
+  difficulty: beginner
 ---
-
 > **DEPRECATED** — Modern Claude models condense and summarize technical documentation
 > natively with comparable quality. The output format preferences encoded here (40% length
 > cap, tables over prose, paths first) are too generic to justify skill overhead. Retained

--- a/skills/engineering-retro/SKILL.md
+++ b/skills/engineering-retro/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: engineering-retro
-description: >
-  Git-based engineering retrospective analyzing commit history, PR patterns, and
-  development velocity over a configurable time window. Use this skill when the user
-  asks for a retrospective, retro, sprint review, weekly review, engineering review,
-  development summary, commit analysis, team velocity report, or says "what did we
-  ship", "what happened this week", "engineering retro", "sprint retro", "dev summary",
-  "/engineering-retro". Supports time windows (7d default, 24h, 14d, 30d) and
-  monorepo path scoping.
+description: 'Git-based engineering retrospective analyzing commit history, PR patterns,
+  and development velocity over a configurable time window. Use this skill when the
+  user asks for a retrospective, retro, sprint review, weekly review, engineering
+  review, development summary, commit analysis, team velocity report, or says "what
+  did we ship", "what happened this week", "engineering retro", "sprint retro", "dev
+  summary", "/engineering-retro". Supports time windows (7d default, 24h, 14d, 30d)
+  and monorepo path scoping.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [retrospective, velocity, git-analysis, sprint]
+  difficulty: intermediate
 ---
-
 # Engineering Retrospective
 
 Generate a structured, git-based engineering retrospective for a configurable time window. This is a **read-only analysis** — no files are modified except the optional JSON snapshot.

--- a/skills/estimate-calibrator/SKILL.md
+++ b/skills/estimate-calibrator/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: estimate-calibrator
-description: >
-  Produces calibrated three-point estimates (best/likely/worst case) with explicit
-  unknowns, confidence intervals, and assumption documentation. Breaks work into
-  atomic units, identifies technical and scope uncertainties, calculates PERT ranges,
-  and provides confidence rationale.
-  Triggers on: "estimate this", "how long will this take", "effort estimate",
-  "time estimate", "best case worst case", "confidence interval", "sizing",
-  "estimate effort", "how big is this", "story points", "t-shirt sizing",
-  "estimate the work", "PERT".
-  NOT for task decomposition, implementation plans, or dependency mapping — use task-decomposer instead.
-  Use this skill when a task or project needs an effort estimate with explicit uncertainty.
+description: 'Produces calibrated three-point estimates (best/likely/worst case) with
+  explicit unknowns, confidence intervals, and assumption documentation. Breaks work
+  into atomic units, identifies technical and scope uncertainties, calculates PERT
+  ranges, and provides confidence rationale. Triggers on: "estimate this", "how long
+  will this take", "effort estimate", "time estimate", "best case worst case", "confidence
+  interval", "sizing", "estimate effort", "how big is this", "story points", "t-shirt
+  sizing", "estimate the work", "PERT". NOT for task decomposition, implementation
+  plans, or dependency mapping — use task-decomposer instead. Use this skill when
+  a task or project needs an effort estimate with explicit uncertainty.
+
+  '
 metadata:
   version: 1.1.0
+  category: development
+  tags: [estimation, pert, confidence-interval, planning]
+  difficulty: intermediate
 ---
-
 # Estimate Calibrator
 
 Replaces single-point guesses with structured three-point estimates: decomposes work

--- a/skills/feasibility-assessor/SKILL.md
+++ b/skills/feasibility-assessor/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: feasibility-assessor
-description: >
-  Evaluate whether a business idea, product concept, or feature is technically buildable
-  and financially viable. Covers unit economics (CAC, LTV, margins), revenue modeling,
-  break-even analysis, architecture risk scoring, build estimation, and integrated
-  feasibility verdicts. Triggers on: feasibility assessment, viability analysis, unit
-  economics review, business case evaluation, technical risk assessment, break-even
-  calculation, build vs buy analysis, go/no-go decision, idea validation, market
-  feasibility, cost-benefit analysis, ROI projection. Use this skill when someone needs
-  to determine whether a business idea, feature, or product is worth pursuing from
-  financial and technical perspectives.
+description: 'Evaluate whether a business idea, product concept, or feature is technically
+  buildable and financially viable. Covers unit economics (CAC, LTV, margins), revenue
+  modeling, break-even analysis, architecture risk scoring, build estimation, and
+  integrated feasibility verdicts. Triggers on: feasibility assessment, viability
+  analysis, unit economics review, business case evaluation, technical risk assessment,
+  break-even calculation, build vs buy analysis, go/no-go decision, idea validation,
+  market feasibility, cost-benefit analysis, ROI projection. Use this skill when someone
+  needs to determine whether a business idea, feature, or product is worth pursuing
+  from financial and technical perspectives.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [feasibility, unit-economics, viability, business-case]
+  difficulty: advanced
 ---
-
 # Feasibility Assessor
 
 Evaluate business ideas and features across two tracks: financial viability and technical feasibility. Produce an integrated verdict with actionable de-risking recommendations.

--- a/skills/filesystem/SKILL.md
+++ b/skills/filesystem/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: filesystem
-description: >
-  File and directory operations using Claude Code built-in tools — replaces the
-  Filesystem MCP server. Maps all 11 MCP tools to native equivalents: Read, Write,
+description: 'File and directory operations using Claude Code built-in tools — replaces
+  the Filesystem MCP server. Maps all 11 MCP tools to native equivalents: Read, Write,
   Edit, Glob, Grep, and Bash. Covers file reading with line ranges, parallel reads,
   pattern-based file search, regex content search, directory listing, tree traversal,
-  move/copy/rename, and metadata inspection. Trigger phrases: "read this file",
-  "write to file", "create a file", "edit file", "find files matching", "search for
-  text in files", "list directory", "show directory tree", "move file", "rename file",
+  move/copy/rename, and metadata inspection. Trigger phrases: "read this file", "write
+  to file", "create a file", "edit file", "find files matching", "search for text
+  in files", "list directory", "show directory tree", "move file", "rename file",
   "copy file", "file info", "find all Python files", "search codebase for". Use this
   skill when performing file operations, navigating codebases, or managing directories.
+
+  '
 metadata:
   version: 1.1.0
+  category: content
+  tags: [files, directories, search, navigation]
+  difficulty: beginner
 ---
-
 # Filesystem
 
 All file and directory operations use Claude Code's built-in tools. No MCP server

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,21 +1,25 @@
 ---
 name: github
-description: >
-  GitHub CLI operations via `gh` for issues, pull requests, CI/Actions, releases, repos, search,
-  gists, and the REST/GraphQL API. Structured output with `--json` and `--jq` for parsing.
-  Covers `gh issue create/list/view/edit/close`, `gh pr create/review/merge/checks`,
-  `gh run list/view/rerun/watch`, `gh release create`, `gh search repos/issues/prs/code`,
-  `gh api` for REST and GraphQL queries, and `gh gist` operations. Includes error handling
-  for HTTP 401/403/404/422/429, scope troubleshooting, and rate limit management.
-  Trigger phrases: "create an issue", "file a bug", "open a ticket", "submit a PR",
-  "raise a pull request", "check pipeline", "view test results", "CI failing",
-  "why did CI fail", "check CI status", "merge a PR", "manage releases",
-  "query the GitHub API", "search repositories", "triage workflows",
-  "automate GitHub operations". Also triggers when the user pastes a GitHub URL.
+description: 'GitHub CLI operations via `gh` for issues, pull requests, CI/Actions,
+  releases, repos, search, gists, and the REST/GraphQL API. Structured output with
+  `--json` and `--jq` for parsing. Covers `gh issue create/list/view/edit/close`,
+  `gh pr create/review/merge/checks`, `gh run list/view/rerun/watch`, `gh release
+  create`, `gh search repos/issues/prs/code`, `gh api` for REST and GraphQL queries,
+  and `gh gist` operations. Includes error handling for HTTP 401/403/404/422/429,
+  scope troubleshooting, and rate limit management. Trigger phrases: "create an issue",
+  "file a bug", "open a ticket", "submit a PR", "raise a pull request", "check pipeline",
+  "view test results", "CI failing", "why did CI fail", "check CI status", "merge
+  a PR", "manage releases", "query the GitHub API", "search repositories", "triage
+  workflows", "automate GitHub operations". Also triggers when the user pastes a GitHub
+  URL.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [github, cli, issues, pull-requests]
+  difficulty: intermediate
 ---
-
 # GitHub
 
 All GitHub operations use the `gh` CLI. Prefer `--json` with `--jq` for structured,

--- a/skills/gpu-optimizer/SKILL.md
+++ b/skills/gpu-optimizer/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: gpu-optimizer
-description: Expert GPU optimization for modern consumer GPUs (8-24GB VRAM). Use this skill when you need to optimize GPU training, speed up CUDA code, reduce OOM errors, tune XGBoost for GPU, migrate NumPy to CuPy, make a model faster, manage GPU memory, optimize VRAM usage, or benchmark PyTorch. Covers mixed precision, gradient checkpointing, XGBoost GPU acceleration, CuPy/cuDF migration, vectorization, torch.compile, and diagnostics. NVIDIA GPUs only. PyTorch, XGBoost, and RAPIDS frameworks.
+description: Expert GPU optimization for modern consumer GPUs (8-24GB VRAM). Use this
+  skill when you need to optimize GPU training, speed up CUDA code, reduce OOM errors,
+  tune XGBoost for GPU, migrate NumPy to CuPy, make a model faster, manage GPU memory,
+  optimize VRAM usage, or benchmark PyTorch. Covers mixed precision, gradient checkpointing,
+  XGBoost GPU acceleration, CuPy/cuDF migration, vectorization, torch.compile, and
+  diagnostics. NVIDIA GPUs only. PyTorch, XGBoost, and RAPIDS frameworks.
 metadata:
   version: 1.1.0
+  category: data
+  tags: [gpu, cuda, vram, pytorch]
+  difficulty: advanced
 ---
-
 # GPU Optimizer
 
 Expert GPU optimization for consumer GPUs with 8–24GB VRAM. Evidence-based patterns only.

--- a/skills/html-presentation/SKILL.md
+++ b/skills/html-presentation/SKILL.md
@@ -1,10 +1,22 @@
 ---
 name: html-presentation
-description: Convert any document, outline, or content into a polished, self-contained HTML slide presentation. Use this skill whenever the user wants to create a presentation, slide deck, pitch deck, or talk from a document, markdown file, outline, notes, or any textual content and wants the output as an HTML file (not PPTX). Also trigger when the user asks for an "HTML presentation", "web-based slides", "reveal.js deck", "browser presentation", or wants to convert a document into slides they can present from a browser. Supports two navigation modes - horizontal (left/right, Reveal.js-powered) and vertical scroll (top-to-bottom, keyboard/scroll navigation). Includes multiple visual themes (dark editorial, light minimal, corporate, hacker terminal). Consider asking the user for clarification on theme, navigation direction, and content structure if not already specified.
+description: Convert any document, outline, or content into a polished, self-contained
+  HTML slide presentation. Use this skill whenever the user wants to create a presentation,
+  slide deck, pitch deck, or talk from a document, markdown file, outline, notes,
+  or any textual content and wants the output as an HTML file (not PPTX). Also trigger
+  when the user asks for an "HTML presentation", "web-based slides", "reveal.js deck",
+  "browser presentation", or wants to convert a document into slides they can present
+  from a browser. Supports two navigation modes - horizontal (left/right, Reveal.js-powered)
+  and vertical scroll (top-to-bottom, keyboard/scroll navigation). Includes multiple
+  visual themes (dark editorial, light minimal, corporate, hacker terminal). Consider
+  asking the user for clarification on theme, navigation direction, and content structure
+  if not already specified.
 metadata:
   version: 1.1.0
+  category: visualization
+  tags: [slides, presentation, reveal-js, html]
+  difficulty: intermediate
 ---
-
 # HTML Presentation Skill
 
 Convert documents, outlines, or freeform content into polished, self-contained HTML slide presentations with keyboard and scroll navigation.

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: humanize
-description: >
-  Detect and remove AI-generated writing patterns from text while preserving semantic meaning
-  and factual accuracy. Rewrites text to sound natural, varied, and human-authored across domains
-  including academic, technical, blog, professional, and social media writing. Use this skill when
-  the user asks to "humanize text", "make this sound human", "remove AI patterns", "rewrite to
-  sound natural", "make this less AI", "de-slop this", "clean up AI writing", "make this not
-  sound like ChatGPT", or provides AI-generated text and asks for a natural rewrite. Also trigger
-  when reviewing drafts for AI tells, checking if text sounds AI-generated, or requesting a
-  "human pass" on content.
+description: 'Detect and remove AI-generated writing patterns from text while preserving
+  semantic meaning and factual accuracy. Rewrites text to sound natural, varied, and
+  human-authored across domains including academic, technical, blog, professional,
+  and social media writing. Use this skill when the user asks to "humanize text",
+  "make this sound human", "remove AI patterns", "rewrite to sound natural", "make
+  this less AI", "de-slop this", "clean up AI writing", "make this not sound like
+  ChatGPT", or provides AI-generated text and asks for a natural rewrite. Also trigger
+  when reviewing drafts for AI tells, checking if text sounds AI-generated, or requesting
+  a "human pass" on content.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [writing, ai-detection, natural-language, rewriting]
+  difficulty: intermediate
 ---
-
 # Humanize: AI Pattern Detection and Removal
 
 Remove AI-generated writing patterns from text. Produce natural, human-sounding output that preserves meaning.

--- a/skills/idea-validator/SKILL.md
+++ b/skills/idea-validator/SKILL.md
@@ -1,27 +1,26 @@
 ---
 name: idea-validator
-description: >
-  Comprehensive business idea validation orchestrator that delegates parallel
-  research to sub-agents and synthesizes a structured report. Constructs a Lean
-  Canvas, applies Jobs-to-be-Done analysis, spawns market research, competitive
-  analysis, and feasibility assessment agents, runs SWOT/PESTLE, and produces a
-  weighted validation scorecard with verdict and recommended experiments.
-  Triggers on: "validate this idea", "assess this business idea", "evaluate my
-  startup idea", "analyze this concept", "critique this business plan", "review
-  my idea", "check if this idea is viable", "audit this business concept",
-  "is this idea worth pursuing", "rate this startup idea", "score this business
-  idea", "business idea validation", "idea feasibility check", "validate my
-  pitch", "evaluate this product concept". Use this skill when the user presents
-  a business idea, startup concept, product proposal, feature pitch, or pivot
-  scenario and wants a structured viability assessment with scoring.
+description: 'Comprehensive business idea validation orchestrator that delegates parallel
+  research to sub-agents and synthesizes a structured report. Constructs a Lean Canvas,
+  applies Jobs-to-be-Done analysis, spawns market research, competitive analysis,
+  and feasibility assessment agents, runs SWOT/PESTLE, and produces a weighted validation
+  scorecard with verdict and recommended experiments. Triggers on: "validate this
+  idea", "assess this business idea", "evaluate my startup idea", "analyze this concept",
+  "critique this business plan", "review my idea", "check if this idea is viable",
+  "audit this business concept", "is this idea worth pursuing", "rate this startup
+  idea", "score this business idea", "business idea validation", "idea feasibility
+  check", "validate my pitch", "evaluate this product concept". Use this skill when
+  the user presents a business idea, startup concept, product proposal, feature pitch,
+  or pivot scenario and wants a structured viability assessment with scoring.
+
+  '
 metadata:
   version: 1.0.0
-  complements:
-    - market-analyzer
-    - competitive-analyzer
-    - feasibility-assessor
+  complements: [market-analyzer, competitive-analyzer, feasibility-assessor]
+  category: review
+  tags: [idea-validation, lean-canvas, jtbd, swot]
+  difficulty: advanced
 ---
-
 # Business Idea Validator
 
 ## Purpose

--- a/skills/immune/SKILL.md
+++ b/skills/immune/SKILL.md
@@ -1,23 +1,25 @@
 ---
 name: immune
-description: >
-  Hybrid adaptive memory system with two complementary memories: Cheatsheet
-  (positive patterns injected before generation) and Immune (negative patterns
-  scanned after generation). Uses Hot/Cold tiered memory with multi-domain
-  support and auto-learning. Detects known errors via antibodies, discovers
-  new threats, and learns winning strategies over time.
-  Triggers on: "scan for errors", "immune scan", "check output quality",
-  "detect patterns", "scan content", "cheatsheet injection", "antibody scan",
-  "adaptive memory scan", "immune check", "quality scan", "pattern detection".
-  NOT for general code review or PR review — use pr-review instead.
-  NOT for security audits of repositories — use repo-sentinel instead.
+description: 'Hybrid adaptive memory system with two complementary memories: Cheatsheet
+  (positive patterns injected before generation) and Immune (negative patterns scanned
+  after generation). Uses Hot/Cold tiered memory with multi-domain support and auto-learning.
+  Detects known errors via antibodies, discovers new threats, and learns winning strategies
+  over time. Triggers on: "scan for errors", "immune scan", "check output quality",
+  "detect patterns", "scan content", "cheatsheet injection", "antibody scan", "adaptive
+  memory scan", "immune check", "quality scan", "pattern detection". NOT for general
+  code review or PR review — use pr-review instead. NOT for security audits of repositories
+  — use repo-sentinel instead.
+
+  '
 metadata:
   version: 1.0.0
   status: active
   classification: tooling-wrapper
   source: https://github.com/contactjccoaching-wq/immune
+  category: review
+  tags: [memory, error-detection, antibodies, adaptive]
+  difficulty: intermediate
 ---
-
 # Immune System v3 — Hybrid Cheatsheet + Immune
 
 You operate a hybrid adaptive system with two complementary memories:

--- a/skills/lightpanda-browser/SKILL.md
+++ b/skills/lightpanda-browser/SKILL.md
@@ -1,10 +1,19 @@
 ---
 name: lightpanda-browser
-description: Lightweight headless browser automation using Lightpanda as the backend engine with agent-browser CLI. 9x lower memory, 11x faster than Chromium. Use for web scraping, DOM interaction, data extraction, form automation, and API testing where visual rendering is not required. Triggers on "lightpanda", "lightweight browser", "fast headless browser", "headless scraping", "low memory browser", "browser without rendering", "is lightpanda faster than chromium", "which headless browser uses less memory", "how do I scrape without chromium", or any browser automation task where speed and resource efficiency matter more than visual fidelity.
+description: Lightweight headless browser automation using Lightpanda as the backend
+  engine with agent-browser CLI. 9x lower memory, 11x faster than Chromium. Use for
+  web scraping, DOM interaction, data extraction, form automation, and API testing
+  where visual rendering is not required. Triggers on "lightpanda", "lightweight browser",
+  "fast headless browser", "headless scraping", "low memory browser", "browser without
+  rendering", "is lightpanda faster than chromium", "which headless browser uses less
+  memory", "how do I scrape without chromium", or any browser automation task where
+  speed and resource efficiency matter more than visual fidelity.
 metadata:
   version: 1.0.0
+  category: visualization
+  tags: [browser, headless, scraping, lightweight]
+  difficulty: beginner
 ---
-
 # Lightpanda Browser — Fast Headless Automation
 
 Headless browser automation using [Lightpanda](https://github.com/lightpanda-io/browser) as the backend engine, controlled through the `agent-browser` CLI via CDP (Chrome DevTools Protocol).

--- a/skills/linkedin-post-style/SKILL.md
+++ b/skills/linkedin-post-style/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: linkedin-post-style
-description: >
-  Write LinkedIn posts matching a specific technical author's voice — direct, analytical, dry-humored,
-  and precise. Use this skill whenever the user asks to write, draft, rewrite, review, improve, or
-  refine a LinkedIn post, social media post, tech commentary, or any public-facing short-form writing
-  about technology, AI, software engineering, or developer tools. Also trigger when the user says
-  "write this in my style", "post about this", "rewrite this for LinkedIn", "draft a post in my style",
-  "does this sound right", "how should I phrase this", or provides raw content/notes and wants it shaped
-  into a post. Includes visual companion guidance for pairing posts with document carousels (via
-  md-to-pdf with Mermaid diagrams), custom images (via concept-to-image), or animations (via
-  concept-to-video).
+description: 'Write LinkedIn posts matching a specific technical author''s voice —
+  direct, analytical, dry-humored, and precise. Use this skill whenever the user asks
+  to write, draft, rewrite, review, improve, or refine a LinkedIn post, social media
+  post, tech commentary, or any public-facing short-form writing about technology,
+  AI, software engineering, or developer tools. Also trigger when the user says "write
+  this in my style", "post about this", "rewrite this for LinkedIn", "draft a post
+  in my style", "does this sound right", "how should I phrase this", or provides raw
+  content/notes and wants it shaped into a post. Includes visual companion guidance
+  for pairing posts with document carousels (via md-to-pdf with Mermaid diagrams),
+  custom images (via concept-to-image), or animations (via concept-to-video).
+
+  '
 metadata:
   version: 1.2.1
+  category: review
+  tags: [linkedin, social-media, writing, content]
+  difficulty: intermediate
 ---
-
 # LinkedIn Post Style Guide
 
 You are writing in a specific author's voice. This is not generic "professional LinkedIn content." Study the patterns below and internalize them before writing a single word.

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,24 +1,23 @@
 ---
 name: literature-review
-description: >
-  Systematic literature review workflow for surveying, synthesizing, and analyzing
-  academic research. Covers the full lifecycle: scope definition, searching academic
-  databases (arXiv, Semantic Scholar, Google Scholar), screening, structured extraction,
-  thematic synthesis, gap identification, and producing a cited review document.
-  Triggers on: "literature review", "survey the literature", "research landscape",
+description: 'Systematic literature review workflow for surveying, synthesizing, and
+  analyzing academic research. Covers the full lifecycle: scope definition, searching
+  academic databases (arXiv, Semantic Scholar, Google Scholar), screening, structured
+  extraction, thematic synthesis, gap identification, and producing a cited review
+  document. Triggers on: "literature review", "survey the literature", "research landscape",
   "related work", "systematic review", "scoping review", "synthesize the research",
   "bibliography on", "find papers about", "review the state of the art", "research
-  gap analysis". Use this skill when surveying a research area, mapping a topic
-  landscape, identifying gaps, or writing a related work section.
+  gap analysis". Use this skill when surveying a research area, mapping a topic landscape,
+  identifying gaps, or writing a related work section.
+
+  '
 metadata:
   version: 1.0.0
-  complements:
-    - arxiv-search
-    - research-critique
-    - manuscript-review
-    - manuscript-provenance
+  complements: [arxiv-search, research-critique, manuscript-review, manuscript-provenance]
+  category: review
+  tags: [academic, literature, synthesis, citations]
+  difficulty: intermediate
 ---
-
 # Literature Review
 
 Systematic discovery, extraction, and synthesis of academic research on a defined topic.

--- a/skills/manuscript-provenance/SKILL.md
+++ b/skills/manuscript-provenance/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: manuscript-provenance
-description: >
-  Computational provenance audit verifying that every number, table, figure,
-  ordering, and terminology in a manuscript is derived from code and scripts —
-  not manually entered. Cross-references LaTeX source against the codebase to
-  detect hardcoded values, stale outputs, broken pipelines, and manual data
-  entry. Companion to manuscript-review: that skill audits the document as
-  prose; this skill audits whether the document is faithfully generated from
-  code. Use when the user says "check provenance", "verify reproducibility",
-  "audit my pipeline", "are my numbers from code", "check manuscript against
-  scripts", "provenance audit", or any request to verify that manuscript
-  content traces back to computational outputs.
+description: 'Computational provenance audit verifying that every number, table, figure,
+  ordering, and terminology in a manuscript is derived from code and scripts — not
+  manually entered. Cross-references LaTeX source against the codebase to detect hardcoded
+  values, stale outputs, broken pipelines, and manual data entry. Companion to manuscript-review:
+  that skill audits the document as prose; this skill audits whether the document
+  is faithfully generated from code. Use when the user says "check provenance", "verify
+  reproducibility", "audit my pipeline", "are my numbers from code", "check manuscript
+  against scripts", "provenance audit", or any request to verify that manuscript content
+  traces back to computational outputs.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [provenance, reproducibility, computational, verification]
+  difficulty: advanced
 ---
-
 # Manuscript Provenance Audit
 
 ## Purpose

--- a/skills/manuscript-review/SKILL.md
+++ b/skills/manuscript-review/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: manuscript-review
-description: >
-  Systematic pre-publication manuscript audit producing a structured refactoring
-  report with section-level diagnostics, citation hygiene analysis, and
-  submission-readiness assessment. Use this skill whenever the user uploads a
-  manuscript, paper, thesis chapter, journal submission, or conference paper and
-  asks for review, feedback, editing, refactoring, pre-submission check,
-  proofreading, or quality audit. Also trigger when the user says "review my
-  paper", "check before submission", "is this ready to submit", "pre-pub
-  checklist", "manuscript review", "refactor my paper", or asks about citation
-  consistency, argument coherence, or formatting compliance. Covers partial
-  requests like "check my references" or "does the abstract work" — the full
-  diagnostic surfaces issues across all facets even when only one was asked about.
+description: 'Systematic pre-publication manuscript audit producing a structured refactoring
+  report with section-level diagnostics, citation hygiene analysis, and submission-readiness
+  assessment. Use this skill whenever the user uploads a manuscript, paper, thesis
+  chapter, journal submission, or conference paper and asks for review, feedback,
+  editing, refactoring, pre-submission check, proofreading, or quality audit. Also
+  trigger when the user says "review my paper", "check before submission", "is this
+  ready to submit", "pre-pub checklist", "manuscript review", "refactor my paper",
+  or asks about citation consistency, argument coherence, or formatting compliance.
+  Covers partial requests like "check my references" or "does the abstract work" —
+  the full diagnostic surfaces issues across all facets even when only one was asked
+  about.
+
+  '
 metadata:
   version: 1.2.1
+  category: review
+  tags: [manuscript, pre-publication, citation-hygiene, submission]
+  difficulty: advanced
 ---
-
 # Manuscript Review Skill
 
 ## Purpose

--- a/skills/market-analyzer/SKILL.md
+++ b/skills/market-analyzer/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: market-analyzer
-description: >
-  Performs structured market analysis including TAM/SAM/SOM sizing, trend identification,
-  and competitive landscape assessment. Uses WebSearch to gather industry data, growth
-  rates, funding signals, and consumer trends. Produces investor-grade market reports
-  with cited sources and confidence-rated estimates.
-  Triggers on: "market analysis", "market size", "TAM SAM SOM", "total addressable market",
-  "market opportunity", "market research", "industry analysis", "market sizing",
-  "how big is the market", "market potential", "analyze this market", "market landscape",
-  "competitive landscape", "market trends", "growth rate", "market assessment".
-  NOT for financial modeling, revenue forecasting, or pricing strategy.
-  Use this skill when a product, feature, or business idea needs market size estimation,
-  trend analysis, or industry assessment with sourced data.
+description: 'Performs structured market analysis including TAM/SAM/SOM sizing, trend
+  identification, and competitive landscape assessment. Uses WebSearch to gather industry
+  data, growth rates, funding signals, and consumer trends. Produces investor-grade
+  market reports with cited sources and confidence-rated estimates. Triggers on: "market
+  analysis", "market size", "TAM SAM SOM", "total addressable market", "market opportunity",
+  "market research", "industry analysis", "market sizing", "how big is the market",
+  "market potential", "analyze this market", "market landscape", "competitive landscape",
+  "market trends", "growth rate", "market assessment". NOT for financial modeling,
+  revenue forecasting, or pricing strategy. Use this skill when a product, feature,
+  or business idea needs market size estimation, trend analysis, or industry assessment
+  with sourced data.
+
+  '
 metadata:
   version: 1.0.0
+  category: research
+  tags: [market-sizing, tam-sam-som, trends, industry]
+  difficulty: intermediate
 ---
-
 # Market Analyzer
 
 Produces structured market analysis reports: sizes the addressable market using top-down

--- a/skills/mcp-to-skill/SKILL.md
+++ b/skills/mcp-to-skill/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: mcp-to-skill
-description: >
-  Convert MCP (Model Context Protocol) servers into on-demand skills to dramatically
-  reduce active context window usage. MCP tool schemas consume tokens on every turn
-  whether used or not; skills load only when needed. Analyzes MCP tool definitions,
-  classifies each tool by replacement strategy, and generates a complete skill package.
-  Use this skill whenever the user mentions: convert MCP, MCP to skill, reduce context
-  size, too many tools, tool token bloat, slim down MCPs, context window full, replace
-  MCP, MCP migration. Also trigger when the user has many active MCP servers and wants
-  to optimize context usage, asks about reducing token overhead from tool definitions,
-  or says my context is too big or running out of context when MCPs are active.
+description: 'Convert MCP (Model Context Protocol) servers into on-demand skills to
+  dramatically reduce active context window usage. MCP tool schemas consume tokens
+  on every turn whether used or not; skills load only when needed. Analyzes MCP tool
+  definitions, classifies each tool by replacement strategy, and generates a complete
+  skill package. Use this skill whenever the user mentions: convert MCP, MCP to skill,
+  reduce context size, too many tools, tool token bloat, slim down MCPs, context window
+  full, replace MCP, MCP migration. Also trigger when the user has many active MCP
+  servers and wants to optimize context usage, asks about reducing token overhead
+  from tool definitions, or says my context is too big or running out of context when
+  MCPs are active.
+
+  '
 metadata:
   version: 1.1.0
+  category: data
+  tags: [mcp, skill-conversion, context-optimization, token-reduction]
+  difficulty: intermediate
 ---
-
 # MCP-to-Skill Converter
 
 Convert MCP servers into on-demand skills. MCP tool schemas sit in the system prompt

--- a/skills/md-to-pdf/SKILL.md
+++ b/skills/md-to-pdf/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: md-to-pdf
-description: >
-  Convert Markdown files to professionally styled PDF documents with full support for Mermaid diagrams,
-  LaTeX/KaTeX math equations, tables, syntax-highlighted code blocks, and all standard Markdown features.
-  Use this skill whenever the user wants to convert a .md file to .pdf, generate a PDF report from Markdown,
-  or produce print-ready documents from Markdown sources containing diagrams, math, or complex formatting.
-  Trigger phrases include: "convert markdown to pdf", "make a pdf from this md", "render this markdown",
-  "export markdown as pdf", "markdown to pdf with diagrams", "pdf from markdown with equations",
-  "generate a pdf report", "how do I export markdown as PDF", "convert my notes to PDF",
-  "can you make a PDF from this markdown".
+description: 'Convert Markdown files to professionally styled PDF documents with full
+  support for Mermaid diagrams, LaTeX/KaTeX math equations, tables, syntax-highlighted
+  code blocks, and all standard Markdown features. Use this skill whenever the user
+  wants to convert a .md file to .pdf, generate a PDF report from Markdown, or produce
+  print-ready documents from Markdown sources containing diagrams, math, or complex
+  formatting. Trigger phrases include: "convert markdown to pdf", "make a pdf from
+  this md", "render this markdown", "export markdown as pdf", "markdown to pdf with
+  diagrams", "pdf from markdown with equations", "generate a pdf report", "how do
+  I export markdown as PDF", "convert my notes to PDF", "can you make a PDF from this
+  markdown".
+
+  '
 license: MIT. See LICENSE.txt for complete terms.
 metadata:
   version: 1.2.0
+  category: visualization
+  tags: [pdf, markdown, mermaid, latex]
+  difficulty: intermediate
 ---
-
 # Markdown to PDF Converter
 
 Converts Markdown files to professionally styled PDFs with full rendering of Mermaid diagrams,

--- a/skills/migration-risk-analyzer/SKILL.md
+++ b/skills/migration-risk-analyzer/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: migration-risk-analyzer
-description: >
-  Analyzes database migration scripts for risk: lock contention, downtime estimation,
-  rollback strategy, and deployment recommendations. Classifies DDL and DML operations
-  by lock type and duration, identifies irreversible changes, generates rollback scripts,
-  and produces pre/post validation queries.
-  Triggers on: "analyze this migration", "migration risk", "is this migration safe",
-  "schema change risk", "DDL risk", "downtime for this migration", "lock risk",
-  "rollback strategy", "how to roll back", "migration review", "alter table risk".
-  Use this skill when reviewing database migrations before deployment.
+description: 'Analyzes database migration scripts for risk: lock contention, downtime
+  estimation, rollback strategy, and deployment recommendations. Classifies DDL and
+  DML operations by lock type and duration, identifies irreversible changes, generates
+  rollback scripts, and produces pre/post validation queries. Triggers on: "analyze
+  this migration", "migration risk", "is this migration safe", "schema change risk",
+  "DDL risk", "downtime for this migration", "lock risk", "rollback strategy", "how
+  to roll back", "migration review", "alter table risk". Use this skill when reviewing
+  database migrations before deployment.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [database, migration, ddl, rollback]
+  difficulty: advanced
 ---
-
 # Migration Risk Analyzer
 
 Systematic risk assessment for database migrations: parse DDL/DML operations, classify

--- a/skills/notebooklm/SKILL.md
+++ b/skills/notebooklm/SKILL.md
@@ -1,24 +1,25 @@
 ---
 name: notebooklm
-description: >
-  Complete API for Google NotebookLM — full programmatic access including
-  features not in the web UI. Create notebooks, add sources (URLs, YouTube,
-  PDFs, audio, video, images), chat with content, generate all artifact types
-  (podcasts, videos, infographics, slide decks, quizzes, flashcards, mind maps,
-  reports, data tables), and download results in multiple formats. Uses the
-  notebooklm-py CLI. Use this skill when the user mentions: notebooklm, notebook
-  lm, create a podcast, generate a podcast, audio overview, create flashcards,
-  generate flashcards, create a quiz, generate quiz, generate infographic, make
-  an infographic, generate slide deck, create mind map, generate mind map,
-  generate report, turn this into a podcast, summarize in notebooklm, add
-  sources to notebooklm, notebooklm analysis, create a video explainer,
-  generate video overview, research with notebooklm, offload analysis, bulk
-  source import, download from notebooklm, notebooklm deliverables, or uses
-  /notebooklm.
+description: 'Complete API for Google NotebookLM — full programmatic access including
+  features not in the web UI. Create notebooks, add sources (URLs, YouTube, PDFs,
+  audio, video, images), chat with content, generate all artifact types (podcasts,
+  videos, infographics, slide decks, quizzes, flashcards, mind maps, reports, data
+  tables), and download results in multiple formats. Uses the notebooklm-py CLI. Use
+  this skill when the user mentions: notebooklm, notebook lm, create a podcast, generate
+  a podcast, audio overview, create flashcards, generate flashcards, create a quiz,
+  generate quiz, generate infographic, make an infographic, generate slide deck, create
+  mind map, generate mind map, generate report, turn this into a podcast, summarize
+  in notebooklm, add sources to notebooklm, notebooklm analysis, create a video explainer,
+  generate video overview, research with notebooklm, offload analysis, bulk source
+  import, download from notebooklm, notebooklm deliverables, or uses /notebooklm.
+
+  '
 metadata:
   version: 1.1.0
+  category: research
+  tags: [notebooklm, podcast, flashcards, source-analysis]
+  difficulty: intermediate
 ---
-
 # NotebookLM Automation
 
 Complete programmatic access to Google NotebookLM — including capabilities not

--- a/skills/package-evaluator/SKILL.md
+++ b/skills/package-evaluator/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: package-evaluator
-description: >
-  Evaluate Claude Code package quality across 6 weighted dimensions: frontmatter quality,
-  trigger coverage, structural completeness, content depth, consistency and integrity,
-  and CONTRIBUTING.md compliance. Covers all 7 package types with type-specific signals.
-  Produces scored audit reports with severity-classified findings. Two modes: Quick Audit
-  (single package, full report) and Full Audit (all packages, ranking table). Triggers on:
-  "evaluate package", "audit agent quality", "score this hook", "package quality", "package
-  audit", "skill review", "skill quality check", "how good is this skill", "AGENT.md
-  feedback". Use this skill when reviewing packages before deployment or diagnosing
-  activation failures. NOT for LLM prompts (use prompt-lab) or PRs (use pr-review).
+description: 'Evaluate Claude Code package quality across 6 weighted dimensions: frontmatter
+  quality, trigger coverage, structural completeness, content depth, consistency and
+  integrity, and CONTRIBUTING.md compliance. Covers all 7 package types with type-specific
+  signals. Produces scored audit reports with severity-classified findings. Two modes:
+  Quick Audit (single package, full report) and Full Audit (all packages, ranking
+  table). Triggers on: "evaluate package", "audit agent quality", "score this hook",
+  "package quality", "package audit", "skill review", "skill quality check", "how
+  good is this skill", "AGENT.md feedback". Use this skill when reviewing packages
+  before deployment or diagnosing activation failures. NOT for LLM prompts (use prompt-lab)
+  or PRs (use pr-review).
+
+  '
 metadata:
   version: 1.3.0
+  category: review
+  tags: [quality, audit, scoring, frontmatter]
+  difficulty: intermediate
 ---
-
 # Package Evaluator
 
 Packages that do not activate on relevant queries waste the entire investment in writing

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: plan-review
-description: >
-  Pre-implementation plan audit that stress-tests scope, assumptions, risks, and
-  failure modes before code is written. Use this skill when the user asks to review
-  a plan, audit a proposal, challenge scope, stress-test an approach, evaluate a
-  technical design, or says "review this plan", "is this plan solid", "what am I
+description: 'Pre-implementation plan audit that stress-tests scope, assumptions,
+  risks, and failure modes before code is written. Use this skill when the user asks
+  to review a plan, audit a proposal, challenge scope, stress-test an approach, evaluate
+  a technical design, or says "review this plan", "is this plan solid", "what am I
   missing", "challenge my assumptions", "plan review", "scope check", "stress-test
   this", "/plan-review". Supports product lens, engineering lens, or combined review.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [plan-audit, scope, risk-assessment, assumptions]
+  difficulty: intermediate
 ---
-
 # Plan Review Skill
 
 ## Purpose

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: pr-review
-description: >
-  Pull request and code review with diff-based routing across five dimensions:
-  code quality and guideline compliance, test coverage analysis, silent failure
-  detection, type design and invariant analysis, and comment quality auditing.
-  Classifies changed files and loads only relevant review methodologies. Produces
-  severity-ranked findings (Critical, Important, Suggestion) with confidence
-  scoring. Replaces pr-review-toolkit plugin. Trigger phrases: "review my PR",
-  "review this code", "check my changes", "is this ready to merge", "audit
-  this PR", "review before committing", "check code quality", "any issues with
-  this code", "pre-merge review", "look over my changes", "code review". Use
-  this skill when reviewing code before commit or merge, checking PR quality,
-  or when the user asks for feedback on recent modifications.
+description: 'Pull request and code review with diff-based routing across five dimensions:
+  code quality and guideline compliance, test coverage analysis, silent failure detection,
+  type design and invariant analysis, and comment quality auditing. Classifies changed
+  files and loads only relevant review methodologies. Produces severity-ranked findings
+  (Critical, Important, Suggestion) with confidence scoring. Replaces pr-review-toolkit
+  plugin. Trigger phrases: "review my PR", "review this code", "check my changes",
+  "is this ready to merge", "audit this PR", "review before committing", "check code
+  quality", "any issues with this code", "pre-merge review", "look over my changes",
+  "code review". Use this skill when reviewing code before commit or merge, checking
+  PR quality, or when the user asks for feedback on recent modifications.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [code-review, pull-request, quality, diff-analysis]
+  difficulty: intermediate
 ---
-
 # PR Review
 
 Diff-based code review across five dimensions. Reads the changed files, selects

--- a/skills/pre-landing-review/SKILL.md
+++ b/skills/pre-landing-review/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: pre-landing-review
-description: >
-  Gate-oriented safety audit for code changes before landing, using a structured
-  checklist with two-pass severity triage. Distinct from pr-review (which is
-  diff-based multi-dimension review) — this is a blocking safety gate. Use this
+description: 'Gate-oriented safety audit for code changes before landing, using a
+  structured checklist with two-pass severity triage. Distinct from pr-review (which
+  is diff-based multi-dimension review) — this is a blocking safety gate. Use this
   skill when the user asks for a pre-landing check, safety audit, pre-merge review,
   gate check, landing review, or says "is this safe to land", "pre-landing review",
   "safety check before merge", "run the checklist", "gate check", "/pre-landing-review".
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [pre-merge, safety-gate, code-review, checklist]
+  difficulty: intermediate
 ---
-
 # Pre-Landing Review
 
 Gate-oriented safety audit for code changes before landing. Uses a structured checklist with two-pass severity triage and blocking/non-blocking classification.

--- a/skills/prompt-lab/SKILL.md
+++ b/skills/prompt-lab/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: prompt-lab
-description: >
-  Systematic LLM prompt engineering: analyzes existing prompts for failure modes,
-  generates structured variants (direct, few-shot, chain-of-thought), designs evaluation
-  rubrics with weighted criteria, and produces test case suites for comparing prompt
-  performance. Triggers on: "prompt engineering", "prompt lab", "generate prompt variants",
-  "A/B test prompts", "evaluate prompt", "optimize prompt", "write a better prompt",
-  "prompt design", "prompt iteration", "few-shot examples", "chain-of-thought prompt",
-  "prompt failure modes", "improve this prompt".
-  Use this skill when designing, improving, or evaluating LLM prompts specifically.
-  NOT for evaluating Claude Code skills or SKILL.md files — use skill-evaluator instead.
+description: 'Systematic LLM prompt engineering: analyzes existing prompts for failure
+  modes, generates structured variants (direct, few-shot, chain-of-thought), designs
+  evaluation rubrics with weighted criteria, and produces test case suites for comparing
+  prompt performance. Triggers on: "prompt engineering", "prompt lab", "generate prompt
+  variants", "A/B test prompts", "evaluate prompt", "optimize prompt", "write a better
+  prompt", "prompt design", "prompt iteration", "few-shot examples", "chain-of-thought
+  prompt", "prompt failure modes", "improve this prompt". Use this skill when designing,
+  improving, or evaluating LLM prompts specifically. NOT for evaluating Claude Code
+  skills or SKILL.md files — use skill-evaluator instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: development
+  tags: [prompt-engineering, evaluation, few-shot, chain-of-thought]
+  difficulty: intermediate
 ---
-
 # Prompt Lab
 
 Replaces trial-and-error prompt engineering with structured methodology: objective

--- a/skills/qa-systematic/SKILL.md
+++ b/skills/qa-systematic/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: qa-systematic
-description: >
-  Systematic web application QA testing with structured issue taxonomy, health
-  scoring, and regression tracking. Use this skill when the user asks for QA
+description: 'Systematic web application QA testing with structured issue taxonomy,
+  health scoring, and regression tracking. Use this skill when the user asks for QA
   testing, systematic testing, smoke testing, regression testing, web app testing,
-  browser testing, or says "QA this", "test the app", "smoke test", "run QA",
-  "systematic test", "check the site", "regression test", "full QA",
-  "/qa-systematic". Supports full, quick, and regression modes.
+  browser testing, or says "QA this", "test the app", "smoke test", "run QA", "systematic
+  test", "check the site", "regression test", "full QA", "/qa-systematic". Supports
+  full, quick, and regression modes.
+
+  '
 metadata:
   version: 1.0.0
+  category: development
+  tags: [qa, testing, browser, regression]
+  difficulty: advanced
 ---
-
 # Systematic QA Testing
 
 ## Modes

--- a/skills/rag-auditor/SKILL.md
+++ b/skills/rag-auditor/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: rag-auditor
-description: >
-  Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across retrieval
-  and generation stages. Measures precision, recall, MRR for retrieval; groundedness,
-  completeness, and hallucination rate for generation. Diagnoses failure root causes
-  and recommends chunk, retrieval, and prompt improvements.
-  Triggers on: "audit RAG pipeline", "RAG quality", "evaluate RAG retrieval",
-  "hallucination detection", "retrieval precision", "why is RAG failing",
-  "RAG diagnosis", "retrieval quality", "RAG evaluation", "chunk quality",
-  "RAG pipeline review", "grounding check".
-  Use this skill when diagnosing or evaluating a RAG pipeline's quality.
-  For general architecture or system audits, use architecture-reviewer instead.
+description: 'Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across
+  retrieval and generation stages. Measures precision, recall, MRR for retrieval;
+  groundedness, completeness, and hallucination rate for generation. Diagnoses failure
+  root causes and recommends chunk, retrieval, and prompt improvements. Triggers on:
+  "audit RAG pipeline", "RAG quality", "evaluate RAG retrieval", "hallucination detection",
+  "retrieval precision", "why is RAG failing", "RAG diagnosis", "retrieval quality",
+  "RAG evaluation", "chunk quality", "RAG pipeline review", "grounding check". Use
+  this skill when diagnosing or evaluating a RAG pipeline''s quality. For general
+  architecture or system audits, use architecture-reviewer instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [rag, retrieval, hallucination, grounding]
+  difficulty: advanced
 ---
-
 # RAG Auditor
 
 Systematic RAG pipeline evaluation across the full retrieval-generation chain: designs

--- a/skills/regex-builder/SKILL.md
+++ b/skills/regex-builder/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: regex-builder
-description: >
-  DEPRECATED: The base model generates, explains, and tests regex patterns natively
-  with high accuracy. This skill no longer provides meaningful uplift. Retained for
-  reference only.
+description: 'DEPRECATED: The base model generates, explains, and tests regex patterns
+  natively with high accuracy. This skill no longer provides meaningful uplift. Retained
+  for reference only.
+
+  '
 metadata:
   version: 1.1.0
   status: deprecated
+  category: development
+  tags: [regex, pattern-matching, testing, validation]
+  difficulty: beginner
 ---
-
 > **DEPRECATED** — Modern Claude models produce accurate, well-explained regex patterns
 > with edge-case test suites natively, including multi-language usage examples. The uplift
 > delta from this skill approaches zero. Retained for archival reference only.

--- a/skills/remotion-video/SKILL.md
+++ b/skills/remotion-video/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: remotion-video
-description: >
-  Create production-grade motion graphics and videos using Remotion (React). Use whenever the
-  user wants branded video content, product demos, data-driven video generation, or motion
-  graphics with audio sync, web fonts, TailwindCSS styling, or media embedding.
-  Covers: marketing videos, product launches, data visualizations, social media content,
-  personalized video at scale, explainer videos with voiceover, animated charts, 3D scenes
-  via Three.js. Requires Node.js and Claude Code environment.
-  Trigger on: "create a Remotion video", "React video", "motion graphics", "branded video",
-  "product demo video", "remotion", "video with audio", "TailwindCSS video",
+description: 'Create production-grade motion graphics and videos using Remotion (React).
+  Use whenever the user wants branded video content, product demos, data-driven video
+  generation, or motion graphics with audio sync, web fonts, TailwindCSS styling,
+  or media embedding. Covers: marketing videos, product launches, data visualizations,
+  social media content, personalized video at scale, explainer videos with voiceover,
+  animated charts, 3D scenes via Three.js. Requires Node.js and Claude Code environment.
+  Trigger on: "create a Remotion video", "React video", "motion graphics", "branded
+  video", "product demo video", "remotion", "video with audio", "TailwindCSS video",
   "data-driven video generation", "personalized video at scale", "video with voiceover".
   For mathematical animations, algorithm visualizations, or headless container rendering,
   use concept-to-video (Manim) instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: business
+  tags: [video, react, remotion, motion-graphics]
+  difficulty: advanced
 ---
-
 # Remotion Video
 
 Creates production-grade videos using Remotion — a React framework where video is code.

--- a/skills/repo-sentinel/SKILL.md
+++ b/skills/repo-sentinel/SKILL.md
@@ -1,21 +1,25 @@
 ---
 name: repo-sentinel
-description: >
-  Full security audit and enforcement for public repositories across 12 attack surfaces: git
-  history, source code, docs, config, .gitignore recon, CI/CD, containers, dependencies, binaries,
-  metadata, platform-specific (GitHub/GitLab), license compliance, and community surface. Provides
-  fast-path and full 20-check audits, pre-commit hooks, CI gates, .gitignore generation, and
-  history scrubbing. Use whenever pushing to a public remote, open-sourcing a repo, writing
-  README/docs, configuring CI/CD or Dockerfiles, adding dependencies, or checking license
-  compliance. Trigger on: push to GitHub, make repo public, open source this, set up the repo,
-  write README, add CI/CD, create Dockerfile, set up pre-commit, add license, write SECURITY.md,
-  secret leaks, credential rotation, .claude/ tracking, repo hygiene, security scanning, or
-  is this safe to push, pre-oss, open source readiness, release audit, or open source audit.
-  This is the gatekeeper between internal and public.
+description: 'Full security audit and enforcement for public repositories across 12
+  attack surfaces: git history, source code, docs, config, .gitignore recon, CI/CD,
+  containers, dependencies, binaries, metadata, platform-specific (GitHub/GitLab),
+  license compliance, and community surface. Provides fast-path and full 20-check
+  audits, pre-commit hooks, CI gates, .gitignore generation, and history scrubbing.
+  Use whenever pushing to a public remote, open-sourcing a repo, writing README/docs,
+  configuring CI/CD or Dockerfiles, adding dependencies, or checking license compliance.
+  Trigger on: push to GitHub, make repo public, open source this, set up the repo,
+  write README, add CI/CD, create Dockerfile, set up pre-commit, add license, write
+  SECURITY.md, secret leaks, credential rotation, .claude/ tracking, repo hygiene,
+  security scanning, or is this safe to push, pre-oss, open source readiness, release
+  audit, or open source audit. This is the gatekeeper between internal and public.
+
+  '
 metadata:
   version: 1.1.0
+  category: review
+  tags: [security, public-repo, secret-scanning, audit]
+  difficulty: advanced
 ---
-
 # Repo Sentinel
 
 Everything in a public repo is permanent attacker surface. This skill defines what belongs in a

--- a/skills/research-critique/SKILL.md
+++ b/skills/research-critique/SKILL.md
@@ -1,23 +1,25 @@
 ---
 name: research-critique
-description: >
-  Critical analysis of research papers, academic manuscripts, preprints, and
-  technical studies — evaluating methodology, claims-evidence alignment,
-  contribution significance, and intellectual honesty. Produces coherent
-  analytical responses (not checklists) that distinguish genuine weaknesses from
-  standard field limitations. Governs intellectual posture: collegial reader, not
-  adversarial reviewer. Triggers on: "critique this paper", "review this
-  research", "what do you think of this paper", "analyze this study", "evaluate
-  the methodology", "is this paper sound", "assess this research", "strengths
-  and weaknesses of this paper", "does the evidence support the claims". Use
-  this skill when the user provides a research paper, preprint, or technical
-  study and asks for critical evaluation of its scientific merit, methodology, or
-  contribution — not formatting, citation hygiene, or submission readiness
-  (use manuscript-review for those).
+description: 'Critical analysis of research papers, academic manuscripts, preprints,
+  and technical studies — evaluating methodology, claims-evidence alignment, contribution
+  significance, and intellectual honesty. Produces coherent analytical responses (not
+  checklists) that distinguish genuine weaknesses from standard field limitations.
+  Governs intellectual posture: collegial reader, not adversarial reviewer. Triggers
+  on: "critique this paper", "review this research", "what do you think of this paper",
+  "analyze this study", "evaluate the methodology", "is this paper sound", "assess
+  this research", "strengths and weaknesses of this paper", "does the evidence support
+  the claims". Use this skill when the user provides a research paper, preprint, or
+  technical study and asks for critical evaluation of its scientific merit, methodology,
+  or contribution — not formatting, citation hygiene, or submission readiness (use
+  manuscript-review for those).
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [research, methodology, claims-evidence, peer-review]
+  difficulty: intermediate
 ---
-
 # Research Paper Critique
 
 ## Purpose

--- a/skills/sequential-thinking/SKILL.md
+++ b/skills/sequential-thinking/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: sequential-thinking
-description: >
-  DEPRECATED: Use the model's native extended thinking instead. Structured, reflective
-  problem-solving through sequential chain-of-thought reasoning that replaced the
-  Sequential Thinking MCP server.
+description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured,
+  reflective problem-solving through sequential chain-of-thought reasoning that replaced
+  the Sequential Thinking MCP server.
+
+  '
 metadata:
   version: 1.1.0
   status: deprecated
+  category: development
+  tags: [reasoning, chain-of-thought, analysis, problem-solving]
+  difficulty: intermediate
 ---
-
 > **DEPRECATED** — Sonnet 4 and Opus 4 handle structured chain-of-thought natively,
 > including revision, branching, and scope adjustment. This skill no longer provides
 > meaningful uplift over the base model. Retained for reference only.

--- a/skills/ship-workflow/SKILL.md
+++ b/skills/ship-workflow/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: ship-workflow
-description: >
-  Automated release pipeline that merges main, runs tests, performs pre-landing
+description: 'Automated release pipeline that merges main, runs tests, performs pre-landing
   review, bumps version, updates changelog, creates bisectable commits, and opens
-  a pull request. Use this skill when the user says "ship it", "ship this",
-  "release this", "prepare for release", "open a PR", "push and PR", "land this",
-  "get this ready to ship", "create release", "/ship-workflow". Handles the full
-  lifecycle from pre-flight checks through PR creation.
+  a pull request. Use this skill when the user says "ship it", "ship this", "release
+  this", "prepare for release", "open a PR", "push and PR", "land this", "get this
+  ready to ship", "create release", "/ship-workflow". Handles the full lifecycle from
+  pre-flight checks through PR creation.
+
+  '
 metadata:
   version: 1.0.0
+  category: review
+  tags: [release, ci-cd, pull-request, changelog]
+  difficulty: intermediate
 ---
-
 # Ship Workflow
 
 Automated release pipeline that takes a feature branch from working state to

--- a/skills/skill-library/SKILL.md
+++ b/skills/skill-library/SKILL.md
@@ -1,51 +1,76 @@
 ---
 name: skill-library
 description: >
-  Agent-native catalog and installer for armory skills. Browse, search, install,
-  update, sync, and remove skills from the armory collection without leaving your
-  agent session. Triggers on: "list available skills", "install skill", "pull skill",
-  "what skills are available", "update my skills", "search skills for",
-  "skill catalog", "armory list", "armory install", "armory search",
-  "remove skill", "uninstall skill", "/library list", "/library use",
-  "/library remove", "show me armory skills", "get the architecture-reviewer
-  skill", "do I have the latest skills". Use this skill when the user wants to
-  discover, install, update, or remove armory skills from within an agent session.
+  Agent-native catalog and installer for armory packages across all 7 types: skills,
+  agents, hooks, rules, commands, utilities, and presets. Browse, search, install,
+  update, sync, and remove packages without leaving your agent session. Supports
+  type filtering and profile-based bundles. Triggers on: "list available packages",
+  "install skill", "install agent", "pull skill", "what packages are available",
+  "update my skills", "search packages for", "package catalog", "armory list",
+  "armory install", "armory search", "remove skill", "/library list", "/library use",
+  "/library remove", "/library profiles", "show me armory packages". Use this skill
+  when discovering, installing, updating, or removing armory packages within a session.
 metadata:
-  version: 1.0.0
+  version: 2.0.0
+  category: operations
+  tags: [armory, catalog, install, package-management, discovery]
+  difficulty: beginner
 ---
+# Package Library
 
-# Skill Library
-
-Agent-native catalog and installer for armory skills. Provides browsing, searching, installing, updating, syncing, and removing skills directly within an agent session.
+Agent-native catalog and installer for all armory package types. Provides browsing, searching, installing, updating, syncing, and removing packages directly within an agent session.
 
 ## Variables
 
 - **ARMORY_REPO**: `Mathews-Tom/armory`
 - **ARMORY_BRANCH**: `main`
 - **ARMORY_CATALOG_URL**: `https://raw.githubusercontent.com/{ARMORY_REPO}/{ARMORY_BRANCH}/manifest.yaml`
-- **DEFAULT_INSTALL_DIR**: `~/.claude/skills/`
+- **DEFAULT_INSTALL_DIR**: `~/.claude/`
 - **CATALOG_CACHE_PATH**: `/tmp/armory-manifest.yaml`
 - **CATALOG_CACHE_TTL**: `600` (seconds)
 
+## Supported Package Types
+
+| Type    | Install Target            | Method          |
+| ------- | ------------------------- | --------------- |
+| skill   | `~/.claude/skills/`       | Copy directory  |
+| agent   | `~/.claude/agents/`       | Copy directory  |
+| hook    | `~/.claude/hooks/`        | Copy directory  |
+| rule    | `~/.claude/rules/`        | Body-only file  |
+| command | `~/.claude/commands/`     | Body-only file  |
+| utility | `~/.claude/utilities/`    | Copy + chmod +x |
+| preset  | `~/.claude/presets/`      | Copy directory  |
+
 ## Command Reference
 
-| Command                     | Cookbook             | Purpose                                                               |
-| --------------------------- | -------------------- | --------------------------------------------------------------------- |
-| `/library list`             | `cookbook/list.md`   | Show all skills with version, installed status, update available      |
-| `/library use <name>`       | `cookbook/use.md`    | Pull a skill from armory into `~/.claude/skills/`                     |
-| `/library search <keyword>` | `cookbook/search.md` | Keyword search across skill names and descriptions                    |
-| `/library sync`             | `cookbook/sync.md`   | Re-pull all installed skills that have updates                        |
-| `/library info <name>`      | `cookbook/info.md`   | Show full detail for a skill                                          |
-| `/library update`           | `cookbook/update.md` | Check all installed skills for available version bumps (dry-run sync) |
-| `/library remove <name>`    | `cookbook/remove.md` | Remove an installed skill from `~/.claude/skills/`                    |
+| Command                              | Cookbook              | Purpose                                                                  |
+| ------------------------------------ | -------------------- | ------------------------------------------------------------------------ |
+| `/library list`                      | `cookbook/list.md`    | Show all packages with type, version, installed status, update available |
+| `/library list --type <type>`        | `cookbook/list.md`    | Filter listing by package type (skill, agent, hook, rule, etc.)         |
+| `/library use <name>`                | `cookbook/use.md`     | Pull a package from armory (auto-detects type from manifest)            |
+| `/library search <keyword>`          | `cookbook/search.md`  | Keyword search across all package types, names, and descriptions        |
+| `/library search --category <name>`  | `cookbook/search.md`  | Filter search by category (development, review, security, etc.)         |
+| `/library sync`                      | `cookbook/sync.md`    | Re-pull all installed packages that have updates                        |
+| `/library info <name>`               | `cookbook/info.md`    | Show full detail for a package (type, version, tags, category)          |
+| `/library update`                    | `cookbook/update.md`  | Check all installed packages for version bumps (dry-run sync)           |
+| `/library remove <name>`             | `cookbook/remove.md`  | Remove an installed package                                              |
+| `/library profiles`                  | `cookbook/profiles.md`| Show available install profiles with package counts                      |
 
 ## Cookbook Dispatch
 
 User commands are routed to the corresponding cookbook file based on the subcommand. When a `/library` command is received, extract the subcommand (the first token after `/library`) and load the matching cookbook file from the `cookbook/` directory relative to this skill. The cookbook file contains the full execution procedure for that operation.
 
-For example, `/library use commit-standards` dispatches to `cookbook/use.md` with `commit-standards` as the skill name argument. `/library list` dispatches to `cookbook/list.md` with no arguments.
+For example, `/library use commit-standards` dispatches to `cookbook/use.md` with `commit-standards` as the package name argument. `/library list --type agent` dispatches to `cookbook/list.md` with `--type agent` as the filter.
 
 If the subcommand does not match any known cookbook, report the error and list the valid subcommands from the table above.
+
+## Type Detection
+
+When `/library use <name>` is called, determine the package type by searching all sections of the manifest (`packages.skills`, `packages.agents`, `packages.hooks`, etc.). The first section containing a matching `name` entry determines the type. Use the type to:
+
+1. Resolve the correct source path: `{type_dir}/{name}/`
+2. Determine the install target: `~/.claude/{install_subdir}/`
+3. Choose the install method: directory copy or body-only extraction
 
 ## Behavioral Notes
 
@@ -53,3 +78,4 @@ If the subcommand does not match any known cookbook, report the error and list t
 - Fetch uses a 3-tier fallback chain: sparse checkout, then `gh api`, then `curl`. Attempt each in order; proceed to the next only on failure.
 - Cache lives in `/tmp/` with a 10-minute TTL. A missing cache file is treated as expired (triggers a re-fetch), not as an error.
 - The catalog is read from `manifest.yaml` on GitHub (at `ARMORY_CATALOG_URL`), not from a separate catalog file. This is the same manifest format used by the armory repository.
+- All package type sections share the same entry format: `name`, `version`, `description`, `path`, `source`, plus optional `tags`, `category`, `difficulty`.

--- a/skills/sql-optimizer/SKILL.md
+++ b/skills/sql-optimizer/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: sql-optimizer
-description: >
-  Analyzes SQL queries for performance issues: missing indexes, N+1 patterns, suboptimal
-  joins, full table scans. Interprets EXPLAIN output, detects anti-patterns, recommends
-  indexes, and rewrites queries with detailed explanations of each optimization.
+description: 'Analyzes SQL queries for performance issues: missing indexes, N+1 patterns,
+  suboptimal joins, full table scans. Interprets EXPLAIN output, detects anti-patterns,
+  recommends indexes, and rewrites queries with detailed explanations of each optimization.
   Triggers on: "optimize this query", "slow query", "query performance", "add indexes",
   "index recommendation", "explain plan", "query plan", "N+1 query", "fix this SQL",
-  "SQL performance", "optimize SQL", "why is this query slow", "index strategy".
-  Use this skill when given a SQL query that needs performance analysis or optimization.
+  "SQL performance", "optimize SQL", "why is this query slow", "index strategy". Use
+  this skill when given a SQL query that needs performance analysis or optimization.
+
+  '
 metadata:
   version: 1.1.0
+  category: data
+  tags: [sql, performance, database, optimization]
+  difficulty: intermediate
 ---
-
 # SQL Optimizer
 
 Systematic SQL performance analysis: parse query structure, interpret EXPLAIN plans,

--- a/skills/static-web-artifacts-builder/SKILL.md
+++ b/skills/static-web-artifacts-builder/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: static-web-artifacts-builder
-description: >
-  Build elaborate, self-contained static HTML artifacts opened in a browser — interactive diagrams,
-  architecture visuals, data dashboards, HTML infographics, and rich interactive deliverables.
-  Use this skill when the output is an HTML file viewed in a browser. Zero build toolchain — no
-  React, no Vite, no Parcel. Pure HTML5 + CSS3 (Grid/Flexbox) + inline SVG. Triggers on:
-  "interactive HTML", "self-contained web component", "open in browser", "interactive diagram",
-  "visual dashboard", "HTML artifact", "HTML infographic", "interactive infographic".
-  For image file output (PNG/SVG), use concept-to-image instead.
+description: 'Build elaborate, self-contained static HTML artifacts opened in a browser
+  — interactive diagrams, architecture visuals, data dashboards, HTML infographics,
+  and rich interactive deliverables. Use this skill when the output is an HTML file
+  viewed in a browser. Zero build toolchain — no React, no Vite, no Parcel. Pure HTML5
+  + CSS3 (Grid/Flexbox) + inline SVG. Triggers on: "interactive HTML", "self-contained
+  web component", "open in browser", "interactive diagram", "visual dashboard", "HTML
+  artifact", "HTML infographic", "interactive infographic". For image file output
+  (PNG/SVG), use concept-to-image instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: visualization
+  tags: [html, interactive, dashboard, svg]
+  difficulty: intermediate
 ---
-
 # Static Web Artifacts Builder
 
 To build high-density static infographic artifacts, follow these steps:

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: task-decomposer
-description: >
-  Produces structured phased task boards from feature requests: dependency-mapped work items
-  with parallelization flags, risk flags, edge case tables, and test strategy matrices.
-  Triggers on: "decompose this feature", "task breakdown with dependencies", "phased
-  implementation plan", "dependency map for", "break this into tasks with phases",
-  "work breakdown structure". The differentiator is the structured output format (phased
-  tables, parallelization flags, dependency chains) — use this skill when you need a
-  formal task board, not ad-hoc decomposition the model handles natively.
-  NOT for effort estimates, PERT calculations, or confidence intervals — use
-  estimate-calibrator instead.
+description: 'Produces structured phased task boards from feature requests: dependency-mapped
+  work items with parallelization flags, risk flags, edge case tables, and test strategy
+  matrices. Triggers on: "decompose this feature", "task breakdown with dependencies",
+  "phased implementation plan", "dependency map for", "break this into tasks with
+  phases", "work breakdown structure". The differentiator is the structured output
+  format (phased tables, parallelization flags, dependency chains) — use this skill
+  when you need a formal task board, not ad-hoc decomposition the model handles natively.
+  NOT for effort estimates, PERT calculations, or confidence intervals — use estimate-calibrator
+  instead.
+
+  '
 metadata:
   version: 1.1.0
+  category: development
+  tags: [task-breakdown, dependencies, planning, phased]
+  difficulty: intermediate
 ---
-
 # Task Decomposer
 
 Transforms ambiguous feature requests into concrete, implementable task sequences:

--- a/skills/tavily/SKILL.md
+++ b/skills/tavily/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: tavily
-description: >
-  AI-optimized web search via Tavily API. Use this skill when no specific URL is provided
-  and the user needs to search the web for current information, recent events, technical
-  documentation, or news. Triggers on: "search the web", "look this up online", "find
-  recent information about", "search for", "google this", "web search", "look up", "find
-  current data on", "what does the web say about", "research online". NOT for fetching a
-  known URL — use web-fetch for that. Tavily returns clean, AI-ready snippets optimized
-  for search-first intent.
+description: 'AI-optimized web search via Tavily API. Use this skill when no specific
+  URL is provided and the user needs to search the web for current information, recent
+  events, technical documentation, or news. Triggers on: "search the web", "look this
+  up online", "find recent information about", "search for", "google this", "web search",
+  "look up", "find current data on", "what does the web say about", "research online".
+  NOT for fetching a known URL — use web-fetch for that. Tavily returns clean, AI-ready
+  snippets optimized for search-first intent.
+
+  '
 metadata:
   version: 1.1.0
+  category: research
+  tags: [web-search, research, real-time, ai-optimized]
+  difficulty: beginner
 ---
-
 # Tavily Search
 
 Web search and URL content extraction powered by Tavily API. Returns clean, structured results

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: test-harness
-description: >
-  Generates comprehensive pytest test suites: happy path, edge cases, error conditions,
-  fixture scaffolding, mock strategy, and async patterns. Analyzes function signatures,
-  dependency chains, and complexity hotspots to produce runnable, parametrized test files.
-  Triggers on: "generate tests", "write tests for", "test this function", "test this class",
-  "create test suite", "what tests should I write", "pytest for", "unit tests for",
-  "mock strategy for", "how to test", "test coverage for", "write a test file".
-  Use this skill when given a Python function, class, or module and asked to produce tests.
+description: 'Generates comprehensive pytest test suites: happy path, edge cases,
+  error conditions, fixture scaffolding, mock strategy, and async patterns. Analyzes
+  function signatures, dependency chains, and complexity hotspots to produce runnable,
+  parametrized test files. Triggers on: "generate tests", "write tests for", "test
+  this function", "test this class", "create test suite", "what tests should I write",
+  "pytest for", "unit tests for", "mock strategy for", "how to test", "test coverage
+  for", "write a test file". Use this skill when given a Python function, class, or
+  module and asked to produce tests.
+
+  '
 metadata:
   version: 1.1.0
+  category: development
+  tags: [testing, pytest, test-generation, python]
+  difficulty: intermediate
 ---
-
 # Test Harness
 
 Systematic test suite generation that transforms source code into comprehensive, runnable

--- a/skills/to-markdown/SKILL.md
+++ b/skills/to-markdown/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: to-markdown
-description: >
-  Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX), Excel
-  (XLSX), PowerPoint (PPTX), HTML, images (EXIF + OCR), audio (transcription),
-  CSV, JSON, XML, YouTube URLs, EPubs, and more. Output is optimised for LLM
-  pipelines, knowledge bases, and document ingestion workflows.
-  Use this skill whenever the user wants to: convert a file to markdown,
-  extract text from a document, scrape a URL to markdown, turn a PDF into
-  readable text, "get the content of this file", ingest documents for RAG,
-  prepare files for an LLM, or says "convert to md / markdown".
-  Trigger on: "convert to markdown", "extract text from PDF", "turn this into
-  markdown", "scrape this URL", "file to md", "document ingestion", "read this
-  PDF", "get contents of", "parse this document", "ingest for RAG".
+description: 'Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX),
+  Excel (XLSX), PowerPoint (PPTX), HTML, images (EXIF + OCR), audio (transcription),
+  CSV, JSON, XML, YouTube URLs, EPubs, and more. Output is optimised for LLM pipelines,
+  knowledge bases, and document ingestion workflows. Use this skill whenever the user
+  wants to: convert a file to markdown, extract text from a document, scrape a URL
+  to markdown, turn a PDF into readable text, "get the content of this file", ingest
+  documents for RAG, prepare files for an LLM, or says "convert to md / markdown".
+  Trigger on: "convert to markdown", "extract text from PDF", "turn this into markdown",
+  "scrape this URL", "file to md", "document ingestion", "read this PDF", "get contents
+  of", "parse this document", "ingest for RAG".
+
+  '
 metadata:
   version: 1.0.0
+  category: visualization
+  tags: [conversion, markdown, document-ingestion, pdf]
+  difficulty: beginner
 ---
-
 # To Markdown
 
 Convert any file or URL to clean Markdown using [MarkItDown](https://github.com/microsoft/markitdown) as the conversion engine, with a lightweight fetch layer for URLs.

--- a/skills/web-fetch/SKILL.md
+++ b/skills/web-fetch/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: web-fetch
-description: >
-  Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch
-  MCP server (fetch_html, fetch_json, fetch_markdown, fetch_txt). Use this skill when
-  a specific URL is provided and the user wants its content. Covers HTTP GET/POST,
-  JSON API consumption with jq, HTML retrieval, markdown conversion, plain text
-  extraction, authenticated requests, redirects, cookies, and timeouts. Trigger
-  phrases: "fetch this URL", "get the page content", "download HTML", "call this
-  API", "curl this endpoint", "grab the JSON", "fetch markdown from", "retrieve web
-  content", "hit this endpoint", "scrape this page", "read this URL", "pull data
-  from API", "make an HTTP request", "extract page content", "get article text". NOT
-  for web searches without a URL — use tavily for that.
+description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces
+  the Fetch MCP server (fetch_html, fetch_json, fetch_markdown, fetch_txt). Use this
+  skill when a specific URL is provided and the user wants its content. Covers HTTP
+  GET/POST, JSON API consumption with jq, HTML retrieval, markdown conversion, plain
+  text extraction, authenticated requests, redirects, cookies, and timeouts. Trigger
+  phrases: "fetch this URL", "get the page content", "download HTML", "call this API",
+  "curl this endpoint", "grab the JSON", "fetch markdown from", "retrieve web content",
+  "hit this endpoint", "scrape this page", "read this URL", "pull data from API",
+  "make an HTTP request", "extract page content", "get article text". NOT for web
+  searches without a URL — use tavily for that.
+
+  '
 metadata:
   version: 1.1.0
+  category: content
+  tags: [http, curl, api, web-content]
+  difficulty: beginner
 ---
-
 # Web Fetch
 
 All web content retrieval uses `curl` (Bash) or the built-in `WebFetch` tool. No MCP

--- a/skills/youtube-analysis/SKILL.md
+++ b/skills/youtube-analysis/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: youtube-analysis
-description: >
-  Extract YouTube video transcripts and produce structured concept analysis
-  with multi-level summaries, key concepts, and actionable takeaways. Pure
-  Python, no API keys, no MCP dependency. Fetches transcripts via
-  youtube-transcript-api with yt-dlp fallback, then Claude analyzes the
-  content directly. Use this skill when the user mentions: analyze youtube
-  video, youtube transcript, summarize this video, what does this video
-  cover, extract concepts from video, video analysis, watch this for me,
-  break down this talk, youtube URL, video summary, lecture notes from
-  video, podcast transcript, conference talk notes, tech talk breakdown,
-  video key points, TL;DR of video, video takeaways, or pastes any URL
-  containing youtube.com or youtu.be.
+description: 'Extract YouTube video transcripts and produce structured concept analysis
+  with multi-level summaries, key concepts, and actionable takeaways. Pure Python,
+  no API keys, no MCP dependency. Fetches transcripts via youtube-transcript-api with
+  yt-dlp fallback, then Claude analyzes the content directly. Use this skill when
+  the user mentions: analyze youtube video, youtube transcript, summarize this video,
+  what does this video cover, extract concepts from video, video analysis, watch this
+  for me, break down this talk, youtube URL, video summary, lecture notes from video,
+  podcast transcript, conference talk notes, tech talk breakdown, video key points,
+  TL;DR of video, video takeaways, or pastes any URL containing youtube.com or youtu.be.
+
+  '
 metadata:
   version: 1.1.0
+  category: visualization
+  tags: [youtube, analysis, skill]
+  difficulty: intermediate
 ---
-
 # YouTube Analysis
 
 Extract transcripts from YouTube videos and produce structured concept analysis — key ideas, arguments, technical terms, takeaways, and multi-level summaries — all without API keys or MCP servers.

--- a/skills/youtube-search/SKILL.md
+++ b/skills/youtube-search/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: youtube-search
-description: >
-  Search YouTube by keyword and return structured video metadata (title, URL,
-  channel, views, duration, upload date). Uses yt-dlp for scraping — no API
-  keys required. Returns ranked results for discovery, trend analysis, and
-  source curation. Use this skill when the user mentions: search youtube,
-  youtube search, find youtube videos, find videos about, top youtube videos on,
-  trending videos on, youtube results for, look up on youtube, what videos exist
-  about, discover youtube content, youtube for research, curate youtube sources,
-  yt search, search for videos, find me videos, youtube trending, popular videos
-  about, latest videos on, youtube discovery, or uses /yt-search.
+description: 'Search YouTube by keyword and return structured video metadata (title,
+  URL, channel, views, duration, upload date). Uses yt-dlp for scraping — no API keys
+  required. Returns ranked results for discovery, trend analysis, and source curation.
+  Use this skill when the user mentions: search youtube, youtube search, find youtube
+  videos, find videos about, top youtube videos on, trending videos on, youtube results
+  for, look up on youtube, what videos exist about, discover youtube content, youtube
+  for research, curate youtube sources, yt search, search for videos, find me videos,
+  youtube trending, popular videos about, latest videos on, youtube discovery, or
+  uses /yt-search.
+
+  '
 metadata:
   version: 1.1.0
+  category: research
+  tags: [youtube, search, skill]
+  difficulty: beginner
 ---
-
 # YouTube Search
 
 Search YouTube by keyword and return structured video metadata — title, URL,

--- a/utilities/arxiv-search/UTILITY.md
+++ b/utilities/arxiv-search/UTILITY.md
@@ -1,26 +1,24 @@
 ---
 name: arxiv-search
 type: utility
-description: >
-  Searches arXiv for academic papers by keyword, author, title, or category and
-  outputs structured JSON with full metadata (title, authors, abstract, dates,
+description: 'Searches arXiv for academic papers by keyword, author, title, or category
+  and outputs structured JSON with full metadata (title, authors, abstract, dates,
   categories, DOI, PDF URL). Supports field-prefixed queries (au:, ti:, abs:, cat:),
   sorting by relevance/date, result limits, and direct ID lookup. Use this utility
   when you need to discover research papers, build a reading list, gather references
-  for a literature review, fetch paper metadata by arXiv ID, or survey recent
-  publications in a research area. Complements research-critique (per-paper analysis)
-  and literature-review (multi-paper synthesis).
+  for a literature review, fetch paper metadata by arXiv ID, or survey recent publications
+  in a research area. Complements research-critique (per-paper analysis) and literature-review
+  (multi-paper synthesis).
+
+  '
 metadata:
   version: 1.0.0
-  complements:
-    - literature-review
-    - research-critique
-utility:
-  runtime: python
-  entry_point: scripts/arxiv_search.py
-  executable: true
+  complements: [literature-review, research-critique]
+  category: review
+  tags: [arxiv, academic, papers, search]
+  difficulty: beginner
+utility: {runtime: python, entry_point: scripts/arxiv_search.py, executable: true}
 ---
-
 # arxiv-search
 
 Search arXiv and retrieve structured paper metadata.

--- a/utilities/dependency-tree/UTILITY.md
+++ b/utilities/dependency-tree/UTILITY.md
@@ -1,21 +1,21 @@
 ---
 name: dependency-tree
 type: utility
-description: >
-  Parses project dependency configuration files (pyproject.toml, package.json, go.mod)
-  and prints a formatted dependency tree to stdout. Auto-detects project type from files
-  present in the working directory. Supports depth limiting for large dependency graphs.
-  Use this utility when you need to visualize project dependencies, inspect version
-  constraints, or get a quick overview of what a project depends on without running
-  package manager commands.
+description: 'Parses project dependency configuration files (pyproject.toml, package.json,
+  go.mod) and prints a formatted dependency tree to stdout. Auto-detects project type
+  from files present in the working directory. Supports depth limiting for large dependency
+  graphs. Use this utility when you need to visualize project dependencies, inspect
+  version constraints, or get a quick overview of what a project depends on without
+  running package manager commands.
+
+  '
 metadata:
   version: 1.0.0
-utility:
-  runtime: python
-  entry_point: scripts/dependency_tree.py
-  executable: true
+  category: visualization
+  tags: [dependencies, tree, analysis, packages]
+  difficulty: intermediate
+utility: {runtime: python, entry_point: scripts/dependency_tree.py, executable: true}
 ---
-
 # dependency-tree
 
 Parse and display project dependencies as a formatted tree.

--- a/utilities/test-coverage-report/UTILITY.md
+++ b/utilities/test-coverage-report/UTILITY.md
@@ -1,20 +1,20 @@
 ---
 name: test-coverage-report
 type: utility
-description: >
-  Summarizes test coverage for recently changed files by comparing git diffs against
-  existing test files. Runs git diff to identify changed source files, checks whether
-  corresponding test files exist, and prints a summary table. Exits non-zero if any
-  changed source file lacks a test file. Use this utility when reviewing a branch or
-  commit to verify that changed code has accompanying tests before merging.
+description: 'Summarizes test coverage for recently changed files by comparing git
+  diffs against existing test files. Runs git diff to identify changed source files,
+  checks whether corresponding test files exist, and prints a summary table. Exits
+  non-zero if any changed source file lacks a test file. Use this utility when reviewing
+  a branch or commit to verify that changed code has accompanying tests before merging.
+
+  '
 metadata:
   version: 1.0.0
-utility:
-  runtime: python
-  entry_point: scripts/coverage_report.py
-  executable: true
+  category: review
+  tags: [coverage, testing, reports, metrics]
+  difficulty: intermediate
+utility: {runtime: python, entry_point: scripts/coverage_report.py, executable: true}
 ---
-
 # test-coverage-report
 
 Check that recently changed source files have corresponding test files.


### PR DESCRIPTION
## Summary

- Add `category`, `tags`, and `difficulty` metadata to all 92 package definition files
- Enrich manifest.yaml with the new metadata fields for machine-readable discovery
- Add `armory-search` CLI command with weighted scoring and filters
- Expand profiles from 4 to 9 role-based bundles with `--list-profiles` flag
- Upgrade skill-library to handle all 7 package types (v2.0.0)
- Document metadata fields in CONTRIBUTING.md

## Metadata Enrichment (92 packages)

Every package now has three structured metadata fields under `metadata:`:

```yaml
metadata:
  version: 1.1.0
  category: review
  tags: [code-review, pull-request, quality, diff-analysis]
  difficulty: intermediate
```

### Categories (9 values)

| Category | Count | Examples |
|----------|-------|---------|
| `review` | 39 | pr-review, code-reviewer, architecture-reviewer |
| `development` | 13 | test-harness, debug-investigator, github |
| `visualization` | 9 | architecture-diagram, concept-to-image, remotion-video |
| `content` | 7 | humanize, linkedin-post-style, changelog-composer |
| `research` | 7 | literature-review, research-critique, youtube-analysis |
| `operations` | 7 | ship-workflow, release-captain, git-protection |
| `data` | 4 | sql-optimizer, migration-risk-analyzer, benchmark-runner |
| `business` | 3 | idea-validator, market-analyzer, competitive-analyzer |
| `security` | 3 | repo-sentinel, secret-scanner, security-reviewer |

### Difficulty distribution

- `beginner`: 14 packages (filesystem, regex-builder, web-fetch, etc.)
- `intermediate`: 62 packages (most skills and agents)
- `advanced`: 16 packages (architecture-reviewer, gpu-optimizer, rag-auditor, etc.)

### Manifest enrichment

`generate_manifest.py` now extracts `tags`, `category`, and `difficulty` from frontmatter metadata into manifest entries. The regenerated manifest includes these fields for all 92 packages, enabling CLI search and external tooling to filter without parsing individual definition files.

## CLI Search (`scripts/search.py`)

New `armory-search` command for terminal-based package discovery:

```bash
armory-search security          # Weighted keyword search
armory-search --type agent      # Filter by package type
armory-search --category review # Filter by category
armory-search --tag python      # Filter by tag
armory-search --list-categories # Show all categories with counts
armory-search --list-tags       # Show all tags with counts
armory-search --limit 5 sql     # Limit results
```

### Scoring weights

| Signal | Weight | Example |
|--------|--------|---------|
| Exact name match | +10 | `armory-search pr-review` |
| Tag match | +5 | `armory-search --tag code-review` |
| Category match | +4 | `armory-search security` matches category |
| Description substring | +2 | `armory-search vulnerability` |
| Fuzzy name match | +1 | `armory-search review` matches `pr-review` |

Results sorted by score descending, then name ascending. Default limit: 20.

Entry point added to pyproject.toml: `armory-search = "scripts.search:main"`

## Role-Based Profiles

Expanded from 4 to 9 profiles in `profiles.yaml`:

| Profile | Description | Includes |
|---------|-------------|----------|
| `core` | Review and commit lifecycle essentials | — |
| `developer` | Core + testing, debugging, architecture | core |
| `python-dev` | Python TDD, type checking, security | core |
| `security-engineer` | Full security stack with agents | core |
| `content-creator` | Writing, presentations, visual production | — |
| `researcher` | Academic research and literature survey | — |
| `business-analyst` | Idea validation, market, competitive analysis | — |
| `security` | Core + security auditing (lightweight) | core |
| `full` | Every available package | — |

New `--list-profiles` flag on the installer:

```bash
uv run scripts/install.py --list-profiles    # Show all profiles
uv run scripts/install.py --profile python-dev  # Install Python dev stack
```

## Skill-Library v2.0.0

Upgraded from skills-only to full package catalog:

- `/library list` shows all 7 types with type column
- `/library list --type agent` filters by type
- `/library search <keyword>` searches across all package types
- `/library search --category security` filters by category
- `/library use <name>` auto-detects type from manifest
- `/library profiles` shows available install profiles
- Type detection resolves correct install target (`~/.claude/{type}/`)

## CONTRIBUTING.md

New "Metadata Fields" section documenting:
- Valid categories table (9 values with descriptions)
- Tag guidelines (3-6 lowercase kebab-case keywords)
- Difficulty level criteria (beginner/intermediate/advanced)
- Updated skill frontmatter example with all metadata fields

## Test plan

- [x] `uv run scripts/validate_frontmatter.py` — 92 packages pass
- [x] `uv run scripts/validate_references.py` — all references intact
- [x] `uv run scripts/validate_evals.py` — all eval schemas valid
- [x] `uv run python -m pytest tests/ -q` — 205 tests pass
- [x] `uv run scripts/generate_manifest.py` + verify tags/category/difficulty in output
- [x] `uv run scripts/search.py security` — returns 13 ranked results
- [x] `uv run scripts/search.py --list-categories` — 9 categories with counts
- [x] `uv run scripts/search.py --list-tags` — all tags with counts
- [x] `uv run scripts/search.py --type agent` — filters to agents only
- [x] `uv run scripts/install.py --list-profiles` — shows 9 profiles with descriptions