### PR TITLE
feat(cost-tracker): add per-tool token tracking, waste detection, and supporting hooks

### DIFF
--- a/hooks/anatomy-index/HOOK.md
+++ b/hooks/anatomy-index/HOOK.md
@@ -1,0 +1,70 @@
+---
+name: anatomy-index
+type: hook
+description: 'Generates and maintains a project file index with one-line descriptions
+  and token estimates. On session start or first tool use, builds .claude/anatomy.md
+  by walking the project tree. Before Read, displays the target file summary so Claude
+  can decide to skip. After Write/Edit, updates the changed file entry in the index.
+  Respects .gitignore exclusions.
+
+  '
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [context, index, anatomy, efficiency]
+  difficulty: intermediate
+hook:
+  events: [PreToolUse, PostToolUse]
+  matcher: ''
+  handler: {type: command, command: bash handler.sh, timeout_ms: 10000}
+---
+# anatomy-index
+
+Maintains a lightweight project file index so Claude can make informed decisions
+about which files to read.
+
+## How It Works
+
+### Index Generation
+
+On first invocation (when `.claude/anatomy.md` does not exist), the hook walks the
+project tree and generates an index with one line per file:
+
+```
+src/config.ts | Configuration loader and validator | ~320 tokens
+src/index.ts  | Express app entry point            | ~180 tokens
+```
+
+### Pre-Read Summary
+
+Before a `Read` tool invocation, the hook looks up the target file in the index
+and emits its summary line to stderr. This lets Claude decide whether the read
+is necessary based on the description and token cost.
+
+### Post-Write/Edit Update
+
+After a `Write` or `Edit` tool invocation, the hook updates the changed file's
+entry in the index with fresh description and token estimate.
+
+## Description Extraction
+
+Extracts the first meaningful comment or docstring from source files:
+
+- **Python**: first docstring (`"""..."""`) or `# comment` at module level
+- **TypeScript/JavaScript**: first `//` or `/** ... */` comment
+- Falls back to filename-based description for other file types
+
+Descriptions are truncated to ~80 characters.
+
+## Token Estimation
+
+Uses `file_size_bytes / 4` as a rough heuristic.
+
+## Exclusions
+
+Respects `.gitignore` patterns and excludes common directories:
+`node_modules`, `__pycache__`, `.git`, `dist`, `build`, `.next`, `venv`, `.venv`
+
+## Index Location
+
+`.claude/anatomy.md` in the project root.

--- a/hooks/anatomy-index/evals/cases.yaml
+++ b/hooks/anatomy-index/evals/cases.yaml
@@ -46,3 +46,10 @@ cases:
     rubric:
       - "Hook should not perform any index operations on Bash tool use"
     trigger_expected: false
+
+  - id: no_trigger_on_grep
+    prompt: "Search the codebase for function definitions using Grep"
+    fixtures: []
+    rubric:
+      - "Hook should not perform any index operations on Grep tool use"
+    trigger_expected: false

--- a/hooks/anatomy-index/evals/cases.yaml
+++ b/hooks/anatomy-index/evals/cases.yaml
@@ -1,0 +1,48 @@
+cases:
+  - id: index_generated_on_first_use
+    prompt: "Read a file in a project that has no .claude/anatomy.md yet"
+    fixtures: []
+    rubric:
+      - "Hook should generate .claude/anatomy.md on first invocation"
+      - "Index should contain file paths, descriptions, and token estimates"
+      - "Index should respect .gitignore and exclude node_modules, __pycache__, etc."
+    trigger_expected: true
+
+  - id: pre_read_shows_summary
+    prompt: "Read src/config.ts in a project with an existing anatomy index"
+    fixtures: []
+    rubric:
+      - "Hook should emit the file's summary line to stderr before the read proceeds"
+      - "Summary should include file path, description, and token estimate"
+    trigger_expected: true
+
+  - id: post_write_updates_index
+    prompt: "Write a new file src/utils.ts and verify the index updates"
+    fixtures: []
+    rubric:
+      - "Hook should add or update the file's entry in .claude/anatomy.md after Write"
+      - "Updated entry should reflect the new file's description and token count"
+    trigger_expected: true
+
+  - id: post_edit_updates_index
+    prompt: "Edit src/config.ts to add a new function"
+    fixtures: []
+    rubric:
+      - "Hook should update the file's entry in .claude/anatomy.md after Edit"
+      - "Token estimate should reflect the new file size"
+    trigger_expected: true
+
+  - id: gitignore_exclusion
+    prompt: "Generate index in a project with node_modules and __pycache__ directories"
+    fixtures: []
+    rubric:
+      - "Index should not contain any files from node_modules or __pycache__"
+      - "Index should only contain tracked/untracked non-ignored files"
+    trigger_expected: true
+
+  - id: no_trigger_on_bash
+    prompt: "Run a Bash command to check disk space"
+    fixtures: []
+    rubric:
+      - "Hook should not perform any index operations on Bash tool use"
+    trigger_expected: false

--- a/hooks/anatomy-index/handler.sh
+++ b/hooks/anatomy-index/handler.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# anatomy-index hook — maintains .claude/anatomy.md project file index.
+# Dispatches based on tool_name from stdin JSON.
+# Always exits 0 (informational only, never blocks tools).
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+INDEX_DIR=".claude"
+INDEX_FILE="${INDEX_DIR}/anatomy.md"
+
+EXCLUDE_DIRS="node_modules|__pycache__|\.git|dist|build|\.next|venv|\.venv|\.mypy_cache|\.pytest_cache|\.tox|\.eggs"
+
+# --- Helpers ---
+
+estimate_tokens() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    local bytes
+    bytes=$(wc -c < "$file" | tr -d ' ')
+    echo $((bytes / 4))
+  else
+    echo 0
+  fi
+}
+
+extract_description() {
+  local file="$1"
+  local ext="${file##*.}"
+  local desc=""
+
+  case "$ext" in
+    py)
+      # First docstring or comment
+      desc=$(sed -n '1,20{
+        /^[[:space:]]*"""/{
+          s/^[[:space:]]*"""//
+          s/"""[[:space:]]*$//
+          /^$/!{p;q;}
+          n
+          s/^[[:space:]]*//
+          s/""".*//
+          p;q
+        }
+        /^[[:space:]]*#[[:space:]]/{
+          s/^[[:space:]]*#[[:space:]]*//
+          p;q
+        }
+      }' "$file" 2>/dev/null)
+      ;;
+    ts|js|tsx|jsx|mjs|cjs)
+      # First // comment or /** */ block
+      desc=$(sed -n '1,20{
+        /^[[:space:]]*\/\/[[:space:]]/{
+          s/^[[:space:]]*\/\/[[:space:]]*//
+          p;q
+        }
+        /^[[:space:]]*\/\*\*/{
+          s/^[[:space:]]*\/\*\*[[:space:]]*//
+          s/[[:space:]]*\*\/.*//
+          /^$/!{p;q;}
+          n
+          s/^[[:space:]]*\*[[:space:]]*//
+          s/[[:space:]]*\*\/.*//
+          p;q
+        }
+      }' "$file" 2>/dev/null)
+      ;;
+    sh|bash|zsh)
+      # First # comment after shebang
+      desc=$(sed -n '1,10{
+        /^#!/d
+        /^[[:space:]]*#[[:space:]]/{
+          s/^[[:space:]]*#[[:space:]]*//
+          p;q
+        }
+      }' "$file" 2>/dev/null)
+      ;;
+  esac
+
+  if [ -z "$desc" ]; then
+    desc=$(basename "$file")
+  fi
+
+  # Truncate to ~80 chars
+  printf '%s' "$desc" | head -c 80
+}
+
+build_index_line() {
+  local file="$1"
+  local tokens
+  local desc
+  tokens=$(estimate_tokens "$file")
+  desc=$(extract_description "$file")
+  printf '%-50s | %-60s | ~%s tokens\n' "$file" "$desc" "$tokens"
+}
+
+should_exclude() {
+  local path="$1"
+  echo "$path" | grep -qE "(^|/)(${EXCLUDE_DIRS})(/|$)"
+}
+
+build_full_index() {
+  mkdir -p "$INDEX_DIR"
+
+  {
+    echo "# Project Anatomy"
+    echo ""
+    echo "Auto-generated file index. One line per file with description and token estimate."
+    echo ""
+    echo '```'
+  } > "$INDEX_FILE"
+
+  # Use git ls-files if in a git repo, otherwise find
+  local files
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    files=$(git ls-files --cached --others --exclude-standard 2>/dev/null | sort)
+  else
+    files=$(find . -type f -not -path '*/\.*' | sed 's|^\./||' | sort)
+  fi
+
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    if should_exclude "$f"; then
+      continue
+    fi
+    # Skip binary files and very large files (>100KB)
+    if [ -f "$f" ] && [ "$(wc -c < "$f" | tr -d ' ')" -lt 102400 ]; then
+      if file -b --mime-type "$f" 2>/dev/null | grep -q "^text/"; then
+        build_index_line "$f" >> "$INDEX_FILE"
+      fi
+    fi
+  done <<< "$files"
+
+  echo '```' >> "$INDEX_FILE"
+}
+
+update_index_entry() {
+  local file="$1"
+  if [ ! -f "$INDEX_FILE" ]; then
+    return
+  fi
+  local new_line
+  new_line=$(build_index_line "$file")
+  # Remove old entry and add new one
+  local escaped_file
+  escaped_file=$(printf '%s' "$file" | sed 's/[.[\/*^$]/\\&/g')
+  if grep -q "^${escaped_file}" "$INDEX_FILE" 2>/dev/null; then
+    sed -i '' "/^${escaped_file}/c\\
+${new_line}" "$INDEX_FILE" 2>/dev/null || true
+  else
+    # Insert before closing ``` marker
+    sed -i '' "/^\`\`\`$/i\\
+${new_line}" "$INDEX_FILE" 2>/dev/null || true
+  fi
+}
+
+lookup_file() {
+  local file="$1"
+  if [ ! -f "$INDEX_FILE" ]; then
+    return
+  fi
+  local escaped_file
+  escaped_file=$(printf '%s' "$file" | sed 's/[.[\/*^$]/\\&/g')
+  local entry
+  entry=$(grep "^${escaped_file}" "$INDEX_FILE" 2>/dev/null || true)
+  if [ -n "$entry" ]; then
+    echo "📋 ${entry}" >&2
+  fi
+}
+
+# --- Main dispatch ---
+
+# Build index if it doesn't exist yet
+if [ ! -f "$INDEX_FILE" ]; then
+  build_full_index
+fi
+
+case "${TOOL_NAME}" in
+  Read)
+    FILE_PATH=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+    if [ -n "$FILE_PATH" ]; then
+      # Convert to relative path if possible
+      REL_PATH="${FILE_PATH#$PWD/}"
+      lookup_file "$REL_PATH"
+    fi
+    ;;
+  Write|Edit)
+    FILE_PATH=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+    if [ -n "$FILE_PATH" ]; then
+      REL_PATH="${FILE_PATH#$PWD/}"
+      update_index_entry "$REL_PATH"
+    fi
+    ;;
+  *)
+    # Other tools — no action needed
+    ;;
+esac
+
+exit 0

--- a/hooks/cost-tracker/HOOK.md
+++ b/hooks/cost-tracker/HOOK.md
@@ -1,30 +1,75 @@
 ---
 name: cost-tracker
 type: hook
-description: 'Logs session cost and token usage to a CSV file after each Claude Code
-  session completes. Fires on the Stop event, reads cost and token data from the session
-  summary JSON on stdin, and appends a row to ~/.claude/cost-log.csv. Use this hook
-  when you want to track API spending over time, identify expensive sessions, or generate
-  usage reports from the CSV data.
+description: 'Tracks per-tool token usage, waste indicators, and session costs. Fires
+  on PostToolUse for Read/Write/Edit to estimate tokens per operation and detect wasteful
+  patterns (repeated reads, large reads with anatomy summaries, full-file reads). On
+  Stop, writes a backward-compatible CSV row and a companion JSON summary with per-tool
+  token breakdowns, waste percentage, and top 5 wasteful operations. Integrates with
+  read-dedup tracker and anatomy-index for cross-hook waste detection.
 
   '
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   category: operations
-  tags: [cost, tokens, usage, logging]
-  difficulty: beginner
+  tags: [cost, tokens, usage, logging, waste, efficiency]
+  difficulty: intermediate
 hook:
-  events: [Stop]
+  events: [PostToolUse, Stop]
   matcher: ''
   handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
 ---
 # cost-tracker
 
-Records session cost and token usage to a local CSV file.
+Tracks per-tool token usage, waste indicators, and session-level costs.
 
-## CSV Format
+## Events
 
-The log file is stored at `~/.claude/cost-log.csv` with the following columns:
+| Event | Matcher | Purpose |
+|-------|---------|---------|
+| `PostToolUse` | `Read` | Estimate read tokens, detect waste patterns |
+| `PostToolUse` | `Write` | Estimate write tokens |
+| `PostToolUse` | `Edit` | Estimate edit tokens (old_string + new_string) |
+| `Stop` | — | Write CSV row + companion JSON summary |
+
+## Per-Tool Token Tracking
+
+Each `Read`, `Write`, or `Edit` invocation appends a JSONL record to
+`/tmp/.claude-cost-tracker-{session_id}.jsonl`:
+
+```json
+{"ts":"2026-03-29T12:00:00Z","tool":"Read","file":"/src/config.ts","tokens":320,"waste":"none"}
+```
+
+Token estimation uses the `bytes / 4` heuristic. For `Edit` operations,
+tokens are estimated from the combined size of `old_string` + `new_string`
+rather than the full file.
+
+## Waste Detection
+
+Three waste indicators are tracked on `Read` operations:
+
+| Waste Type | Trigger |
+|-----------|---------|
+| `repeated_read` | File appears >1 time in the read-dedup tracker |
+| `large_read_with_anatomy` | File is >1000 tokens and has an anatomy-index entry |
+| `full_file_read` | File is >2000 tokens and read without `offset`/`limit` params |
+
+Multiple waste types on a single read are joined with `+`
+(e.g., `repeated_read+full_file_read`).
+
+### Cross-Hook Integration
+
+- **read-dedup**: Reads `/tmp/.claude-read-tracker-{session_id}.txt` to detect
+  duplicate file reads without duplicating tracking logic.
+- **anatomy-index**: Checks `.claude/anatomy.md` for file summaries to flag
+  large reads where a summary was available.
+
+## Output Files
+
+### CSV (backward compatible)
+
+`~/.claude/cost-log.csv` — one row per session, unchanged format:
 
 | Column | Description |
 |--------|-------------|
@@ -33,9 +78,34 @@ The log file is stored at `~/.claude/cost-log.csv` with the following columns:
 | `total_cost` | Total API cost in USD |
 | `total_tokens` | Total tokens consumed (input + output) |
 
-## Usage
+### Companion JSON
 
-Query spending with standard CLI tools:
+`~/.claude/cost-tracker-summary-{session_id}.json` — per-session summary:
+
+```json
+{
+  "session_id": "abc123",
+  "timestamp": "2026-03-29T12:00:00Z",
+  "total_cost": 0.45,
+  "total_tokens": 12500,
+  "tool_tokens": {
+    "Read": 8200,
+    "Write": 1500,
+    "Edit": 300,
+    "total": 10000
+  },
+  "waste": {
+    "total_waste_tokens": 3200,
+    "waste_pct": 32,
+    "top_operations": [
+      {"file": "/src/large.ts", "tokens": 2000, "type": "full_file_read"},
+      {"file": "/src/config.ts", "tokens": 1200, "type": "repeated_read"}
+    ]
+  }
+}
+```
+
+## Usage
 
 ```bash
 # Total cost this month
@@ -44,12 +114,19 @@ awk -F, 'NR>1 {sum+=$3} END {printf "$%.2f\n", sum}' ~/.claude/cost-log.csv
 # Top 5 most expensive sessions
 sort -t, -k3 -rn ~/.claude/cost-log.csv | head -5
 
-# Daily cost breakdown
-awk -F, 'NR>1 {split($1,d,"T"); costs[d[1]]+=$3} END {for(k in costs) printf "%s: $%.2f\n", k, costs[k]}' ~/.claude/cost-log.csv
+# View waste summary for a session
+cat ~/.claude/cost-tracker-summary-SESSION_ID.json | jq '.waste'
+
+# Find sessions with >20% waste
+for f in ~/.claude/cost-tracker-summary-*.json; do
+  jq -r 'select(.waste.waste_pct > 20) | "\(.session_id): \(.waste.waste_pct)% waste"' "$f" 2>/dev/null
+done
 ```
 
 ## Notes
 
-- The CSV header is written automatically on first use.
-- If cost or token data is missing from the session JSON, the row is still written with zero values.
-- The file grows unbounded — prune manually or with a cron job if needed.
+- The CSV format is unchanged from v1 — existing tooling continues to work.
+- Per-tool JSONL state is cleaned up on Stop. If a session crashes, stale files
+  remain in `/tmp/` and are cleaned by OS temp file rotation.
+- Waste percentages are integer (floor division). A session with zero tool
+  operations reports 0% waste.

--- a/hooks/cost-tracker/evals/cases.yaml
+++ b/hooks/cost-tracker/evals/cases.yaml
@@ -1,10 +1,13 @@
 cases:
+  # --- Stop event (backward compatible) ---
+
   - id: log_session_with_cost
     prompt: "Session ended with $0.45 cost and 12500 tokens used"
     fixtures: []
     rubric:
       - "Hook should fire on Stop event and append a row to cost-log.csv"
       - "CSV row should contain timestamp, session_id, cost, and token count"
+      - "A companion JSON summary should be written to ~/.claude/"
     trigger_expected: true
 
   - id: log_session_zero_cost
@@ -12,18 +15,99 @@ cases:
     fixtures: []
     rubric:
       - "Hook should still log a row even when cost is zero"
+      - "Companion JSON summary should have empty tool_tokens and 0 waste"
     trigger_expected: true
 
-  - id: no_log_on_tool_use
+  # --- PostToolUse: Read ---
+
+  - id: track_read_tokens
+    prompt: "Read a 2KB Python file at /src/utils.py"
+    fixtures: []
+    rubric:
+      - "Hook should fire on PostToolUse for Read tool"
+      - "Should append a JSONL record with tool=Read and tokens ~500"
+      - "Waste type should be none for a first-time, small read"
+    trigger_expected: true
+
+  - id: detect_repeated_read
+    prompt: "Read /src/config.ts for the second time in this session"
+    fixtures: []
+    rubric:
+      - "Hook should detect the file was already in the read-dedup tracker"
+      - "JSONL record waste field should be repeated_read"
+    trigger_expected: true
+
+  - id: detect_large_read_with_anatomy
+    prompt: "Read a 6KB file /src/server.ts that has an anatomy-index entry"
+    fixtures: []
+    rubric:
+      - "Hook should check anatomy.md for the file entry"
+      - "Since the file is >1000 tokens and has an anatomy entry, waste should be large_read_with_anatomy"
+    trigger_expected: true
+
+  - id: detect_full_file_read
+    prompt: "Read a 12KB file /src/big-module.ts without offset or limit"
+    fixtures: []
+    rubric:
+      - "File is >2000 tokens and read without offset/limit params"
+      - "Waste type should include full_file_read"
+    trigger_expected: true
+
+  - id: no_waste_on_partial_read
+    prompt: "Read /src/big-module.ts with offset=100 and limit=50"
+    fixtures: []
+    rubric:
+      - "Even though file is large, offset/limit were provided"
+      - "Waste type should be none (partial read is efficient)"
+    trigger_expected: true
+
+  # --- PostToolUse: Write ---
+
+  - id: track_write_tokens
+    prompt: "Write a new file /src/output.ts with 1KB of content"
+    fixtures: []
+    rubric:
+      - "Hook should fire on PostToolUse for Write tool"
+      - "Should append a JSONL record with tool=Write and tokens ~250"
+      - "Waste type should be none for writes"
+    trigger_expected: true
+
+  # --- PostToolUse: Edit ---
+
+  - id: track_edit_tokens
+    prompt: "Edit /src/config.ts replacing a 50-byte string with a 80-byte string"
+    fixtures: []
+    rubric:
+      - "Hook should fire on PostToolUse for Edit tool"
+      - "Token estimate should be based on old_string + new_string size, not full file"
+      - "Should append a JSONL record with tool=Edit"
+    trigger_expected: true
+
+  # --- Session summary ---
+
+  - id: session_summary_with_waste
+    prompt: "Session ending after 5 reads (2 wasteful), 3 writes, 1 edit"
+    fixtures: []
+    rubric:
+      - "Stop handler should aggregate per-tool tokens from JSONL state"
+      - "Summary JSON should show Read/Write/Edit token breakdowns"
+      - "Waste section should report waste_pct > 0 and list top operations"
+      - "CSV row should still be written for backward compatibility"
+      - "JSONL state file should be cleaned up after summary generation"
+    trigger_expected: true
+
+  # --- Non-matching events ---
+
+  - id: no_track_on_bash
     prompt: "Run a Bash command to check disk space"
     fixtures: []
     rubric:
-      - "Hook should not fire on PreToolUse events — only on Stop"
+      - "Hook should not track tokens for Bash tool invocations"
     trigger_expected: false
 
-  - id: no_log_on_edit
-    prompt: "Edit a Python file to fix a typo"
+  - id: no_track_on_grep
+    prompt: "Search codebase for function definitions"
     fixtures: []
     rubric:
-      - "Hook should not fire on Edit tool use — only on Stop"
+      - "Hook should not track tokens for Grep tool invocations"
     trigger_expected: false

--- a/hooks/cost-tracker/handler.sh
+++ b/hooks/cost-tracker/handler.sh
@@ -1,29 +1,258 @@
 #!/usr/bin/env bash
-# cost-tracker hook — appends session cost/token data to CSV.
-# Reads session summary JSON from stdin on Stop event.
-# Always exits 0 (logging should never block shutdown).
+# cost-tracker hook — tracks per-tool token usage, waste indicators, and session costs.
+# Events: PostToolUse (Read, Write, Edit), Stop.
+# Always exits 0 (logging should never block operations).
 
 set -euo pipefail
 
 CSV_FILE="$HOME/.claude/cost-log.csv"
 INPUT=$(cat)
 
-# Write header if file doesn't exist
-if [ ! -f "$CSV_FILE" ]; then
-  echo "timestamp,session_id,total_cost,total_tokens" > "$CSV_FILE"
-fi
+# --- Extract common fields ---
 
-TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
+TOOL_NAME=$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 SESSION_ID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 SESSION_ID=${SESSION_ID:-unknown}
 
-TOTAL_COST=$(printf '%s' "$INPUT" | sed -n 's/.*"total_cost"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p' | head -1)
-TOTAL_COST=${TOTAL_COST:-0}
+# Per-session state: JSONL file with one record per tool invocation
+STATE_FILE="/tmp/.claude-cost-tracker-${SESSION_ID}.jsonl"
 
-TOTAL_TOKENS=$(printf '%s' "$INPUT" | sed -n 's/.*"total_tokens"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
-TOTAL_TOKENS=${TOTAL_TOKENS:-0}
+# --- Helpers ---
 
-echo "${TIMESTAMP},${SESSION_ID},${TOTAL_COST},${TOTAL_TOKENS}" >> "$CSV_FILE"
+estimate_tokens_from_file() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    local bytes
+    bytes=$(wc -c < "$file" | tr -d ' ')
+    echo $((bytes / 4))
+  else
+    echo 0
+  fi
+}
+
+estimate_tokens_from_size() {
+  local bytes="$1"
+  echo $((bytes / 4))
+}
+
+check_read_dedup_tracker() {
+  local file="$1"
+  local tracker="/tmp/.claude-read-tracker-${SESSION_ID}.txt"
+  if [ -f "$tracker" ]; then
+    local count
+    count=$(grep -cxF "$file" "$tracker" 2>/dev/null || echo 0)
+    echo "$count"
+  else
+    echo 0
+  fi
+}
+
+check_anatomy_entry() {
+  local file="$1"
+  local anatomy=".claude/anatomy.md"
+  if [ -f "$anatomy" ]; then
+    local escaped
+    escaped=$(printf '%s' "$file" | sed 's/[.[\/*^$]/\\&/g')
+    if grep -q "^${escaped}" "$anatomy" 2>/dev/null; then
+      echo 1
+    else
+      echo 0
+    fi
+  else
+    echo 0
+  fi
+}
+
+append_operation() {
+  # Appends a JSONL record to the session state file
+  local tool="$1"
+  local file_path="$2"
+  local tokens="$3"
+  local waste_type="$4"
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"ts":"%s","tool":"%s","file":"%s","tokens":%s,"waste":"%s"}\n' \
+    "$timestamp" "$tool" "$file_path" "$tokens" "$waste_type" >> "$STATE_FILE"
+}
+
+# --- PostToolUse: Read ---
+
+handle_read() {
+  local file_path
+  file_path=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  [ -z "$file_path" ] && return
+
+  local tokens
+  tokens=$(estimate_tokens_from_file "$file_path")
+
+  # Determine waste type
+  local waste="none"
+
+  # Check 1: Repeated read (cross-reference read-dedup tracker)
+  local read_count
+  read_count=$(check_read_dedup_tracker "$file_path")
+  if [ "$read_count" -gt 1 ]; then
+    waste="repeated_read"
+  fi
+
+  # Check 2: Large read when anatomy summary existed
+  if [ "$tokens" -gt 1000 ]; then
+    local rel_path="${file_path#$PWD/}"
+    local has_anatomy
+    has_anatomy=$(check_anatomy_entry "$rel_path")
+    if [ "$has_anatomy" -eq 1 ] && [ "$waste" = "none" ]; then
+      waste="large_read_with_anatomy"
+    elif [ "$has_anatomy" -eq 1 ] && [ "$waste" = "repeated_read" ]; then
+      waste="repeated_read+large_read_with_anatomy"
+    fi
+  fi
+
+  # Check 3: Full-file read when partial would suffice
+  # Heuristic: if file >2000 tokens and no offset/limit params detected, flag it
+  local has_offset
+  has_offset=$(printf '%s' "$INPUT" | sed -n 's/.*"offset"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+  local has_limit
+  has_limit=$(printf '%s' "$INPUT" | sed -n 's/.*"limit"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+  if [ "$tokens" -gt 2000 ] && [ -z "$has_offset" ] && [ -z "$has_limit" ]; then
+    if [ "$waste" = "none" ]; then
+      waste="full_file_read"
+    else
+      waste="${waste}+full_file_read"
+    fi
+  fi
+
+  append_operation "Read" "$file_path" "$tokens" "$waste"
+}
+
+# --- PostToolUse: Write ---
+
+handle_write() {
+  local file_path
+  file_path=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  [ -z "$file_path" ] && return
+
+  local tokens
+  tokens=$(estimate_tokens_from_file "$file_path")
+
+  append_operation "Write" "$file_path" "$tokens" "none"
+}
+
+# --- PostToolUse: Edit ---
+
+handle_edit() {
+  local file_path
+  file_path=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  [ -z "$file_path" ] && return
+
+  # For edits, estimate tokens from old_string + new_string sizes rather than full file
+  local old_string new_string
+  old_string=$(printf '%s' "$INPUT" | sed -n 's/.*"old_string"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  new_string=$(printf '%s' "$INPUT" | sed -n 's/.*"new_string"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+  local old_bytes new_bytes tokens
+  old_bytes=${#old_string}
+  new_bytes=${#new_string}
+  tokens=$(estimate_tokens_from_size $((old_bytes + new_bytes)))
+
+  append_operation "Edit" "$file_path" "$tokens" "none"
+}
+
+# --- Stop: Session summary ---
+
+handle_stop() {
+  # Write original CSV row (backward compatible)
+  if [ ! -f "$CSV_FILE" ]; then
+    echo "timestamp,session_id,total_cost,total_tokens" > "$CSV_FILE"
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  local total_cost
+  total_cost=$(printf '%s' "$INPUT" | sed -n 's/.*"total_cost"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p' | head -1)
+  total_cost=${total_cost:-0}
+
+  local total_tokens
+  total_tokens=$(printf '%s' "$INPUT" | sed -n 's/.*"total_tokens"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+  total_tokens=${total_tokens:-0}
+
+  echo "${timestamp},${SESSION_ID},${total_cost},${total_tokens}" >> "$CSV_FILE"
+
+  # Generate companion summary JSON from per-tool state
+  local summary_file="$HOME/.claude/cost-tracker-summary-${SESSION_ID}.json"
+
+  if [ ! -f "$STATE_FILE" ]; then
+    # No per-tool data collected — write minimal summary
+    cat > "$summary_file" <<ENDJSON
+{"session_id":"${SESSION_ID}","timestamp":"${timestamp}","total_cost":${total_cost},"total_tokens":${total_tokens},"tool_tokens":{},"waste":{"total_waste_tokens":0,"waste_pct":0,"operations":[]}}
+ENDJSON
+    return
+  fi
+
+  # Aggregate per-tool tokens
+  local read_tokens=0 write_tokens=0 edit_tokens=0
+  local total_tool_tokens=0
+  local waste_tokens=0
+  local waste_ops=""
+  local waste_count=0
+
+  while IFS= read -r line; do
+    local tool tokens waste
+    tool=$(printf '%s' "$line" | sed -n 's/.*"tool"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    tokens=$(printf '%s' "$line" | sed -n 's/.*"tokens"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+    waste=$(printf '%s' "$line" | sed -n 's/.*"waste"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    tokens=${tokens:-0}
+
+    case "$tool" in
+      Read) read_tokens=$((read_tokens + tokens)) ;;
+      Write) write_tokens=$((write_tokens + tokens)) ;;
+      Edit) edit_tokens=$((edit_tokens + tokens)) ;;
+    esac
+    total_tool_tokens=$((total_tool_tokens + tokens))
+
+    if [ "$waste" != "none" ]; then
+      waste_tokens=$((waste_tokens + tokens))
+      waste_count=$((waste_count + 1))
+      local file_path
+      file_path=$(printf '%s' "$line" | sed -n 's/.*"file"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+      if [ "$waste_count" -le 5 ]; then
+        [ -n "$waste_ops" ] && waste_ops="${waste_ops},"
+        waste_ops="${waste_ops}{\"file\":\"${file_path}\",\"tokens\":${tokens},\"type\":\"${waste}\"}"
+      fi
+    fi
+  done < "$STATE_FILE"
+
+  local waste_pct=0
+  if [ "$total_tool_tokens" -gt 0 ]; then
+    waste_pct=$((waste_tokens * 100 / total_tool_tokens))
+  fi
+
+  cat > "$summary_file" <<ENDJSON
+{"session_id":"${SESSION_ID}","timestamp":"${timestamp}","total_cost":${total_cost},"total_tokens":${total_tokens},"tool_tokens":{"Read":${read_tokens},"Write":${write_tokens},"Edit":${edit_tokens},"total":${total_tool_tokens}},"waste":{"total_waste_tokens":${waste_tokens},"waste_pct":${waste_pct},"top_operations":[${waste_ops}]}}
+ENDJSON
+
+  # Clean up session state file
+  rm -f "$STATE_FILE"
+}
+
+# --- Main dispatch ---
+
+case "${TOOL_NAME:-}" in
+  Read)
+    handle_read
+    ;;
+  Write)
+    handle_write
+    ;;
+  Edit)
+    handle_edit
+    ;;
+  *)
+    # Check if this is a Stop event (no tool_name, but has total_cost/session_id)
+    if printf '%s' "$INPUT" | grep -q '"total_cost"'; then
+      handle_stop
+    fi
+    ;;
+esac
 
 exit 0

--- a/hooks/read-dedup/HOOK.md
+++ b/hooks/read-dedup/HOOK.md
@@ -1,0 +1,52 @@
+---
+name: read-dedup
+type: hook
+description: 'Detects and warns about duplicate file reads within a Claude Code session.
+  Fires on PreToolUse for the Read tool, tracks files read in a session-scoped temp
+  file, and emits a stderr warning with estimated token count when a file is read again.
+  Reduces wasted context by nudging the model to reuse knowledge from earlier reads.
+
+  '
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [context, dedup, tokens, efficiency]
+  difficulty: beginner
+hook:
+  events: [PreToolUse]
+  matcher: Read
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
+---
+# read-dedup
+
+Warns when Claude Code reads the same file twice in a single session.
+
+## How It Works
+
+On every `Read` tool invocation, the hook checks whether the target file has
+already been read during the current session. If so, it emits a stderr warning
+with the file's estimated token count:
+
+```
+⚠ src/config.ts was already read this session (~520 tokens). Use existing knowledge.
+```
+
+The model sees stderr output and can adjust its behavior accordingly.
+
+## Token Estimation
+
+Uses a rough heuristic: `file_size_bytes / 4`. This approximates the typical
+byte-to-token ratio for source code and prose.
+
+## Session Tracking
+
+Read history is stored in `/tmp/.claude-read-tracker-{session_id}.json` as a
+plain newline-delimited list of file paths. The tracker file is cleaned up
+automatically when Claude Code starts a new session (install the `Stop` event
+variant to clean up on exit, or rely on OS temp file cleanup).
+
+## Limitations
+
+- Partial reads (offset/limit) of the same file still count as a duplicate.
+- Token estimate is approximate — actual tokenization varies by content.
+- Does not distinguish between reading different ranges of the same file.

--- a/hooks/read-dedup/evals/cases.yaml
+++ b/hooks/read-dedup/evals/cases.yaml
@@ -1,0 +1,40 @@
+cases:
+  - id: first_read_no_warning
+    prompt: "Read the file src/config.ts for the first time in a session"
+    fixtures: []
+    rubric:
+      - "Hook should fire on PreToolUse for Read tool"
+      - "No warning should be emitted since this is the first read of the file"
+      - "File path should be recorded in the session tracker"
+    trigger_expected: true
+
+  - id: duplicate_read_warns
+    prompt: "Read src/config.ts again after it was already read earlier in the session"
+    fixtures: []
+    rubric:
+      - "Hook should emit a stderr warning mentioning the file path and estimated token count"
+      - "Warning should suggest using existing knowledge instead of re-reading"
+      - "Hook should still exit 0 (read is not blocked)"
+    trigger_expected: true
+
+  - id: different_file_no_warning
+    prompt: "Read src/utils.ts after previously reading src/config.ts"
+    fixtures: []
+    rubric:
+      - "No warning should be emitted since this is a different file"
+      - "Both file paths should be tracked independently"
+    trigger_expected: true
+
+  - id: no_trigger_on_edit
+    prompt: "Edit a Python file to fix a typo"
+    fixtures: []
+    rubric:
+      - "Hook should not fire on Edit tool use — only on Read"
+    trigger_expected: false
+
+  - id: no_trigger_on_bash
+    prompt: "Run a Bash command to list directory contents"
+    fixtures: []
+    rubric:
+      - "Hook should not fire on Bash tool use — only on Read"
+    trigger_expected: false

--- a/hooks/read-dedup/handler.sh
+++ b/hooks/read-dedup/handler.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# read-dedup hook — warns on duplicate file reads within a session.
+# Reads tool input JSON from stdin, extracts file_path.
+# Emits stderr warning with estimated token count on duplicate reads.
+# Always exits 0 (never blocks reads).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+FILE_PATH=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+SESSION_ID=${SESSION_ID:-default}
+
+TRACKER="/tmp/.claude-read-tracker-${SESSION_ID}.txt"
+
+# Check if file was already read this session
+if [ -f "$TRACKER" ] && grep -qxF "$FILE_PATH" "$TRACKER"; then
+  # Estimate tokens from file size (bytes / 4)
+  if [ -f "$FILE_PATH" ]; then
+    BYTES=$(wc -c < "$FILE_PATH" | tr -d ' ')
+    TOKENS=$((BYTES / 4))
+  else
+    TOKENS=0
+  fi
+  echo "⚠ ${FILE_PATH} was already read this session (~${TOKENS} tokens). Use existing knowledge." >&2
+  exit 0
+fi
+
+# Record this read
+echo "$FILE_PATH" >> "$TRACKER"
+
+exit 0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1276,6 +1276,23 @@ packages:
     category: operations
     difficulty: advanced
   hooks:
+  - name: anatomy-index
+    version: 1.0.0
+    description: Generates and maintains a project file index with one-line descriptions and token estimates. On session start
+      or first tool use, builds .claude/anatomy.md by walking the project tree. Before Read, displays the target file summary
+      so Claude can decide to skip. After Write/Edit, updates the changed file entry in the index. Respects .gitignore exclusions.
+    path: hooks/anatomy-index
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/anatomy-index/HOOK.md
+    events:
+    - PreToolUse
+    - PostToolUse
+    tags:
+    - context
+    - index
+    - anatomy
+    - efficiency
+    category: operations
+    difficulty: intermediate
   - name: cost-tracker
     version: 2.0.0
     description: Tracks per-tool token usage, waste indicators, and session costs. Fires on PostToolUse for Read/Write/Edit
@@ -1330,6 +1347,22 @@ packages:
     - files
     - safety
     - pre-edit
+    category: operations
+    difficulty: beginner
+  - name: read-dedup
+    version: 1.0.0
+    description: Detects and warns about duplicate file reads within a Claude Code session. Fires on PreToolUse for the Read
+      tool, tracks files read in a session-scoped temp file, and emits a stderr warning with estimated token count when a
+      file is read again. Reduces wasted context by nudging the model to reuse knowledge from earlier reads.
+    path: hooks/read-dedup
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/read-dedup/HOOK.md
+    events:
+    - PreToolUse
+    tags:
+    - context
+    - dedup
+    - tokens
+    - efficiency
     category: operations
     difficulty: beginner
   rules:
@@ -1387,6 +1420,24 @@ packages:
     - pytest
     - ci
     category: review
+    difficulty: beginner
+  - name: token-efficiency
+    version: 1.0.0
+    description: Enforces token-efficient tool usage patterns to reduce context waste and lower session costs. Covers file
+      reading strategies (targeted line-range reads, avoiding re-reads of in-context files), search-first patterns (Grep/Glob
+      before full Read), write discipline (never write unchanged content, append without full read), and context management
+      (check summaries before committing to full reads). Use this rule when optimizing Claude Code session efficiency, reducing
+      token consumption, or establishing tool-usage best practices. Triggers on "token efficiency", "reduce tokens", "context
+      waste", "tool usage", "read efficiency", "minimize reads".
+    path: rules/token-efficiency
+    source: https://github.com/Mathews-Tom/armory/blob/main/rules/token-efficiency/RULE.md
+    scope: global
+    tags:
+    - token-efficiency
+    - context-management
+    - tool-usage
+    - cost-reduction
+    category: development
     difficulty: beginner
   commands:
   - name: refactor

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1277,22 +1277,26 @@ packages:
     difficulty: advanced
   hooks:
   - name: cost-tracker
-    version: 1.0.0
-    description: Logs session cost and token usage to a CSV file after each Claude Code session completes. Fires on the Stop
-      event, reads cost and token data from the session summary JSON on stdin, and appends a row to ~/.claude/cost-log.csv.
-      Use this hook when you want to track API spending over time, identify expensive sessions, or generate usage reports
-      from the CSV data.
+    version: 2.0.0
+    description: Tracks per-tool token usage, waste indicators, and session costs. Fires on PostToolUse for Read/Write/Edit
+      to estimate tokens per operation and detect wasteful patterns (repeated reads, large reads with anatomy summaries, full-file
+      reads). On Stop, writes a backward-compatible CSV row and a companion JSON summary with per-tool token breakdowns, waste
+      percentage, and top 5 wasteful operations. Integrates with read-dedup tracker and anatomy-index for cross-hook waste
+      detection.
     path: hooks/cost-tracker
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/cost-tracker/HOOK.md
     events:
+    - PostToolUse
     - Stop
     tags:
     - cost
     - tokens
     - usage
     - logging
+    - waste
+    - efficiency
     category: operations
-    difficulty: beginner
+    difficulty: intermediate
   - name: git-protection
     version: 1.0.0
     description: 'Blocks dangerous git operations that can cause irreversible data loss. Intercepts Bash tool invocations

--- a/rules/token-efficiency/RULE.md
+++ b/rules/token-efficiency/RULE.md
@@ -1,0 +1,98 @@
+---
+name: token-efficiency
+type: rule
+description: >
+  Enforces token-efficient tool usage patterns to reduce context waste and lower
+  session costs. Covers file reading strategies (targeted line-range reads, avoiding
+  re-reads of in-context files), search-first patterns (Grep/Glob before full Read),
+  write discipline (never write unchanged content, append without full read), and
+  context management (check summaries before committing to full reads). Use this rule
+  when optimizing Claude Code session efficiency, reducing token consumption, or
+  establishing tool-usage best practices. Triggers on "token efficiency", "reduce
+  tokens", "context waste", "tool usage", "read efficiency", "minimize reads".
+metadata:
+  version: 1.0.0
+  scope: global
+  applies_to:
+    languages: ["*"]
+  category: development
+  tags: [token-efficiency, context-management, tool-usage, cost-reduction]
+  difficulty: beginner
+---
+
+# Token Efficiency
+
+Rules for minimizing token waste when using Claude Code tools. Every unnecessary read, redundant write, or unfocused search burns tokens that deliver zero value.
+
+## Search Before Read
+
+Use Grep or Glob to locate what you need before reading entire files.
+
+- **Grep** to find content by pattern — returns matching lines with file paths
+- **Glob** to find files by name pattern — returns matching file paths
+- **Read** only after you know exactly which file and lines you need
+
+```
+# wrong: read the entire file hoping to find a function
+Read src/auth/handler.ts            # 500 lines consumed
+
+# right: search first, then read the target
+Grep "function validateToken" src/  # 1 line consumed
+Read src/auth/handler.ts:142-168    # 26 lines consumed
+```
+
+## Never Re-Read In-Context Files
+
+If a file was already read in this conversation, its content is in context. Do not read it again.
+
+- Before issuing a Read, check whether the file already appeared in tool results
+- If you need to reference earlier content, work from what is already in context
+- The only exception: the file was modified since the last read and you need the updated content
+
+## Targeted Line-Range Reads
+
+When reading large files, specify the exact line range you need.
+
+- Use `offset` and `limit` parameters on Read to fetch only the relevant section
+- After a Grep match returns line numbers, read a narrow window around those lines
+- Full-file reads are acceptable only for files under ~100 lines or when you genuinely need the entire content
+
+```
+# wrong: reading 2000 lines when you need 20
+Read src/server.ts
+
+# right: reading only the section you need
+Read src/server.ts offset=340 limit=30
+```
+
+## Append Without Full Read
+
+When adding content to the end of a file, do not read the entire file first.
+
+- Use Edit with a unique anchor string near the end of the file (a closing brace, a final export, a trailing comment)
+- If the file structure is known from earlier context, write directly using the known structure
+- A full read is justified only when you do not know the file structure at all
+
+## Check Descriptions Before Full Reads
+
+Before committing to reading a file, use cheaper signals to confirm it is the right target.
+
+- File names and directory structure often reveal purpose without reading content
+- Grep a distinctive keyword to confirm the file contains what you expect
+- Read the first 20-30 lines (imports, class declaration) to verify before reading the full file
+
+## Never Write Unchanged Content
+
+Do not write a file back with no meaningful changes.
+
+- If an Edit produces `old_string` identical to `new_string`, skip the operation
+- If you read a file and determine no changes are needed, do not write it back
+- Each write costs tokens for the content and confirmation — skip writes that produce identical output
+
+## Minimize Exploration Passes
+
+Plan your exploration before executing it.
+
+- Decide which files you need to understand before starting a chain of reads
+- Batch related Grep queries by pattern when possible instead of running them one at a time
+- If exploring a directory structure, one `ls` or Glob call is cheaper than reading every file to understand the layout

--- a/rules/token-efficiency/evals/cases.yaml
+++ b/rules/token-efficiency/evals/cases.yaml
@@ -1,0 +1,39 @@
+cases:
+  - id: reduce_token_usage
+    prompt: "How can I reduce token consumption when using Claude Code?"
+    fixtures: []
+    rubric:
+      - "recommends Grep/Glob before full file reads"
+      - "mentions targeted line-range reads for large files"
+      - "advises against re-reading files already in context"
+    trigger_expected: true
+
+  - id: search_before_read
+    prompt: "I need to find where the authentication logic is defined in this codebase"
+    fixtures: []
+    rubric:
+      - "suggests using Grep to locate the function before reading files"
+      - "does not recommend reading every file in the directory"
+    trigger_expected: true
+
+  - id: efficient_file_editing
+    prompt: "I want to add a new export at the end of this module without wasting tokens"
+    fixtures: []
+    rubric:
+      - "recommends Edit with an anchor string near the end"
+      - "advises against reading the entire file first when appending"
+    trigger_expected: true
+
+  - id: negative_code_performance
+    prompt: "How do I optimize the runtime performance of my Python sorting algorithm?"
+    fixtures: []
+    rubric:
+      - "runtime performance optimization is about code execution speed, not token usage"
+    trigger_expected: false
+
+  - id: negative_cost_billing
+    prompt: "How much does Claude API usage cost per million tokens?"
+    fixtures: []
+    rubric:
+      - "API pricing is a billing question, not a tool usage efficiency pattern"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

Upgrades cost-tracker from session-level totals to **per-tool token tracking with waste detection**, and adds the two companion hooks and one governance rule that complete the token-efficiency observability stack.

### cost-tracker v2 (`hooks/cost-tracker/`)
- Track tokens per `Read`, `Write`, and `Edit` invocation via session-scoped JSONL state files
- Token estimation: `bytes/4` for Read/Write (full file), `(old_string + new_string) bytes/4` for Edit (diff-only)
- **Waste detection** on Read operations with three composable heuristics:
  - `repeated_read` — file already in the read-dedup tracker
  - `large_read_with_anatomy` — file >1000 tokens with an anatomy-index entry available
  - `full_file_read` — file >2000 tokens read without `offset`/`limit` params
- On Stop: writes backward-compatible CSV row + new companion JSON summary with per-tool breakdowns, waste percentage, and top 5 wasteful operations
- JSONL state cleaned up after summary generation; stale files handled by OS temp rotation

### read-dedup (`hooks/read-dedup/`) — NEW
- Fires on `PreToolUse` for `Read`
- Tracks files read per session in `/tmp/.claude-read-tracker-{session_id}.txt`
- Emits stderr warning with estimated token count on duplicate reads
- Provides the session read tracker consumed by cost-tracker's `repeated_read` waste check

### anatomy-index (`hooks/anatomy-index/`) — NEW
- Fires on `PreToolUse` (Read) and `PostToolUse` (Write/Edit)
- Builds and maintains `.claude/anatomy.md` — one line per file with description and token estimate
- Surfaces file summary to stderr before Read so the model can skip unnecessary reads
- Updates entries after Write/Edit to keep the index current
- Uses `git ls-files` for tree walking, respects `.gitignore` and common exclusion dirs
- Provides the anatomy index consumed by cost-tracker's `large_read_with_anatomy` waste check

### token-efficiency rule (`rules/token-efficiency/`) — NEW
- Codifies token-efficient tool usage patterns: search-before-read, targeted line-range reads, no re-reads of in-context files, write discipline, and exploration planning
- Enforceable rule with eval cases

## Data flow

```
read-dedup ──writes──▶ /tmp/.claude-read-tracker-{session}.txt ──read by──▶ cost-tracker
anatomy-index ──writes──▶ .claude/anatomy.md ──read by──▶ cost-tracker
cost-tracker ──writes──▶ ~/.claude/cost-log.csv (backward-compat)
                       ──writes──▶ ~/.claude/cost-tracker-summary-{session}.json (new)
```

## Files changed

| Component | Files | Lines |
|-----------|-------|-------|
| cost-tracker v2 | handler.sh, HOOK.md, evals/cases.yaml | +466/-44 |
| read-dedup | handler.sh, HOOK.md, evals/cases.yaml | +129 |
| anatomy-index | handler.sh, HOOK.md, evals/cases.yaml | +320 |
| token-efficiency | RULE.md, evals/cases.yaml | +137 |
| manifest | manifest.yaml | +16/-1 |

**Total: 12 files, +1024/-44**

## Test plan

- [ ] Verify cost-tracker fires on PostToolUse for Read/Write/Edit and appends JSONL records
- [ ] Verify waste detection flags repeated reads, large reads with anatomy entries, and full-file reads without offset/limit
- [ ] Verify Stop handler produces both CSV row and companion JSON summary with correct aggregates
- [ ] Verify read-dedup emits stderr warning on second read of same file
- [ ] Verify anatomy-index builds `.claude/anatomy.md` on first invocation and updates entries on Write/Edit
- [ ] Verify token-efficiency rule eval cases pass
- [ ] Verify backward compatibility: existing cost-log.csv consumers see no schema change
- [ ] Verify all hooks exit 0 (never block operations)