### PR TITLE
feat(hooks): add prompt-context hook, terse-mode preset, and fix installer gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # armory
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 104](https://img.shields.io/badge/packages-104-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/) [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 106](https://img.shields.io/badge/packages-106-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/) [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
 
 Curated, production-grade skills, agents, hooks, rules, commands, utilities, and presets for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 
@@ -43,6 +43,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [code-reviewer](agents/code-reviewer/)         | sonnet | Multi-phase code review with severity-ranked findings |
 | [security-reviewer](agents/security-reviewer/) | sonnet | OWASP Top 10 vulnerability scanning                   |
 | [secret-scanner](agents/secret-scanner/)       | haiku  | Pre-commit detection of hardcoded credentials         |
+| [test-engineer](agents/test-engineer/)         | sonnet | Co-evolutionary skill evolution with generate-verify-refine loops |
 
 ### Skills — Development & Tooling
 
@@ -60,6 +61,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |
 | [skill-library](skills/skill-library/)           | Agent-native catalog for browsing, installing, updating, syncing, and removing armory skills from within a Claude Code session                              |
+| [env-validator](skills/env-validator/)           | Validate `.env` files against project requirements — missing vars, type mismatches, insecure defaults, `.env.example` drift                                 |
 
 ### Skills — Research & Analysis
 
@@ -145,6 +147,14 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [humanize](skills/humanize/)                       | Detect and remove AI-generated writing patterns — 24 lexical patterns + 12 statistical signals, 6 domain profiles, 5-phase pipeline with semantic preservation      |
 | [linkedin-post-style](skills/linkedin-post-style/) | Write LinkedIn posts in a specific technical voice with visual companion support — carousels via md-to-pdf, images via concept-to-image, video via concept-to-video |
 
+### Skills — Skill Evolution (EvoSkills)
+
+| Skill                                                  | Description                                                                                                       |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| [paper-to-skill](skills/paper-to-skill/)               | Convert research papers into executable skill packages via methodology extraction and co-evolutionary refinement |
+| [skill-distiller](skills/skill-distiller/)             | Distill Opus-quality skill packages into deterministic, Haiku-executable workflows via trace-driven distillation |
+| [surrogate-verifier](skills/surrogate-verifier/)       | Information-isolated verification generating structured test assertions and failure diagnostics for skills        |
+
 ### Skills — Deprecated
 
 Skills below are superseded by base model capabilities. They remain installable but receive no further updates.
@@ -162,6 +172,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [commit-standards](rules/commit-standards/)     | Conventional commit format, branch naming      |
 | [test-standards](rules/test-standards/)         | Coverage thresholds, test quality requirements |
 | [security-standards](rules/security-standards/) | Secret management, input validation, auth      |
+| [token-efficiency](rules/token-efficiency/)     | Token-efficient tool usage patterns            |
 
 ## Commands
 
@@ -170,14 +181,18 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [tdd](commands/tdd/)                     | Test-driven development workflow |
 | [security-scan](commands/security-scan/) | Security vulnerability audit     |
 | [refactor](commands/refactor/)           | Code simplification workflow     |
+| [evolve](commands/evolve/)               | Co-evolutionary skill generation |
 
 ## Hooks
 
-| Hook                                      | Description                    |
-| ----------------------------------------- | ------------------------------ |
-| [git-protection](hooks/git-protection/)   | Block dangerous git operations |
-| [pre-edit-backup](hooks/pre-edit-backup/) | Backup files before edits      |
-| [cost-tracker](hooks/cost-tracker/)       | Log session cost/token usage   |
+| Hook                                      | Description                                          |
+| ----------------------------------------- | ---------------------------------------------------- |
+| [git-protection](hooks/git-protection/)   | Block dangerous git operations                       |
+| [pre-edit-backup](hooks/pre-edit-backup/) | Backup files before edits                            |
+| [cost-tracker](hooks/cost-tracker/)       | Log session cost/token usage                         |
+| [anatomy-index](hooks/anatomy-index/)     | Maintain project file index with token estimates     |
+| [read-dedup](hooks/read-dedup/)           | Warn on duplicate file reads within a session        |
+| [prompt-context](hooks/prompt-context/)   | Inject text file as additionalContext on every prompt |
 
 ## Utilities
 
@@ -197,6 +212,8 @@ Presets install curated bundles of passive packages (rules, hooks, commands) in 
 | [sec-strict](presets/sec-strict/)       | 5 skills, 3 agents, 2 rules, 2 hooks, 1 command  | Audit-grade security stack with codebase-auditor. Superset of `core`.                           |
 | [python-strict](presets/python-strict/) | 4 skills, 2 agents, 3 rules, 2 hooks, 2 commands | Full Python enforcement — TDD, type checking, test coverage, security standards.                |
 | [ai-builder](presets/ai-builder/)       | 6 skills                                         | AI/ML development toolkit — agent building, prompt engineering, GPU optimization, RAG auditing. |
+| [skill-evolution](presets/skill-evolution/) | 6 skills, 1 agent, 1 command               | EvoSkills pipeline — co-evolutionary skill factory with paper-to-skill, distillation, and verification. |
+| [terse-mode](presets/terse-mode/)       | 1 hook                                           | Terse output enforcement via prompt-context hook with compaction-immune rule injection.          |
 
 ### Deprecated Presets
 
@@ -293,7 +310,7 @@ Packages activate when Claude detects a matching intent. Each package defines tr
 /refactor src/utils.py     -> code simplification
 ```
 
-**Hooks** fire automatically on Claude Code lifecycle events (PreToolUse, PostToolUse, Stop, SessionStart). **Rules** load as context when relevant. **Presets** install bundles via `just install-profile`.
+**Hooks** fire automatically on Claude Code lifecycle events (PreToolUse, PostToolUse, Stop, UserPromptSubmit). **Rules** load as context when relevant. **Presets** install bundles via `just install-profile`.
 
 ---
 

--- a/hooks/prompt-context/HOOK.md
+++ b/hooks/prompt-context/HOOK.md
@@ -1,0 +1,103 @@
+---
+name: prompt-context
+type: hook
+description:
+  "Injects a text file into every prompt as additionalContext via the UserPromptSubmit
+  event. Reads from project-level .claude/prompt-context.txt first, falling back to
+  ~/.claude/prompt-context.txt. Fail-open: missing or unreadable files exit 0 silently
+  rather than blocking input. Use this hook to enforce output styles, inject project
+  reminders, prime roles, or apply constraints that survive context compaction — the
+  injection lands adjacent to the user prompt on every turn, the highest-attention
+  slot in the context window.
+
+  "
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [context, prompt, style, injection, compaction-immune]
+  difficulty: beginner
+hook:
+  events: [UserPromptSubmit]
+  matcher: ""
+  handler: { type: command, command: bash handler.sh, timeout_ms: 5000 }
+---
+
+# prompt-context
+
+Injects a text file into every user prompt as `additionalContext`.
+
+## Why This Hook Exists
+
+Claude Code offers several mechanisms for persistent instructions — `CLAUDE.md`,
+`outputStyle`, `--append-system-prompt` — but each has structural limitations:
+
+| Mechanism                | Limitation                                                   |
+| ------------------------ | ------------------------------------------------------------ |
+| `CLAUDE.md`              | Loaded at session start; drifts out of attention by turn 30+ |
+| `outputStyle`            | System-prompt-level; models sometimes second-guess it        |
+| `--append-system-prompt` | Single slot; conflicts with other wrappers                   |
+| Compact Instructions     | Survives `/compact` but still competes with conversation     |
+
+A `UserPromptSubmit` hook re-fires on every turn. Its output lands immediately
+adjacent to the user's request — the highest-attention position in the context
+window. Rules injected here are compaction-immune and recency-biased.
+
+## File Lookup Order
+
+The hook checks two locations and uses the first file found:
+
+1. **Project-level:** `.claude/prompt-context.txt` (relative to working directory)
+2. **Global:** `~/.claude/prompt-context.txt`
+
+This enables per-project overrides while maintaining a global default.
+
+## Fail-Open Design
+
+If neither file exists or the file is unreadable, the hook exits 0 with no
+output. This prevents a missing or corrupted rules file from blocking user
+input.
+
+## Example Content
+
+A `prompt-context.txt` for terse output enforcement:
+
+```text
+Apply to your next response:
+- No preamble, no postamble, no narration
+- Strip hedging (think/perhaps/might/maybe/seems/likely/probably)
+- Strip praise (great/perfect/excellent/amazing/fantastic)
+- Strip soft language (would you like, if you'd prefer, you may want)
+- Strip meta-commentary (let's, now we'll, moving on, next, first)
+- Strip engagement (feel free, let me know, hope this helps, happy to)
+- Strip terminal questions unless the user explicitly asked one
+- After tool calls, stop. Do not summarize what just happened.
+- Code over prose. Facts over hedging. Stop at the information boundary.
+```
+
+Other use cases:
+
+- **Role priming:** "You are reviewing code as a security auditor. Flag OWASP Top 10 patterns."
+- **Project reminders:** "This repo uses pnpm. Never suggest npm install."
+- **Output constraints:** "All responses must include file:line references."
+
+## Subagent Limitation
+
+Subagents (Explore, Plan, code-reviewer, etc.) have isolated contexts and do
+not fire `UserPromptSubmit`. To cover subagent output, pair this hook with
+an `outputStyle` setting:
+
+```json
+{
+  "outputStyle": "concise"
+}
+```
+
+The hook handles main-agent output; the output style handles subagent output.
+
+## Modifying Rules
+
+Edit the `prompt-context.txt` file. Changes take effect on the next prompt —
+no restart required, because the hook re-reads the file on every invocation.
+
+To disable temporarily, rename the file (e.g., `prompt-context.txt.disabled`).
+The hook fails open and the session reverts to default behavior.

--- a/hooks/prompt-context/evals/cases.yaml
+++ b/hooks/prompt-context/evals/cases.yaml
@@ -1,0 +1,57 @@
+cases:
+  - id: injects_global_context
+    prompt: "Send a prompt in a session with ~/.claude/prompt-context.txt configured"
+    fixtures: []
+    rubric:
+      - "Hook should fire on UserPromptSubmit event"
+      - "Content of prompt-context.txt should appear in additionalContext"
+      - "Hook should output valid JSON with hookSpecificOutput.hookEventName set to UserPromptSubmit"
+    trigger_expected: true
+
+  - id: project_overrides_global
+    prompt: "Send a prompt in a project that has .claude/prompt-context.txt while a global one also exists"
+    fixtures: []
+    rubric:
+      - "Hook should use the project-level file, not the global one"
+      - "Only project-level content should appear in additionalContext"
+    trigger_expected: true
+
+  - id: fail_open_no_file
+    prompt: "Send a prompt when no prompt-context.txt exists anywhere"
+    fixtures: []
+    rubric:
+      - "Hook should exit 0 with no output"
+      - "User prompt should not be blocked"
+      - "No error should be emitted to stderr"
+    trigger_expected: true
+
+  - id: fail_open_unreadable
+    prompt: "Send a prompt when prompt-context.txt exists but has no read permission"
+    fixtures: []
+    rubric:
+      - "Hook should exit 0 with no output"
+      - "User prompt should not be blocked"
+    trigger_expected: true
+
+  - id: no_trigger_on_tool_use
+    prompt: "Claude uses the Read tool to inspect a file"
+    fixtures: []
+    rubric:
+      - "Hook should not fire on PreToolUse or PostToolUse events"
+      - "Hook only fires on UserPromptSubmit"
+    trigger_expected: false
+
+  - id: no_trigger_on_stop
+    prompt: "Claude finishes a response and the session emits a Stop event"
+    fixtures: []
+    rubric:
+      - "Hook should not fire on Stop events"
+    trigger_expected: false
+
+  - id: survives_compaction
+    prompt: "Send a prompt after /compact has summarized earlier messages"
+    fixtures: []
+    rubric:
+      - "Hook should re-inject the full content of prompt-context.txt"
+      - "Content should not be affected by prior context compaction"
+    trigger_expected: true

--- a/hooks/prompt-context/handler.sh
+++ b/hooks/prompt-context/handler.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# prompt-context hook — injects a text file as additionalContext on every prompt.
+# Checks project-level .claude/prompt-context.txt first, then ~/.claude/prompt-context.txt.
+# Fails open: missing or unreadable files exit 0 silently.
+
+set -euo pipefail
+
+# Determine which file to read (project-level takes precedence)
+CONTEXT_FILE=""
+if [ -r ".claude/prompt-context.txt" ]; then
+  CONTEXT_FILE=".claude/prompt-context.txt"
+elif [ -r "${HOME}/.claude/prompt-context.txt" ]; then
+  CONTEXT_FILE="${HOME}/.claude/prompt-context.txt"
+fi
+
+# No file found — fail open
+if [ -z "$CONTEXT_FILE" ]; then
+  exit 0
+fi
+
+# Read content, fail open on error
+CONTENT=$(cat "$CONTEXT_FILE" 2>/dev/null) || exit 0
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+# Escape content for JSON embedding (newlines, quotes, backslashes, tabs)
+ESCAPED=$(printf '%s' "$CONTENT" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
+
+# Emit structured JSON output
+printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"}}' "$ESCAPED"
+
+exit 0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1491,6 +1491,25 @@ packages:
     - pre-edit
     category: operations
     difficulty: beginner
+  - name: prompt-context
+    version: 1.0.0
+    description: 'Injects a text file into every prompt as additionalContext via the UserPromptSubmit event. Reads from project-level
+      .claude/prompt-context.txt first, falling back to ~/.claude/prompt-context.txt. Fail-open: missing or unreadable files
+      exit 0 silently rather than blocking input. Use this hook to enforce output styles, inject project reminders, prime
+      roles, or apply constraints that survive context compaction — the injection lands adjacent to the user prompt on every
+      turn, the highest-attention slot in the context window.'
+    path: hooks/prompt-context
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/prompt-context/HOOK.md
+    events:
+    - UserPromptSubmit
+    tags:
+    - context
+    - prompt
+    - style
+    - injection
+    - compaction-immune
+    category: operations
+    difficulty: beginner
   - name: read-dedup
     version: 1.0.0
     description: Detects and warns about duplicate file reads within a Claude Code session. Fires on PreToolUse for the Read
@@ -1854,3 +1873,19 @@ packages:
     - pipeline
     category: meta
     difficulty: advanced
+  - name: terse-mode
+    version: 1.0.0
+    description: Enforces terse, no-narration output from Claude Code. Bundles the prompt-context hook with a curated terse
+      rules file that strips hedging, praise, soft language, meta-commentary, engagement phrases, and unsolicited offers from
+      every response. Use this preset when you want action-only output without preambles, postambles, or trailing questions
+      — code over prose, facts over hedging, stop at the information boundary.
+    path: presets/terse-mode
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/terse-mode/PRESET.md
+    tags:
+    - terse
+    - concise
+    - style
+    - output
+    - verbosity
+    category: operations
+    difficulty: beginner

--- a/presets/terse-mode/PRESET.md
+++ b/presets/terse-mode/PRESET.md
@@ -1,0 +1,102 @@
+---
+name: terse-mode
+type: preset
+description:
+  "Enforces terse, no-narration output from Claude Code. Bundles the prompt-context
+  hook with a curated terse rules file that strips hedging, praise, soft language,
+  meta-commentary, engagement phrases, and unsolicited offers from every response.
+  Use this preset when you want action-only output without preambles, postambles,
+  or trailing questions — code over prose, facts over hedging, stop at the information
+  boundary.
+
+  "
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [terse, concise, style, output, verbosity]
+  difficulty: beginner
+preset:
+  packages:
+    hooks:
+      - { name: prompt-context }
+  compatibility:
+    platforms: [darwin, linux]
+---
+
+# Terse Mode
+
+Enforces terse, action-only output from Claude Code by injecting strip-rules
+into every prompt via the `prompt-context` hook.
+
+## Included Packages
+
+| Type | Package        | Role                                                  |
+| ---- | -------------- | ----------------------------------------------------- |
+| Hook | prompt-context | Injects rules as additionalContext on every user turn |
+
+## Setup
+
+After installing this preset, create `~/.claude/prompt-context.txt` with the
+following content:
+
+```text
+Apply to your next response:
+- No preamble, no postamble, no narration
+- Strip hedging (think/perhaps/might/maybe/seems/likely/probably)
+- Strip praise (great/perfect/excellent/amazing/fantastic)
+- Strip soft language (would you like, if you'd prefer, you may want)
+- Strip meta-commentary (let's, now we'll, moving on, next, first)
+- Strip engagement (feel free, let me know, hope this helps, happy to)
+- Strip offers (I can help with, shall we, should we)
+- Strip terminal questions unless the user explicitly asked one
+- After tool calls, stop. Do not summarize what just happened.
+- Code over prose. Facts over hedging. Stop at the information boundary.
+```
+
+For project-specific overrides, place the file at `.claude/prompt-context.txt`
+in the project root instead.
+
+## Subagent Coverage
+
+The hook covers main-agent output. Subagents (Explore, Plan, code-reviewer)
+have isolated contexts that bypass `UserPromptSubmit`. To cover subagent
+output, add an `outputStyle` to your `settings.json`:
+
+```json
+{
+  "outputStyle": "concise"
+}
+```
+
+Together, the hook handles main-agent prose and the output style handles
+subagent prose.
+
+## What This Replaces
+
+Once installed, these sections in `CLAUDE.md` become redundant and can be
+removed:
+
+- "No preamble / no postamble / no narration" rules
+- Lists of strip-words (hedging, praise, soft language, engagement)
+- "Stop at information boundary" rules
+- Self-check rituals ("scan your draft before sending")
+- Compact Instructions sections (the hook survives compaction natively)
+
+**Keep** in `CLAUDE.md`: honesty rules, technical precision rules,
+code-quality rules, tool-use strategy, and imperative tone rules. These are
+orthogonal to prose-style enforcement.
+
+## Compliance
+
+Realistic compliance ranges based on mechanism:
+
+| Configuration                               | Compliance                         |
+| ------------------------------------------- | ---------------------------------- |
+| `CLAUDE.md` alone                           | ~50%                               |
+| `CLAUDE.md` + `outputStyle`                 | ~70-80%                            |
+| This preset (hook + `outputStyle` fallback) | ~85-95% main agent, ~70% subagents |
+
+## Disabling
+
+Rename or delete `~/.claude/prompt-context.txt`. The hook fails open —
+the session reverts to default verbosity with no errors.

--- a/scripts/hooks_installer.py
+++ b/scripts/hooks_installer.py
@@ -13,7 +13,6 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.frontmatter import parse_frontmatter
-from scripts.package_types import REPO_ROOT
 
 
 def install_hook(hook_dir: Path, claude_dir: Path) -> None:

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -22,6 +22,7 @@ from rich.prompt import Prompt
 from rich.table import Table
 
 from scripts.frontmatter import extract_body, extract_version, parse_frontmatter
+from scripts.hooks_installer import install_hook as _install_hook_to_settings
 from scripts.package_types import (
     MANIFEST_PATH,
     REPO_ROOT,
@@ -382,7 +383,107 @@ def install_utility(source: Path, target: Path, pkg_type: PackageType) -> int:
     return count
 
 
-def install_package(plan: InstallPlan) -> int:
+def install_hook(source: Path, target: Path, claude_dir: Path) -> int:
+    """Install a hook package — copy files and register in settings.json."""
+    _install_hook_to_settings(source, claude_dir)
+    # Count handler files that were copied (HOOK.md excluded by hooks_installer)
+    target_dir = claude_dir / "hooks" / target.name
+    return sum(1 for f in target_dir.rglob("*") if f.is_file()) if target_dir.exists() else 0
+
+
+def resolve_preset_packages(
+    source_path: Path, pkg_type: PackageType,
+) -> dict[str, list[str]]:
+    """Read a preset's PRESET.md and return {type_key: [package_names]}.
+
+    The preset frontmatter has:
+      preset:
+        packages:
+          skills: [{name: x}, ...]
+          hooks: [{name: y}, ...]
+    """
+    def_file = source_path / pkg_type.definition_file
+    content = def_file.read_text(encoding="utf-8")
+    meta = parse_frontmatter(content)
+    preset_meta = meta.get("preset", {})
+    packages_meta = preset_meta.get("packages", {})
+
+    result: dict[str, list[str]] = {}
+    for section, entries in packages_meta.items():
+        # section is e.g. "skills", "hooks" — map to type key
+        type_key = _section_to_type_key(section)
+        if type_key and isinstance(entries, list):
+            names = [e["name"] for e in entries if isinstance(e, dict) and "name" in e]
+            if names:
+                result[type_key] = names
+    return result
+
+
+def install_preset(
+    plan: InstallPlan, claude_dir: Path,
+) -> tuple[int, list[str]]:
+    """Install a preset — copy directory, then transitively install bundled packages.
+
+    Returns (file_count, list of sub-package install messages).
+    """
+    pkg = plan.package
+    file_count = copy_package(pkg.source_path, plan.target_path)
+    messages: list[str] = []
+
+    # Resolve bundled packages
+    bundled = resolve_preset_packages(pkg.source_path, pkg.pkg_type)
+    if not bundled:
+        return file_count, messages
+
+    # Discover all available packages for resolution
+    all_packages = discover_packages()
+    pkg_index: dict[tuple[str, str], PackageInfo] = {
+        (p.pkg_type.key, p.name): p for p in all_packages
+    }
+
+    for type_key, names in bundled.items():
+        for name in names:
+            sub_pkg = pkg_index.get((type_key, name))
+            if sub_pkg is None:
+                messages.append(
+                    f"  [yellow]Warning: preset references {type_key}/{name} but it was not found[/yellow]"
+                )
+                continue
+
+            install_dir = claude_dir / sub_pkg.pkg_type.install_subdir
+            if sub_pkg.pkg_type.key in BODY_ONLY_TYPES:
+                target = install_dir / f"{name}.md"
+            else:
+                target = install_dir / name
+
+            installed_ver = get_installed_version(install_dir, name, sub_pkg.pkg_type)
+
+            # Skip if already at same or newer version
+            if installed_ver is not None and not is_newer(sub_pkg.version, installed_ver):
+                messages.append(
+                    f"  [dim]{type_key}/{name} v{installed_ver} already installed[/dim]"
+                )
+                continue
+
+            sub_plan = InstallPlan(
+                package=sub_pkg,
+                action=InstallAction.UPGRADE if installed_ver else InstallAction.INSTALL,
+                installed_version=installed_ver,
+                target_path=target,
+            )
+            sub_count = install_package(sub_plan, claude_dir)
+            file_count += sub_count
+            action_word = "Upgraded" if installed_ver else "Installed"
+            type_color = TYPE_COLORS.get(type_key, "white")
+            messages.append(
+                f"  {action_word} [{type_color}]{type_key}[/] "
+                f"[cyan]{name}[/cyan] v{sub_pkg.version} ({sub_count} files)"
+            )
+
+    return file_count, messages
+
+
+def install_package(plan: InstallPlan, claude_dir: Path | None = None) -> int:
     """Install a single package according to its type. Returns file count."""
     pkg = plan.package
     key = pkg.pkg_type.key
@@ -391,7 +492,9 @@ def install_package(plan: InstallPlan) -> int:
         return install_body_only(pkg.source_path, plan.target_path, pkg.pkg_type)
     if key == "utility":
         return install_utility(pkg.source_path, plan.target_path, pkg.pkg_type)
-    # skill, agent, hook, preset — copy full directory
+    if key == "hook" and claude_dir is not None:
+        return install_hook(pkg.source_path, plan.target_path, claude_dir)
+    # skill, agent, preset (without resolution) — copy full directory
     return copy_package(pkg.source_path, plan.target_path)
 
 
@@ -402,8 +505,13 @@ _ACTION_LABELS: dict[InstallAction, str] = {
 }
 
 
-def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
+def execute_plans(
+    plans: list[InstallPlan], selected: list[int], claude_dir: Path | None = None,
+) -> None:
     """Execute selected installation plans."""
+    if claude_dir is None:
+        claude_dir = DEFAULT_CLAUDE_DIR
+
     to_install = [plans[i] for i in selected if plans[i].action != InstallAction.SKIP]
 
     if not to_install:
@@ -415,7 +523,13 @@ def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
 
         for plan in to_install:
             progress.update(task, description=f"Installing {plan.package.name}...")
-            file_count = install_package(plan)
+
+            if plan.package.pkg_type.key == "preset":
+                file_count, sub_messages = install_preset(plan, claude_dir)
+            else:
+                file_count = install_package(plan, claude_dir)
+                sub_messages = []
+
             progress.advance(task)
             label = _ACTION_LABELS.get(plan.action, "Installed")
             console.print(
@@ -424,6 +538,8 @@ def execute_plans(plans: list[InstallPlan], selected: list[int]) -> None:
                 f"[cyan]{plan.package.name}[/cyan] "
                 f"v{plan.package.version} ({file_count} files)"
             )
+            for msg in sub_messages:
+                console.print(msg)
 
     # Summary
     console.print()
@@ -733,7 +849,7 @@ def main() -> int:
         return 0
 
     # Execute
-    execute_plans(plans, selected_actionable)
+    execute_plans(plans, selected_actionable, claude_dir)
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds the armory's first `UserPromptSubmit` hook for compaction-immune rule injection, a terse-mode preset that bundles it, and fixes two critical installer gaps where hooks and presets were copied but never fully activated.

### New packages

- **`prompt-context` hook** — Reads a text file and injects its contents as `additionalContext` on every user prompt. File lookup checks project-level `.claude/prompt-context.txt` first, falling back to `~/.claude/prompt-context.txt`. Fail-open design: missing files exit 0 silently. Use cases include style enforcement, project reminders, role priming, and output constraints.

- **`terse-mode` preset** — Bundles the `prompt-context` hook with a curated set of strip-rules (hedging, praise, soft language, meta-commentary, engagement phrases, unsolicited offers). Documents `outputStyle` pairing for subagent coverage and `CLAUDE.md` cleanup guidance.

### Installer fixes

- **Hook registration** — `install.py` previously copied hook files to `~/.claude/hooks/{name}/` but never registered them in `settings.json`. Hooks were installed but inert. Now routes hook installation through `hooks_installer.install_hook()`, which parses `HOOK.md` frontmatter and merges the hook config into `settings.json` with `_hook_name` ownership tagging for clean uninstall.

- **Preset dependency resolution** — `install.py` previously copied preset directories as flat files without resolving `preset.packages` references. Installing a preset like `core` did not install its bundled skills, hooks, or rules. Now `install_preset()` reads the preset frontmatter, resolves all bundled packages from the manifest, and transitively installs each one — including hooks with full `settings.json` registration.

### README sync

Adds 12 packages that were present in the manifest but missing from README across 6 types:
- **Agents:** test-engineer
- **Skills:** env-validator, paper-to-skill, skill-distiller, surrogate-verifier (new EvoSkills section)
- **Hooks:** anatomy-index, read-dedup, prompt-context
- **Rules:** token-efficiency
- **Commands:** evolve
- **Presets:** skill-evolution, terse-mode

Updates badge count from 104 to 106. Adds `UserPromptSubmit` to the hook event list in the Usage section.

## Commits

| Type | Scope | Description |
|------|-------|-------------|
| `feat` | hooks | Add `prompt-context` hook for UserPromptSubmit injection |
| `feat` | presets | Add `terse-mode` preset bundling prompt-context hook |
| `fix` | install | Register hooks in settings.json and resolve preset dependencies |
| `chore` | — | Regenerate manifest with new packages (106 total) |
| `docs` | readme | Add missing packages and update counts |

## Test plan

- [x] `uv run python -m pytest tests/ -x -q` — 205 tests pass, no regressions
- [x] `uv run scripts/validate_evals.py` — all eval cases valid
- [x] `uv run scripts/generate_manifest.py` — 63 skills, 15 agents, 6 hooks, 4 rules, 4 commands, 3 utilities, 11 presets
- [x] Hook smoke test: handler.sh exits 0 with no output when no file exists (fail-open)
- [x] Hook smoke test: handler.sh emits valid JSON with `additionalContext` when file exists
- [x] Hook smoke test: project-level file takes precedence over global
- [x] Integration test: hook installation creates `settings.json` entry with `UserPromptSubmit`
- [x] Integration test: `resolve_preset_packages()` correctly parses `core` preset dependencies
- [x] Integration test: `install_preset()` for `terse-mode` transitively installs and registers `prompt-context` hook