### PR TITLE
fix(install): skip symlinked packages during preset transitive install

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -456,6 +456,13 @@ def install_preset(
             else:
                 target = install_dir / name
 
+            # Skip symlinked packages (externally managed)
+            if sub_pkg.pkg_type.key not in BODY_ONLY_TYPES and target.is_symlink():
+                messages.append(
+                    f"  [dim]{type_key}/{name} is a symlink (externally managed), skipping[/dim]"
+                )
+                continue
+
             installed_ver = get_installed_version(install_dir, name, sub_pkg.pkg_type)
 
             # Skip if already at same or newer version


### PR DESCRIPTION
## Summary

- Fixes `OSError: Cannot call rmtree on a symbolic link` when installing presets that bundle packages already symlinked in `~/.claude/`

## Root cause

`install_preset()` resolves bundled packages and calls `install_package()` directly, bypassing the symlink guard in `build_install_plans()` (line 224). When a sub-package target (e.g. `~/.claude/skills/immune`) is a symlink, `copy_package()` calls `shutil.rmtree()` on it, which raises `OSError`.

## Fix

Adds the same symlink check from `build_install_plans()` to the preset sub-package loop. Symlinked packages are skipped with a message indicating they are externally managed.

## Test plan

- [x] 205 existing tests pass
- [x] Verified fix addresses the exact traceback from the issue