### PR TITLE
feat: adopt agent-skills concepts — router, code folding, anti-rationalization, lifecycle phases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,6 +275,75 @@ Add 3-6 lowercase kebab-case tags that help users discover the package. Include:
 | `intermediate` | Multi-step workflows, some domain knowledge needed         |
 | `advanced`     | Complex multi-phase analysis, deep domain expertise needed |
 
+### Phase (optional)
+
+Lifecycle phase indicating when in the development workflow this package is used. Helps the `/route` command and orchestrator agents sequence work correctly.
+
+| Phase      | When                                                          |
+| ---------- | ------------------------------------------------------------- |
+| `define`   | Idea validation, requirements gathering, market research      |
+| `plan`     | Task breakdown, estimation, architecture decisions            |
+| `build`    | Writing code, generating tests, debugging, optimization       |
+| `verify`   | Running benchmarks, QA testing, validation                    |
+| `review`   | Code review, security audit, architecture review, refactoring |
+| `ship`     | Release, changelog, documentation, deployment                 |
+
+```yaml
+metadata:
+  version: 1.0.0
+  category: review
+  tags: [code-review, quality]
+  difficulty: intermediate
+  phase: review
+```
+
+## Optional Content Sections
+
+Skills and agents may include three optional sections that improve agent compliance. These are recommended for review, quality, and security packages.
+
+### Rationalizations
+
+A table of common excuses agents use to skip the skill's workflow, paired with factual rebuttals. Preemptively closes escape hatches.
+
+```markdown
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Tests pass, so the code is fine" | Tests are necessary but insufficient — they miss architecture and security |
+| "It's a small diff" | Small changes cause most production incidents |
+```
+
+**When to include:** Recommended for any skill where partial compliance is dangerous (review, security, testing, migration).
+
+### Red Flags
+
+Observable patterns indicating the skill isn't being followed correctly during execution. Provides runtime self-correction signals.
+
+```markdown
+## Red Flags
+
+- Approving without reading every changed file in full
+- No file:line references in findings
+- Skipping a review dimension because "it looks fine"
+```
+
+**When to include:** Recommended for skills with multi-step workflows where steps can be silently skipped.
+
+### Verification
+
+Concrete evidence requirements proving the skill was executed correctly. Demands artifacts (test output, build logs, scores), not subjective assessment.
+
+```markdown
+## Verification
+
+- [ ] All tests pass with output captured
+- [ ] Coverage meets thresholds: 80% overall, 90% new code
+- [ ] Linter exits clean: `ruff check` + `mypy --strict`
+```
+
+**When to include:** Recommended for skills that produce measurable outcomes (testing, review, deployment).
+
 ## Quality Gate — Skill Evaluator
 
 Before submitting a PR, run the [skill-evaluator](skills/skill-evaluator/) against your package:

--- a/NEW_PACKAGE_CHECKLIST.md
+++ b/NEW_PACKAGE_CHECKLIST.md
@@ -33,6 +33,10 @@ Follow this checklist every time you build a new package for the armory. Items a
   description: <200-800 chars> # See description rules below
   metadata:
     version: 1.0.0
+    category: development     # required
+    tags: [keyword1, keyword2] # required
+    difficulty: intermediate   # required
+    phase: build               # optional — define/plan/build/verify/review/ship
   ---
   ```
 - [ ] **Create `references/`** — add reference documents the package needs (setup guides, compatibility matrices, command references).
@@ -55,6 +59,9 @@ Write the definition file body with these sections (in order):
 - [ ] **Troubleshooting** — common failure modes with diagnostic commands and fixes
 - [ ] **Reference table** — links to all files in `references/`
 - [ ] **Template table** — links to all files in `templates/` with descriptions
+- [ ] **Rationalizations** (optional, recommended for review/quality/security skills) — table of common excuses agents use to skip steps, paired with factual rebuttals
+- [ ] **Red Flags** (optional, recommended for multi-step workflows) — observable patterns indicating the skill isn't being followed correctly
+- [ ] **Verification** (optional, recommended for skills with measurable outcomes) — checklist of concrete evidence requirements proving correct execution
 
 ## Phase 4: Eval Cases
 

--- a/agents/security-reviewer/AGENT.md
+++ b/agents/security-reviewer/AGENT.md
@@ -244,4 +244,32 @@ Flag: debug mode in production as HIGH, missing CORS restrictions as MEDIUM.
 6. Check for existing sanitization/validation before flagging
 7. Rate severity based on exploitability and impact, not just pattern matching
 8. Flag framework-specific issues (Django ORM vs raw SQL, React vs vanilla DOM)
-```
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's internal only, no external access" | Internal services get compromised via lateral movement — SSRF, stolen credentials, supply chain attacks all start internal |
+| "We'll add auth later" | "Later" is after the breach — unauthenticated endpoints in any environment are exploitable from day one |
+| "The framework sanitizes input" | Frameworks sanitize for their default context — template injection, SQL in raw queries, and deserialization bypasses are framework-blind |
+| "It's behind a VPN" | VPNs are a network boundary, not an authorization layer — compromised VPN credentials grant full access |
+| "No one would think to exploit this" | Security through obscurity is not security — automated scanners and bots don't "think", they enumerate |
+| "The risk is theoretical" | All exploits were theoretical until the first breach — if data flows from user input to a dangerous sink, it's exploitable |
+
+## Red Flags
+
+- Reporting vulnerabilities without tracing the data flow from source to sink
+- Flagging patterns without checking for existing sanitization/validation
+- Rating severity based on pattern matching alone without considering exploitability
+- No remediation code provided — findings without fixes are not actionable
+- Missing OWASP Top 10 mapping for findings
+- Ignoring framework-specific security features (CSRF tokens, parameterized queries, CSP headers)
+
+## Verification
+
+- [ ] Every finding includes: vulnerability description, exploit scenario, affected file:line, OWASP category
+- [ ] Every finding includes remediation code in the target language
+- [ ] Data flow traced: user input → intermediate processing → vulnerable sink
+- [ ] Existing sanitization/validation checked before flagging
+- [ ] Severity rated by exploitability AND impact, not just pattern match
+- [ ] No theoretical vulnerabilities without concrete data flow evidence

--- a/agents/test-engineer/AGENT.md
+++ b/agents/test-engineer/AGENT.md
@@ -20,7 +20,7 @@ model: opus
 color: yellow
 metadata:
   version: 1.0.0
-  category: meta
+  category: development
   execution_phase: on-demand
   priority: 60
   enabled: true

--- a/commands/refactor/COMMAND.md
+++ b/commands/refactor/COMMAND.md
@@ -15,6 +15,7 @@ metadata:
   category: development
   tags: [refactoring, code-quality, simplification]
   difficulty: intermediate
+  phase: review
 command:
   syntax: /refactor [path]
   handler: inline

--- a/commands/route/COMMAND.md
+++ b/commands/route/COMMAND.md
@@ -1,0 +1,169 @@
+---
+name: route
+type: command
+description: >-
+  Skill router that maps user tasks to the best armory packages. Provides a
+  decision-tree organized by development lifecycle phase (define, plan, build,
+  verify, review, ship) plus cross-cutting domains (research, content, business).
+  Triggers on: "/route", "which skill", "what package", "find the right skill",
+  "help me pick a skill", "discover packages". Use this command when unsure
+  which armory skill, agent, or command to use for a task.
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [discovery, routing, meta, navigation]
+  difficulty: beginner
+  phase: plan
+command:
+  syntax: /route [task-description]
+  handler: inline
+  dependencies: []
+---
+# Route — Skill & Package Discovery
+
+When the user invokes `/route [task]`, match their task to the best armory package(s) using the decision tree below. If the task is ambiguous, ask one clarifying question before recommending.
+
+## How to Use This Router
+
+1. Read the user's task description
+2. Match to the most specific category below
+3. Recommend the **primary** package and any **complementary** packages
+4. If the MCP armory server is available, cross-reference with `search_packages` for confirmation
+
+---
+
+## Define Phase — "I have an idea"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Validate a business idea | `idea-validator` skill | `market-analyzer`, `competitive-analyzer`, `feasibility-assessor` |
+| Market research | `market-analyzer` skill | `competitive-analyzer` |
+| Competitive analysis | `competitive-analyzer` skill | `market-analyzer` |
+| Feasibility assessment | `feasibility-assessor` skill | `estimate-calibrator` |
+| Full business validation pipeline | `idea-scout` agent | (orchestrates all four above) |
+
+## Plan Phase — "I need to plan the work"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Break down a project into tasks | `task-decomposer` skill | `estimate-calibrator` |
+| Estimate effort/timeline | `estimate-calibrator` skill | `task-decomposer` |
+| Design system architecture | `project-architect` agent | `architecture-diagram` skill |
+| Record architecture decisions | `adr-writer` skill | `architecture-reviewer` skill |
+| Plan a full project | `project-planner` agent | `task-decomposer`, `estimate-calibrator` |
+
+## Build Phase — "I need to write code"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Write tests first (TDD) | `/tdd` command | `test-harness` skill |
+| Generate test suite for existing code | `test-harness` skill | — |
+| Debug a failing test or error | `debug-investigator` skill | — |
+| Optimize SQL queries | `sql-optimizer` skill | `benchmark-runner` |
+| Optimize GPU/ML workloads | `gpu-optimizer` skill | `benchmark-runner` |
+| Build a full feature end-to-end | `full-stack-builder` agent | `test-harness`, `pr-review` |
+| Prompt engineering / iteration | `prompt-lab` skill | `rag-auditor` |
+| Audit RAG pipeline | `rag-auditor` skill | `prompt-lab` |
+| Build an MCP server or agent skill | `agent-builder` skill | `mcp-to-skill` |
+| Convert MCP tool to skill | `mcp-to-skill` skill | `agent-builder` |
+| Validate environment setup | `env-validator` skill | — |
+
+## Verify Phase — "I need to validate quality"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Run benchmarks | `benchmark-runner` skill | `sql-optimizer`, `gpu-optimizer` |
+| Systematic QA testing | `qa-systematic` skill | `test-harness` |
+| Audit RAG quality | `rag-auditor` skill | — |
+| Validate environment config | `env-validator` skill | — |
+
+## Review Phase — "I need a code review"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Review a PR | `pr-review` skill | `code-refiner` |
+| Full codebase audit | `codebase-auditor` agent | (orchestrates multiple reviewers) |
+| Architecture review | `architecture-reviewer` skill | `architecture-diagram` |
+| Security review | `security-reviewer` agent | `secret-scanner` agent |
+| Scan for secrets/credentials | `secret-scanner` agent | — |
+| Security scan (command) | `/security-scan` command | `security-reviewer` agent |
+| Refactor/simplify code | `code-refiner` skill | — |
+| Refactor (command) | `/refactor` command | `code-refiner` skill |
+| Dependency vulnerabilities | `dependency-audit` skill | — |
+| Migration risk assessment | `migration-risk-analyzer` skill | — |
+| Pre-merge gate check | `pre-landing-review` skill | `pr-review` |
+| Evaluate a package/library | `package-evaluator` skill | `dependency-audit` |
+| Monitor repo health | `repo-sentinel` skill | `dependency-audit` |
+| UX review | `ux-expert` skill | — |
+| Devil's advocate / challenge assumptions | `devils-advocate` skill | — |
+
+## Ship Phase — "I need to ship"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Ship workflow (PR + changelog) | `ship-workflow` skill | `changelog-composer` |
+| Generate changelog | `changelog-composer` skill | — |
+| Generate API documentation | `api-docs-generator` skill | — |
+| Full release lifecycle | `release-captain` agent | `ship-workflow`, `changelog-composer` |
+| Engineering retrospective | `engineering-retro` skill | — |
+| Review before creating PR | `plan-review` agent | `pr-review` |
+
+## Research — "I need to investigate"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Deep multi-source research | `research-analyst` agent | — |
+| Literature review (academic) | `literature-review` skill | `arxiv-search` utility |
+| Search arXiv papers | `arxiv-search` utility | `literature-review` |
+| YouTube content analysis | `youtube-analysis` skill | `youtube-search` skill |
+| Search YouTube | `youtube-search` skill | `youtube-analysis` |
+| Critique research methodology | `research-critique` skill | `literature-review` |
+| NotebookLM-style analysis | `notebooklm` skill | — |
+| Web fetch / scrape | `web-fetch` skill | `lightpanda-browser` |
+| Convert academic paper to skill | `paper-to-skill` skill | `skill-distiller` |
+
+## Content & Media — "I need to create content"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| LinkedIn post | `linkedin-post-style` skill | `humanize` skill |
+| Blog post / article | `content-strategist` agent | `humanize` |
+| Slide presentation (HTML) | `html-presentation` skill | — |
+| Architecture diagram | `architecture-diagram` skill | `architecture-reviewer` |
+| Generate image from concept | `concept-to-image` skill | — |
+| Generate video from concept | `concept-to-video` skill | `remotion-video` |
+| Programmatic video (Remotion) | `remotion-video` skill | — |
+| Build static website | `static-web-artifacts-builder` skill | — |
+| Convert to Markdown | `to-markdown` skill | — |
+| Convert Markdown to PDF | `md-to-pdf` skill | — |
+| Humanize AI text | `humanize` skill | — |
+| Media production (auto-format) | `media-producer` agent | — |
+| Write a proposal | `proposal-writer` agent | `estimate-calibrator` |
+
+## Orchestration — "I need to coordinate work"
+
+| Task | Primary Package | Complements |
+|------|----------------|-------------|
+| Coordinate multi-agent work | `team-lead` agent | (delegates to specialized agents) |
+| Evolve/improve a skill | `test-engineer` agent | `surrogate-verifier`, `skill-distiller` |
+| Full skill evolution pipeline | `/evolve` command | `test-engineer` agent |
+
+---
+
+## Presets — Pre-Configured Bundles
+
+If the user wants a curated set of packages for a role or workflow:
+
+| Preset | Purpose |
+|--------|---------|
+| `core` | Essential packages for any project |
+| `python-strict` | Python development with strict typing and testing |
+| `sec-strict` | Security-focused development |
+| `research` | Academic and technical research |
+| `eng-ops` | Engineering operations and shipping |
+| `content-ops` | Content creation and publishing |
+| `biz-validation` | Business idea validation pipeline |
+| `media-craft` | Visual and video content creation |
+| `terse-mode` | Minimal output style |
+| `ai-builder` | AI/ML development |
+| `skill-evolution` | Skill creation and refinement |

--- a/commands/route/evals/cases.yaml
+++ b/commands/route/evals/cases.yaml
@@ -1,0 +1,55 @@
+cases:
+  - id: route_explicit_command
+    prompt: "/route I need to review a pull request"
+    fixtures: []
+    rubric:
+      - "activates route command"
+      - "recommends pr-review skill as primary"
+      - "suggests code-refiner as complement"
+    trigger_expected: true
+
+  - id: route_ambiguous_task
+    prompt: "/route I need to check my code"
+    fixtures: []
+    rubric:
+      - "activates route command"
+      - "asks clarifying question to distinguish review vs. security vs. refactor"
+    trigger_expected: true
+
+  - id: route_business_idea
+    prompt: "which skill should I use to validate a startup idea?"
+    fixtures: []
+    rubric:
+      - "recommends idea-validator or idea-scout"
+      - "mentions business validation presets as alternative"
+    trigger_expected: true
+
+  - id: route_research_task
+    prompt: "/route I want to research the state of WebAssembly for server-side rendering"
+    fixtures: []
+    rubric:
+      - "recommends research-analyst agent as primary"
+      - "may suggest literature-review or web-fetch as complements"
+    trigger_expected: true
+
+  - id: route_shipping
+    prompt: "find the right skill for creating a release with changelog"
+    fixtures: []
+    rubric:
+      - "recommends release-captain agent or ship-workflow skill"
+      - "mentions changelog-composer as complement"
+    trigger_expected: true
+
+  - id: negative_direct_task
+    prompt: "Review this PR for security issues"
+    fixtures: []
+    rubric:
+      - "does not activate route command (direct task — should invoke security-reviewer or pr-review directly)"
+    trigger_expected: false
+
+  - id: negative_code_generation
+    prompt: "Write a function to parse CSV files"
+    fixtures: []
+    rubric:
+      - "does not activate route command (direct implementation task, not a discovery question)"
+    trigger_expected: false

--- a/commands/security-scan/COMMAND.md
+++ b/commands/security-scan/COMMAND.md
@@ -15,6 +15,7 @@ metadata:
   category: review
   tags: [security, scanning, vulnerabilities, audit]
   difficulty: intermediate
+  phase: review
 command:
   syntax: /security-scan [path-or-scope]
   handler: inline

--- a/commands/tdd/COMMAND.md
+++ b/commands/tdd/COMMAND.md
@@ -15,6 +15,7 @@ metadata:
   category: development
   tags: [tdd, testing, red-green-refactor, test-first]
   difficulty: intermediate
+  phase: build
 command:
   syntax: /tdd [function-or-module]
   handler: inline

--- a/hooks/anatomy-index/HOOK.md
+++ b/hooks/anatomy-index/HOOK.md
@@ -5,7 +5,8 @@ description: 'Generates and maintains a project file index with one-line descrip
   and token estimates. On session start or first tool use, builds .claude/anatomy.md
   by walking the project tree. Before Read, displays the target file summary so Claude
   can decide to skip. After Write/Edit, updates the changed file entry in the index.
-  Respects .gitignore exclusions.
+  Respects .gitignore exclusions. Triggers on: file index, project map, codebase
+  anatomy, file summary index, project structure overview.
 
   '
 metadata:

--- a/hooks/prompt-context/HOOK.md
+++ b/hooks/prompt-context/HOOK.md
@@ -8,7 +8,8 @@ description:
   rather than blocking input. Use this hook to enforce output styles, inject project
   reminders, prime roles, or apply constraints that survive context compaction — the
   injection lands adjacent to the user prompt on every turn, the highest-attention
-  slot in the context window.
+  slot in the context window. Triggers on: inject prompt context, persistent
+  instructions, system prompt injection, context injection hook, output style hook.
 
   "
 metadata:

--- a/hooks/read-dedup/HOOK.md
+++ b/hooks/read-dedup/HOOK.md
@@ -5,6 +5,8 @@ description: 'Detects and warns about duplicate file reads within a Claude Code 
   Fires on PreToolUse for the Read tool, tracks files read in a session-scoped temp
   file, and emits a stderr warning with estimated token count when a file is read again.
   Reduces wasted context by nudging the model to reuse knowledge from earlier reads.
+  Triggers on: duplicate read detection, token waste, re-read prevention, file read
+  tracker, context dedup.
 
   '
 metadata:

--- a/hooks/simplify-ignore/HOOK.md
+++ b/hooks/simplify-ignore/HOOK.md
@@ -1,0 +1,105 @@
+---
+name: simplify-ignore
+type: hook
+description: >-
+  Collapses code blocks marked with simplify-ignore-start/simplify-ignore-end
+  comment markers before the agent reads a file. Redirects the Read tool to a
+  collapsed copy via updatedInput and adds additionalContext warning the agent
+  not to edit collapsed regions. On Stop, cleans up the session cache directory.
+  Prevents agents from modifying infrastructure code, generated code, or complex
+  subsystems they should not touch. Language-agnostic — works with any comment
+  syntax. Triggers on: "hide code from agent", "code folding", "protect code
+  sections", "collapse infrastructure code", "simplify-ignore markers".
+metadata:
+  version: 1.1.0
+  category: operations
+  tags: [context, simplify, code-folding, efficiency]
+  difficulty: intermediate
+hook:
+  events: [PreToolUse, Stop]
+  matcher: Read
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
+---
+# simplify-ignore
+
+Hides marked code blocks from Claude Code's Read tool, reducing context noise
+and preventing agents from modifying protected code sections.
+
+## How It Works
+
+### Marker Format
+
+Add comment markers around code blocks to hide:
+
+```python
+# simplify-ignore-start
+class InternalCacheManager:
+    """Complex infrastructure the agent shouldn't touch."""
+    # ... 500 lines of cache invalidation logic ...
+# simplify-ignore-end
+```
+
+Works with any comment syntax:
+
+```javascript
+// simplify-ignore-start
+// ... protected code ...
+// simplify-ignore-end
+```
+
+```html
+<!-- simplify-ignore-start -->
+<!-- ... protected code ... -->
+<!-- simplify-ignore-end -->
+```
+
+### Events
+
+| Event | Matcher | Purpose |
+|-------|---------|---------|
+| `PreToolUse` | `Read` | Redirect Read to a collapsed copy via `updatedInput` |
+| `Stop` | — | Clean up the session cache directory |
+
+### PreToolUse (Read)
+
+1. Read the JSON input from stdin to extract `file_path`, `session_id`, and
+   optional `offset`/`limit` parameters
+2. Check if the file contains `simplify-ignore-start` markers
+3. If markers found:
+   - Cache the original in `/tmp/.claude-simplify-ignore-{session}/`
+   - Generate a collapsed copy with `[COLLAPSED: N lines — simplify-ignore]`
+     placeholders replacing each marked block
+   - Emit `hookSpecificOutput` JSON with:
+     - `permissionDecision: "allow"` — do not block the Read
+     - `updatedInput.file_path` — redirected to the collapsed temp file
+     - `additionalContext` — informs the agent about collapsed regions
+4. If no markers, exit 0 (passthrough — no JSON output)
+
+### Stop
+
+Clean up the session cache directory to avoid temp file accumulation.
+
+## Output Format
+
+On files with markers, the hook emits:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {"file_path": "/tmp/.claude-simplify-ignore-.../file.collapsed"},
+    "additionalContext": "simplify-ignore: collapsed 42 lines in /path/to/file.py ..."
+  }
+}
+```
+
+## Caveats
+
+- Edits to collapsed regions are silently ignored — the agent cannot modify
+  what it cannot see
+- Nested markers are not supported — the first `simplify-ignore-end` closes
+  the most recent `simplify-ignore-start`
+- The cache is session-scoped and cleaned on Stop — no persistent state
+- The collapsed temp file path differs from the original — agents see the
+  temp path in Read output but `additionalContext` names the real file

--- a/hooks/simplify-ignore/evals/cases.yaml
+++ b/hooks/simplify-ignore/evals/cases.yaml
@@ -1,0 +1,39 @@
+cases:
+  - id: collapse_marked_python_file
+    prompt: "Read a Python file containing simplify-ignore-start and simplify-ignore-end markers"
+    fixtures: []
+    rubric:
+      - "detects simplify-ignore markers in the file"
+      - "replaces marked block with collapsed placeholder showing line count"
+      - "preserves all content outside the markers"
+    trigger_expected: true
+
+  - id: collapse_multiple_blocks
+    prompt: "Read a file with multiple simplify-ignore regions"
+    fixtures: []
+    rubric:
+      - "collapses each marked block independently"
+      - "reports total collapsed lines in stderr"
+    trigger_expected: true
+
+  - id: passthrough_unmarked_file
+    prompt: "Read a regular file with no simplify-ignore markers"
+    fixtures: []
+    rubric:
+      - "exits immediately without modifying content"
+      - "no stderr output"
+    trigger_expected: false
+
+  - id: negative_edit_without_markers
+    prompt: "Edit a file that has no simplify-ignore markers"
+    fixtures: []
+    rubric:
+      - "does not activate simplify-ignore (no markers present, normal edit passthrough)"
+    trigger_expected: false
+
+  - id: cleanup_on_stop
+    prompt: "Session ends after reading files with simplify-ignore markers"
+    fixtures: []
+    rubric:
+      - "removes session cache directory on Stop event"
+    trigger_expected: true

--- a/hooks/simplify-ignore/handler.sh
+++ b/hooks/simplify-ignore/handler.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# simplify-ignore hook — collapses marked code blocks before Read.
+# Markers: simplify-ignore-start / simplify-ignore-end (any comment syntax).
+# On PreToolUse(Read): writes collapsed content to a temp file and redirects
+#   the Read tool to the collapsed version via updatedInput.
+# On Stop: cleans up session cache directory.
+# Always exits 0 (never blocks reads).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Detect event type from hook input
+TOOL_NAME=$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+SESSION_ID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+SESSION_ID=${SESSION_ID:-default}
+
+CACHE_DIR="/tmp/.claude-simplify-ignore-${SESSION_ID}"
+
+# Stop event — clean up cache
+if [ -z "$TOOL_NAME" ]; then
+  rm -rf "$CACHE_DIR" 2>/dev/null || true
+  exit 0
+fi
+
+# PreToolUse(Read) — collapse marked blocks
+FILE_PATH=$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Quick check: does the file contain markers?
+if ! grep -q 'simplify-ignore-start' "$FILE_PATH" 2>/dev/null; then
+  exit 0
+fi
+
+# Set up cache directory
+mkdir -p "$CACHE_DIR"
+CACHE_KEY=$(printf '%s' "$FILE_PATH" | sed 's|/|__|g')
+COLLAPSED_FILE="${CACHE_DIR}/${CACHE_KEY}.collapsed"
+
+# Cache original for reference
+cp "$FILE_PATH" "${CACHE_DIR}/${CACHE_KEY}.original"
+
+# Collapse marked blocks using awk — write to temp file
+awk '
+  /simplify-ignore-start/ {
+    inside = 1
+    count = 0
+    match($0, /^[[:space:]]*[^a-zA-Z]*/)
+    prefix = substr($0, RSTART, RLENGTH)
+    next
+  }
+  /simplify-ignore-end/ {
+    if (inside) {
+      printf "%s[COLLAPSED: %d lines — simplify-ignore]\n", prefix, count
+      inside = 0
+    }
+    next
+  }
+  inside {
+    count++
+    next
+  }
+  { print }
+' "$FILE_PATH" > "$COLLAPSED_FILE"
+
+ORIGINAL_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' ')
+COLLAPSED_COUNT=$(wc -l < "$COLLAPSED_FILE" | tr -d ' ')
+DIFF=$((ORIGINAL_COUNT - COLLAPSED_COUNT))
+
+if [ "$DIFF" -le 0 ]; then
+  # No lines collapsed — nothing to override
+  rm -f "$COLLAPSED_FILE"
+  exit 0
+fi
+
+# Escape the collapsed file path for JSON
+ESCAPED_PATH=$(printf '%s' "$COLLAPSED_FILE" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+# Also extract offset/limit from original input to preserve them
+OFFSET=$(printf '%s' "$INPUT" | sed -n 's/.*"offset"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+LIMIT=$(printf '%s' "$INPUT" | sed -n 's/.*"limit"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+
+# Build updatedInput — redirect Read to the collapsed file
+UPDATED_INPUT="{\"file_path\":\"${ESCAPED_PATH}\""
+if [ -n "$OFFSET" ]; then
+  UPDATED_INPUT="${UPDATED_INPUT},\"offset\":${OFFSET}"
+fi
+if [ -n "$LIMIT" ]; then
+  UPDATED_INPUT="${UPDATED_INPUT},\"limit\":${LIMIT}"
+fi
+UPDATED_INPUT="${UPDATED_INPUT}}"
+
+# Emit structured JSON: redirect Read + inform agent about collapsed regions
+CONTEXT="simplify-ignore: collapsed ${DIFF} lines in ${FILE_PATH} (${ORIGINAL_COUNT} → ${COLLAPSED_COUNT}). Regions marked with simplify-ignore markers are hidden. Do not attempt to edit collapsed regions."
+ESCAPED_CONTEXT=$(printf '%s' "$CONTEXT" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"simplify-ignore: redirecting to collapsed file","updatedInput":%s,"additionalContext":"%s"}}' "$UPDATED_INPUT" "$ESCAPED_CONTEXT"
+
+exit 0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -17,6 +17,7 @@ packages:
     - adr
     category: operations
     difficulty: intermediate
+    phase: plan
   - name: agent-builder
     version: 1.1.1
     description: Build AI agents and automate Claude Code programmatically using the Claude Agent SDK and headless CLI mode.
@@ -34,6 +35,7 @@ packages:
     - mcp
     category: development
     difficulty: intermediate
+    phase: build
   - name: api-docs-generator
     version: 1.1.1
     description: 'Audits and enhances API documentation for FastAPI and REST endpoints. Identifies missing descriptions, incomplete
@@ -50,6 +52,7 @@ packages:
     - fastapi
     category: review
     difficulty: intermediate
+    phase: ship
   - name: architecture-diagram
     version: 1.1.1
     description: 'Generate detailed layered architecture diagrams as self-contained HTML artifacts with inline SVG icons,
@@ -86,6 +89,7 @@ packages:
     - security-audit
     category: review
     difficulty: advanced
+    phase: review
   - name: benchmark-runner
     version: 1.1.1
     description: 'Designs structured benchmarks for comparing algorithms, models, or implementations. Selects appropriate
@@ -103,6 +107,7 @@ packages:
     - metrics
     category: data
     difficulty: intermediate
+    phase: verify
   - name: changelog-composer
     version: 1.1.1
     description: 'Generates structured changelogs and release notes from git history and PR descriptions. Classifies changes
@@ -120,6 +125,7 @@ packages:
     - versioning
     category: content
     difficulty: intermediate
+    phase: ship
   - name: code-refiner
     version: 1.1.1
     description: 'Deep code simplification, refactoring, and quality refinement. Analyzes structural complexity, anti-patterns,
@@ -138,6 +144,7 @@ packages:
     - readability
     category: review
     difficulty: intermediate
+    phase: review
   - name: competitive-analyzer
     version: 1.0.1
     description: 'Systematic competitive landscape analysis covering Porter''s Five Forces, competitor discovery, feature
@@ -162,6 +169,7 @@ packages:
     - positioning
     category: business
     difficulty: advanced
+    phase: define
   - name: concept-to-image
     version: 1.2.1
     description: 'Turn any concept, idea, or description into a polished static HTML visual, then export it as a PNG or SVG
@@ -218,6 +226,7 @@ packages:
     - bisect
     category: development
     difficulty: intermediate
+    phase: build
   - name: dependency-audit
     version: 1.1.1
     description: 'Audits project dependencies for license compliance, maintenance health, security vulnerabilities, and bloat.
@@ -235,6 +244,7 @@ packages:
     - supply-chain
     category: review
     difficulty: intermediate
+    phase: review
   - name: devils-advocate
     version: 1.0.0
     description: 'Challenges AI-generated plans, code, designs, and decisions before you commit. Pairs with any other skill
@@ -254,6 +264,7 @@ packages:
     - pre-mortem
     category: review
     difficulty: intermediate
+    phase: review
   - name: doc-condenser
     version: 1.1.1
     description: 'DEPRECATED: The base model handles document condensation and summarization natively at high quality. This
@@ -283,6 +294,7 @@ packages:
     - sprint
     category: review
     difficulty: intermediate
+    phase: ship
   - name: env-validator
     version: 1.0.1
     description: 'Validates .env files and environment variable configurations against project requirements. Checks for missing
@@ -302,6 +314,7 @@ packages:
     - deployment
     category: operations
     difficulty: intermediate
+    phase: build
   - name: estimate-calibrator
     version: 1.1.1
     description: 'Produces calibrated three-point estimates (best/likely/worst case) with explicit unknowns, confidence intervals,
@@ -320,6 +333,7 @@ packages:
     - planning
     category: development
     difficulty: intermediate
+    phase: plan
   - name: feasibility-assessor
     version: 1.0.1
     description: 'Evaluate whether a business idea, product concept, or feature is technically buildable and financially viable.
@@ -337,6 +351,7 @@ packages:
     - business-case
     category: review
     difficulty: advanced
+    phase: define
     complements:
     - idea-validator
   - name: filesystem
@@ -392,6 +407,7 @@ packages:
     - pytorch
     category: data
     difficulty: advanced
+    phase: build
   - name: html-presentation
     version: 1.1.1
     description: Convert any document, outline, or content into a polished, self-contained HTML slide presentation. Use this
@@ -452,6 +468,7 @@ packages:
     - swot
     category: review
     difficulty: advanced
+    phase: define
   - name: immune
     version: 1.0.1
     description: 'Hybrid adaptive memory system with two complementary memories: Cheatsheet (positive patterns injected before
@@ -544,6 +561,7 @@ packages:
     - verification
     category: review
     difficulty: advanced
+    phase: review
     complements:
     - literature-review
   - name: manuscript-review
@@ -565,6 +583,7 @@ packages:
     - submission
     category: review
     difficulty: advanced
+    phase: review
     complements:
     - literature-review
   - name: market-analyzer
@@ -586,6 +605,7 @@ packages:
     - industry
     category: research
     difficulty: intermediate
+    phase: define
     complements:
     - competitive-analyzer
     - idea-validator
@@ -607,6 +627,7 @@ packages:
     - token-reduction
     category: data
     difficulty: intermediate
+    phase: build
   - name: md-to-pdf
     version: 1.2.1
     description: 'Convert Markdown files to professionally styled PDF documents with full support for Mermaid diagrams, LaTeX/KaTeX
@@ -642,6 +663,7 @@ packages:
     - rollback
     category: review
     difficulty: advanced
+    phase: review
   - name: notebooklm
     version: 1.1.1
     description: 'Complete API for Google NotebookLM — full programmatic access including features not in the web UI. Create
@@ -680,6 +702,7 @@ packages:
     - frontmatter
     category: review
     difficulty: intermediate
+    phase: review
   - name: paper-to-skill
     version: 1.0.1
     description: 'Converts research papers into executable skill packages by extracting actionable methodologies and feeding
@@ -700,6 +723,7 @@ packages:
     - methodology-extraction
     category: research
     difficulty: advanced
+    phase: build
   - name: plan-review
     version: 1.0.1
     description: Pre-implementation plan audit that stress-tests scope, assumptions, risks, and failure modes before code
@@ -734,6 +758,7 @@ packages:
     - diff-analysis
     category: review
     difficulty: intermediate
+    phase: review
   - name: pre-landing-review
     version: 1.0.1
     description: Gate-oriented safety audit for code changes before landing, using a structured checklist with two-pass severity
@@ -749,6 +774,7 @@ packages:
     - checklist
     category: review
     difficulty: intermediate
+    phase: review
   - name: prompt-lab
     version: 1.1.1
     description: 'Systematic LLM prompt engineering: analyzes existing prompts for failure modes, generates structured variants
@@ -767,6 +793,7 @@ packages:
     - chain-of-thought
     category: development
     difficulty: intermediate
+    phase: build
   - name: qa-systematic
     version: 1.0.1
     description: Systematic web application QA testing with structured issue taxonomy, health scoring, and regression tracking.
@@ -782,6 +809,7 @@ packages:
     - regression
     category: development
     difficulty: advanced
+    phase: verify
   - name: rag-auditor
     version: 1.1.1
     description: 'Evaluates RAG (Retrieval-Augmented Generation) pipeline quality across retrieval and generation stages.
@@ -800,6 +828,7 @@ packages:
     - grounding
     category: review
     difficulty: advanced
+    phase: build
   - name: regex-builder
     version: 1.1.1
     description: 'DEPRECATED: The base model generates, explains, and tests regex patterns natively with high accuracy. This
@@ -852,6 +881,7 @@ packages:
     - audit
     category: review
     difficulty: advanced
+    phase: review
   - name: research-critique
     version: 1.0.1
     description: 'Critical analysis of research papers, academic manuscripts, preprints, and technical studies — evaluating
@@ -871,6 +901,7 @@ packages:
     - peer-review
     category: review
     difficulty: intermediate
+    phase: review
     complements:
     - literature-review
   - name: sequential-thinking
@@ -901,6 +932,7 @@ packages:
     - changelog
     category: review
     difficulty: intermediate
+    phase: ship
   - name: skill-distiller
     version: 1.0.1
     description: 'Converts Opus-quality skill packages into deterministic, Haiku-executable workflows through trace-driven
@@ -922,6 +954,7 @@ packages:
     - deterministic
     category: development
     difficulty: advanced
+    phase: build
   - name: skill-library
     version: 2.0.1
     description: 'Agent-native catalog and installer for armory packages across all 7 types: skills, agents, hooks, rules,
@@ -957,6 +990,7 @@ packages:
     - optimization
     category: data
     difficulty: intermediate
+    phase: build
   - name: static-web-artifacts-builder
     version: 1.1.1
     description: 'Build elaborate, self-contained static HTML artifacts opened in a browser — interactive diagrams, architecture
@@ -996,6 +1030,7 @@ packages:
     - eval
     category: review
     difficulty: advanced
+    phase: verify
   - name: task-decomposer
     version: 1.1.1
     description: 'Produces structured phased task boards from feature requests: dependency-mapped work items with parallelization
@@ -1013,6 +1048,7 @@ packages:
     - phased
     category: development
     difficulty: intermediate
+    phase: plan
   - name: tavily
     version: 1.1.1
     description: 'AI-optimized web search via Tavily API. Use this skill when no specific URL is provided and the user needs
@@ -1048,6 +1084,7 @@ packages:
     - python
     category: development
     difficulty: intermediate
+    phase: build
   - name: to-markdown
     version: 1.0.1
     description: 'Convert any file or URL to clean Markdown. Handles PDF, Word (DOCX), Excel (XLSX), PowerPoint (PPTX), HTML,
@@ -1086,6 +1123,7 @@ packages:
     - b2b-saas
     category: review
     difficulty: intermediate
+    phase: review
   - name: web-fetch
     version: 1.1.1
     description: 'Web content fetching and URL retrieval via curl and WebFetch — replaces the Fetch MCP server (fetch_html,
@@ -1415,14 +1453,15 @@ packages:
     - co-evolutionary
     - testing
     - opus
-    category: meta
+    category: development
     difficulty: advanced
   hooks:
   - name: anatomy-index
     version: 1.0.0
-    description: Generates and maintains a project file index with one-line descriptions and token estimates. On session start
-      or first tool use, builds .claude/anatomy.md by walking the project tree. Before Read, displays the target file summary
-      so Claude can decide to skip. After Write/Edit, updates the changed file entry in the index. Respects .gitignore exclusions.
+    description: 'Generates and maintains a project file index with one-line descriptions and token estimates. On session
+      start or first tool use, builds .claude/anatomy.md by walking the project tree. Before Read, displays the target file
+      summary so Claude can decide to skip. After Write/Edit, updates the changed file entry in the index. Respects .gitignore
+      exclusions. Triggers on: file index, project map, codebase anatomy, file summary index, project structure overview.'
     path: hooks/anatomy-index
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/anatomy-index/HOOK.md
     events:
@@ -1497,7 +1536,8 @@ packages:
       .claude/prompt-context.txt first, falling back to ~/.claude/prompt-context.txt. Fail-open: missing or unreadable files
       exit 0 silently rather than blocking input. Use this hook to enforce output styles, inject project reminders, prime
       roles, or apply constraints that survive context compaction — the injection lands adjacent to the user prompt on every
-      turn, the highest-attention slot in the context window.'
+      turn, the highest-attention slot in the context window. Triggers on: inject prompt context, persistent instructions,
+      system prompt injection, context injection hook, output style hook.'
     path: hooks/prompt-context
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/prompt-context/HOOK.md
     events:
@@ -1512,9 +1552,10 @@ packages:
     difficulty: beginner
   - name: read-dedup
     version: 1.0.0
-    description: Detects and warns about duplicate file reads within a Claude Code session. Fires on PreToolUse for the Read
+    description: 'Detects and warns about duplicate file reads within a Claude Code session. Fires on PreToolUse for the Read
       tool, tracks files read in a session-scoped temp file, and emits a stderr warning with estimated token count when a
-      file is read again. Reduces wasted context by nudging the model to reuse knowledge from earlier reads.
+      file is read again. Reduces wasted context by nudging the model to reuse knowledge from earlier reads. Triggers on:
+      duplicate read detection, token waste, re-read prevention, file read tracker, context dedup.'
     path: hooks/read-dedup
     source: https://github.com/Mathews-Tom/armory/blob/main/hooks/read-dedup/HOOK.md
     events:
@@ -1526,6 +1567,26 @@ packages:
     - efficiency
     category: operations
     difficulty: beginner
+  - name: simplify-ignore
+    version: 1.1.0
+    description: 'Collapses code blocks marked with simplify-ignore-start/simplify-ignore-end comment markers before the agent
+      reads a file. Redirects the Read tool to a collapsed copy via updatedInput and adds additionalContext warning the agent
+      not to edit collapsed regions. On Stop, cleans up the session cache directory. Prevents agents from modifying infrastructure
+      code, generated code, or complex subsystems they should not touch. Language-agnostic — works with any comment syntax.
+      Triggers on: "hide code from agent", "code folding", "protect code sections", "collapse infrastructure code", "simplify-ignore
+      markers".'
+    path: hooks/simplify-ignore
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/simplify-ignore/HOOK.md
+    events:
+    - PreToolUse
+    - Stop
+    tags:
+    - context
+    - simplify
+    - code-folding
+    - efficiency
+    category: operations
+    difficulty: intermediate
   rules:
   - name: commit-standards
     version: 1.0.0
@@ -1584,12 +1645,13 @@ packages:
     difficulty: beginner
   - name: token-efficiency
     version: 1.0.0
-    description: Enforces token-efficient tool usage patterns to reduce context waste and lower session costs. Covers file
+    description: 'Enforces token-efficient tool usage patterns to reduce context waste and lower session costs. Covers file
       reading strategies (targeted line-range reads, avoiding re-reads of in-context files), search-first patterns (Grep/Glob
       before full Read), write discipline (never write unchanged content, append without full read), and context management
       (check summaries before committing to full reads). Use this rule when optimizing Claude Code session efficiency, reducing
-      token consumption, or establishing tool-usage best practices. Triggers on "token efficiency", "reduce tokens", "context
-      waste", "tool usage", "read efficiency", "minimize reads".
+      token consumption, or establishing tool-usage best practices. Triggers on: "token efficiency", "reduce tokens", "context
+      waste", "tool usage", "read efficiency", "minimize reads", "save tokens", "optimize reads", "how to reduce token usage",
+      "session cost", "context window management".'
     path: rules/token-efficiency
     source: https://github.com/Mathews-Tom/armory/blob/main/rules/token-efficiency/RULE.md
     scope: global
@@ -1633,6 +1695,23 @@ packages:
     - simplification
     category: development
     difficulty: intermediate
+    phase: review
+  - name: route
+    version: 1.0.0
+    description: 'Skill router that maps user tasks to the best armory packages. Provides a decision-tree organized by development
+      lifecycle phase (define, plan, build, verify, review, ship) plus cross-cutting domains (research, content, business).
+      Triggers on: "/route", "which skill", "what package", "find the right skill", "help me pick a skill", "discover packages".
+      Use this command when unsure which armory skill, agent, or command to use for a task.'
+    path: commands/route
+    source: https://github.com/Mathews-Tom/armory/blob/main/commands/route/COMMAND.md
+    tags:
+    - discovery
+    - routing
+    - meta
+    - navigation
+    category: operations
+    difficulty: beginner
+    phase: plan
   - name: security-scan
     version: 1.0.0
     description: 'Security audit workflow that scans a codebase path or scope for vulnerabilities across six categories: hardcoded
@@ -1649,6 +1728,7 @@ packages:
     - audit
     category: review
     difficulty: intermediate
+    phase: review
   - name: tdd
     version: 1.0.0
     description: 'Test-driven development workflow for functions, modules, or features. Guides Claude through the red-green-refactor
@@ -1665,6 +1745,7 @@ packages:
     - test-first
     category: development
     difficulty: intermediate
+    phase: build
   utilities:
   - name: arxiv-search
     version: 1.0.0
@@ -1875,10 +1956,11 @@ packages:
     difficulty: advanced
   - name: terse-mode
     version: 1.0.0
-    description: Enforces terse, no-narration output from Claude Code. Bundles the prompt-context hook with a curated terse
+    description: 'Enforces terse, no-narration output from Claude Code. Bundles the prompt-context hook with a curated terse
       rules file that strips hedging, praise, soft language, meta-commentary, engagement phrases, and unsolicited offers from
       every response. Use this preset when you want action-only output without preambles, postambles, or trailing questions
-      — code over prose, facts over hedging, stop at the information boundary.
+      — code over prose, facts over hedging, stop at the information boundary. Triggers on: terse mode, concise output, minimal
+      responses, quiet mode, no narration, brief output style.'
     path: presets/terse-mode
     source: https://github.com/Mathews-Tom/armory/blob/main/presets/terse-mode/PRESET.md
     tags:

--- a/presets/terse-mode/PRESET.md
+++ b/presets/terse-mode/PRESET.md
@@ -7,7 +7,8 @@ description:
   meta-commentary, engagement phrases, and unsolicited offers from every response.
   Use this preset when you want action-only output without preambles, postambles,
   or trailing questions — code over prose, facts over hedging, stop at the information
-  boundary.
+  boundary. Triggers on: terse mode, concise output, minimal responses, quiet mode,
+  no narration, brief output style.
 
   "
 metadata:

--- a/rules/token-efficiency/RULE.md
+++ b/rules/token-efficiency/RULE.md
@@ -8,8 +8,10 @@ description: >
   write discipline (never write unchanged content, append without full read), and
   context management (check summaries before committing to full reads). Use this rule
   when optimizing Claude Code session efficiency, reducing token consumption, or
-  establishing tool-usage best practices. Triggers on "token efficiency", "reduce
-  tokens", "context waste", "tool usage", "read efficiency", "minimize reads".
+  establishing tool-usage best practices. Triggers on: "token efficiency",
+  "reduce tokens", "context waste", "tool usage", "read efficiency", "minimize
+  reads", "save tokens", "optimize reads", "how to reduce token usage",
+  "session cost", "context window management".
 metadata:
   version: 1.0.0
   scope: global

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -169,6 +169,9 @@ def collect_packages(pkg_type: PackageType, repo: str) -> list[dict[str, Any]]:
             difficulty = metadata.get("difficulty")
             if isinstance(difficulty, str) and difficulty:
                 entry["difficulty"] = difficulty
+            phase = metadata.get("phase")
+            if isinstance(phase, str) and phase:
+                entry["phase"] = phase
 
         entries.append(entry)
 

--- a/scripts/hooks_installer.py
+++ b/scripts/hooks_installer.py
@@ -15,6 +15,23 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.frontmatter import parse_frontmatter
 
 
+def _resolve_hook_command(command: str, hook_dir: Path) -> str:
+    """Rewrite relative script references in a hook command to absolute paths.
+
+    Handles patterns like ``bash handler.sh`` or ``bash helper.sh`` where the
+    script is a bare filename (no slashes, no ``~``).  Already-absolute paths
+    and paths containing ``~`` or ``/`` are left untouched.
+    """
+    import re
+
+    def _replace(m: re.Match[str]) -> str:
+        prefix, script = m.group(1), m.group(2)
+        return f"{prefix}{hook_dir / script}"
+
+    # Match: <word-boundary>bash <bare-script.sh> — only bare filenames
+    return re.sub(r"(bash\s+)([A-Za-z0-9_.-]+\.sh)\b", _replace, command)
+
+
 def install_hook(hook_dir: Path, claude_dir: Path) -> None:
     """Install a hook package.
 
@@ -45,7 +62,7 @@ def install_hook(hook_dir: Path, claude_dir: Path) -> None:
     if settings_path.exists():
         settings = json.loads(settings_path.read_text(encoding="utf-8"))
 
-    settings = merge_hook_config(settings, name, hook_config)
+    settings = merge_hook_config(settings, name, hook_config, claude_dir)
     settings_path.write_text(
         json.dumps(settings, indent=2) + "\n", encoding="utf-8"
     )
@@ -71,7 +88,10 @@ def uninstall_hook(name: str, claude_dir: Path) -> None:
 
 
 def merge_hook_config(
-    settings: dict[str, Any], hook_name: str, hook_meta: dict[str, Any]
+    settings: dict[str, Any],
+    hook_name: str,
+    hook_meta: dict[str, Any],
+    claude_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Add hook configuration to settings dict. Returns modified settings.
 
@@ -86,6 +106,10 @@ def merge_hook_config(
 
     Each hook package gets its own matcher entry tagged with _hook_name for
     tracking which package owns it.
+
+    When *claude_dir* is provided, relative script references (e.g.
+    ``bash handler.sh``) are rewritten to absolute paths pointing at the
+    installed hook directory so the command works regardless of CWD.
     """
     hooks_section = settings.setdefault("hooks", {})
     events = hook_meta.get("events", [])
@@ -94,6 +118,13 @@ def merge_hook_config(
 
     hook_entry = dict(handler)
     hook_entry["_hook_name"] = hook_name
+
+    # Rewrite relative script paths to absolute installed paths
+    if claude_dir is not None:
+        cmd = hook_entry.get("command", "")
+        if cmd:
+            hook_dir = claude_dir / "hooks" / hook_name
+            hook_entry["command"] = _resolve_hook_command(cmd, hook_dir)
 
     for event in events:
         event_list: list[dict[str, Any]] = hooks_section.setdefault(event, [])

--- a/skills/adr-writer/SKILL.md
+++ b/skills/adr-writer/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: operations
   tags: [architecture, decision-record, documentation, adr]
   difficulty: intermediate
+  phase: plan
 ---
 
 # ADR Writer

--- a/skills/agent-builder/SKILL.md
+++ b/skills/agent-builder/SKILL.md
@@ -14,6 +14,7 @@ metadata:
   category: development
   tags: [agent-sdk, headless, automation, mcp]
   difficulty: intermediate
+  phase: build
 ---
 
 # Agent Builder - Claude SDK & CLI Expert

--- a/skills/api-docs-generator/SKILL.md
+++ b/skills/api-docs-generator/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: review
   tags: [api, documentation, openapi, fastapi]
   difficulty: intermediate
+  phase: ship
 ---
 
 # API Docs Generator

--- a/skills/architecture-reviewer/SKILL.md
+++ b/skills/architecture-reviewer/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: review
   tags: [architecture, scalability, enterprise, security-audit]
   difficulty: advanced
+  phase: review
 ---
 # Architecture Reviewer
 
@@ -343,3 +344,33 @@ Apply these rules to ensure fair, useful reviews:
 
 7. **Honest about unknowns:** If the input doesn't provide enough information to evaluate a
    sub-criterion, say so explicitly. Don't guess. Flag it as requiring more information.
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It works in production already" | Working today doesn't mean it scales, maintains, or survives team turnover — architecture debt compounds silently |
+| "We'll refactor when it becomes a problem" | By then the cost is 10x higher — refactoring under load with accumulated dependencies is surgical, not routine |
+| "The framework handles that" | Frameworks provide defaults, not architecture — you're still responsible for boundaries, error propagation, and data flow |
+| "It's an internal service, standards don't apply" | Internal services become external faster than you expect — technical debt migrates across boundaries |
+| "Performance is fine for our current scale" | Architecture reviews evaluate the next 10x, not the current state — O(n^2) at 1k rows is invisible at 100k rows |
+| "We don't have time for a full review" | Partial reviews create false confidence — better to review fewer dimensions thoroughly than all dimensions superficially |
+
+## Red Flags
+
+- Evaluating only the happy path without tracing error propagation
+- No scalability assessment (missing load projection, bottleneck identification)
+- Scoring a dimension without reading the relevant code — relying on documentation alone
+- Marking dimensions as N/A without justification
+- Recommendations that are generic ("add caching", "use a queue") without specifying what, where, and why
+- Reviewing implementation details instead of architectural decisions
+
+## Verification
+
+- [ ] All 7 dimensions evaluated with sub-criterion scores
+- [ ] Each finding includes specific file/component references
+- [ ] Scalability assessment includes concrete load projections or growth assumptions
+- [ ] Cross-cutting analysis identifies at least one inter-dimension concern
+- [ ] Every recommendation specifies what to change, where, and expected impact
+- [ ] N/A dimensions justified explicitly — not silently skipped
+- [ ] Final score is a weighted composite, not an average of vibes

--- a/skills/benchmark-runner/SKILL.md
+++ b/skills/benchmark-runner/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: data
   tags: [benchmarking, performance, comparison, metrics]
   difficulty: intermediate
+  phase: verify
 ---
 
 # Benchmark Runner

--- a/skills/changelog-composer/SKILL.md
+++ b/skills/changelog-composer/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: content
   tags: [changelog, release-notes, git-history, versioning]
   difficulty: intermediate
+  phase: ship
 ---
 
 # Changelog Composer

--- a/skills/code-refiner/SKILL.md
+++ b/skills/code-refiner/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: review
   tags: [refactoring, code-quality, simplification, readability]
   difficulty: intermediate
+  phase: review
 ---
 
 # Code Refiner
@@ -241,3 +242,32 @@ For language-specific idiom guidance, read the appropriate reference file:
 
 Only load the reference file for the language(s) in the current scope. These provide detailed
 pattern catalogs that supplement the general methodology above.
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's readable enough" | "Enough" is not a standard — if the next developer needs to re-read a function 3 times, it's not readable |
+| "Refactoring risks regressions" | Not refactoring risks accumulating debt — run the test suite before and after, that's what tests are for |
+| "This is how the codebase has always done it" | Consistency with a bad pattern is still bad — improve incrementally, don't preserve anti-patterns |
+| "The performance might get worse" | Benchmark before and after — most readability refactors have zero performance impact; premature optimization is the root of all evil |
+| "It's not broken, don't fix it" | Refining isn't fixing — it's making working code maintainable, testable, and understandable for the next person |
+| "I'll refactor the whole module later" | Incremental refinement works; big-bang rewrites fail — improve what you touch now |
+
+## Red Flags
+
+- Changing behavior while claiming "just a refactor" — refining must preserve all existing behavior
+- Touching code outside the declared scope without justification
+- Removing error handling or validation during simplification
+- Introducing new abstractions for one-time operations
+- Refactoring without running the test suite before and after
+- Making style changes to code that wasn't part of the original task
+
+## Verification
+
+- [ ] All existing tests pass before and after refinement
+- [ ] No behavioral changes — output/side-effects identical for all inputs
+- [ ] Changes stay within declared scope — no drive-by edits to unrelated code
+- [ ] Cyclomatic complexity reduced or unchanged — never increased
+- [ ] No new abstractions introduced for single-use cases
+- [ ] Linter and type checker pass: `ruff check` + `mypy --strict` or `tsc --noEmit` + `eslint`

--- a/skills/competitive-analyzer/SKILL.md
+++ b/skills/competitive-analyzer/SKILL.md
@@ -20,6 +20,7 @@ metadata:
   category: business
   tags: [competitive-analysis, market, porters-five-forces, positioning]
   difficulty: advanced
+  phase: define
 ---
 
 # Competitive Analyzer

--- a/skills/debug-investigator/SKILL.md
+++ b/skills/debug-investigator/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: development
   tags: [debugging, root-cause, hypothesis, bisect]
   difficulty: intermediate
+  phase: build
 ---
 
 # Debug Investigator

--- a/skills/dependency-audit/SKILL.md
+++ b/skills/dependency-audit/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: review
   tags: [dependencies, vulnerabilities, licenses, supply-chain]
   difficulty: intermediate
+  phase: review
 ---
 
 # Dependency Audit
@@ -205,3 +206,32 @@ Push back if:
 - The project is a prototype that won't ship — defer audit until production decision
 - The user wants dependency updates, not audit — different task (dependabot, renovate)
 - The project has no dependencies (pure standard library) — nothing to audit
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's a trusted package" | Trust is not a security model — trusted packages get compromised (event-stream, ua-parser-js, colors.js) |
+| "Only a minor version bump" | Minor versions can introduce vulnerabilities, change behavior, or add transitive dependencies — semver is a promise, not a guarantee |
+| "We don't use the vulnerable function" | Transitive dependencies might — and attack surface includes any code loaded into the process |
+| "The CVE is low severity" | Low severity in isolation can be critical in your context — a "low" SSRF in an internal service with cloud metadata access is critical |
+| "We'll update when there's a known exploit" | Known exploits mean you're already behind — patch within SLA, not after breach |
+| "Too many dependencies to audit" | That's the problem, not an excuse — high dependency count IS a risk finding |
+
+## Red Flags
+
+- Auditing only direct dependencies while ignoring transitive dependency tree
+- Dismissing CVEs without checking if the vulnerable code path is reachable
+- No license compatibility check — GPL in a proprietary codebase is a legal finding
+- Accepting "no known vulnerabilities" from a single scanner without cross-referencing
+- Ignoring dependency age — unmaintained packages with no updates in 2+ years are a risk
+- Skipping lockfile analysis (pinned vs. floating versions)
+
+## Verification
+
+- [ ] Both direct and transitive dependencies scanned
+- [ ] Vulnerability scanner output captured: `npm audit` / `pip-audit` / `cargo audit`
+- [ ] Each CVE finding includes: severity, affected version range, upgrade path, reachability assessment
+- [ ] License compatibility verified against project license
+- [ ] Dependency age and maintenance status checked for top-level deps
+- [ ] Lockfile present and version pinning verified — no floating ranges in production

--- a/skills/devils-advocate/SKILL.md
+++ b/skills/devils-advocate/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: review
   tags: [review, critical-thinking, blind-spots, decision-review, pre-mortem]
   difficulty: intermediate
+  phase: review
 ---
 # Devil's Advocate
 

--- a/skills/engineering-retro/SKILL.md
+++ b/skills/engineering-retro/SKILL.md
@@ -15,6 +15,7 @@ metadata:
   category: review
   tags: [retrospective, velocity, git-analysis, sprint]
   difficulty: intermediate
+  phase: ship
 ---
 
 # Engineering Retrospective

--- a/skills/env-validator/SKILL.md
+++ b/skills/env-validator/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: operations
   tags: [env, configuration, validation, dotenv, deployment]
   difficulty: intermediate
+  phase: build
 ---
 
 # Env Validator

--- a/skills/estimate-calibrator/SKILL.md
+++ b/skills/estimate-calibrator/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: development
   tags: [estimation, pert, confidence-interval, planning]
   difficulty: intermediate
+  phase: plan
 ---
 
 # Estimate Calibrator

--- a/skills/feasibility-assessor/SKILL.md
+++ b/skills/feasibility-assessor/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: review
   tags: [feasibility, unit-economics, viability, business-case]
   difficulty: advanced
+  phase: define
 ---
 
 # Feasibility Assessor

--- a/skills/gpu-optimizer/SKILL.md
+++ b/skills/gpu-optimizer/SKILL.md
@@ -12,6 +12,7 @@ metadata:
   category: data
   tags: [gpu, cuda, vram, pytorch]
   difficulty: advanced
+  phase: build
 ---
 
 # GPU Optimizer

--- a/skills/idea-validator/SKILL.md
+++ b/skills/idea-validator/SKILL.md
@@ -21,6 +21,7 @@ metadata:
   category: review
   tags: [idea-validation, lean-canvas, jtbd, swot]
   difficulty: advanced
+  phase: define
 ---
 
 # Business Idea Validator

--- a/skills/manuscript-provenance/SKILL.md
+++ b/skills/manuscript-provenance/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: review
   tags: [provenance, reproducibility, computational, verification]
   difficulty: advanced
+  phase: review
 ---
 
 # Manuscript Provenance Audit

--- a/skills/manuscript-review/SKILL.md
+++ b/skills/manuscript-review/SKILL.md
@@ -19,6 +19,7 @@ metadata:
   category: review
   tags: [manuscript, pre-publication, citation-hygiene, submission]
   difficulty: advanced
+  phase: review
 ---
 
 # Manuscript Review Skill

--- a/skills/market-analyzer/SKILL.md
+++ b/skills/market-analyzer/SKILL.md
@@ -19,6 +19,7 @@ metadata:
   category: research
   tags: [market-sizing, tam-sam-som, trends, industry]
   difficulty: intermediate
+  phase: define
 ---
 
 # Market Analyzer

--- a/skills/mcp-to-skill/SKILL.md
+++ b/skills/mcp-to-skill/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: data
   tags: [mcp, skill-conversion, context-optimization, token-reduction]
   difficulty: intermediate
+  phase: build
 ---
 
 # MCP-to-Skill Converter

--- a/skills/migration-risk-analyzer/SKILL.md
+++ b/skills/migration-risk-analyzer/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: review
   tags: [database, migration, ddl, rollback]
   difficulty: advanced
+  phase: review
 ---
 
 # Migration Risk Analyzer
@@ -199,4 +200,32 @@ Push back if:
 - The migration is for a development/staging database — risk analysis is for production
 - The migration only creates new tables (no ALTER, no existing data) — low risk by definition
 - The user wants migration execution, not analysis — this skill assesses risk, it doesn't run migrations
-```
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's backwards compatible" | Backwards compatible at the schema level doesn't mean backwards compatible at the application level — query plans, ORM mappings, and application code all interact |
+| "We can roll back" | Rollback is not free — data written after migration may not survive rollback; DROP COLUMN has no rollback without backup |
+| "It's a small table" | Table size is one factor — lock duration, concurrent write rate, and replication lag matter more than row count |
+| "We've run this migration type before" | Past success doesn't predict future success — different data distribution, different load, different constraints |
+| "Downtime window is long enough" | Estimate based on dev data, not production — migration on 10k rows takes seconds; on 50M rows with indexes, it takes hours |
+| "The ORM handles it" | ORMs generate SQL, they don't guarantee safety — `ALTER TABLE` locking behavior is engine-specific and ORM-opaque |
+
+## Red Flags
+
+- No estimate of migration duration based on production data volume
+- No rollback plan or rollback plan that doesn't account for data written post-migration
+- Analyzing migration SQL without checking the current table size and write rate
+- No consideration of replication lag in multi-replica setups
+- Assuming zero downtime without verifying lock behavior for the specific DDL operation
+- Skipping index analysis — adding an index on a large table can lock writes for minutes to hours
+
+## Verification
+
+- [ ] Production table sizes and row counts documented for all affected tables
+- [ ] Lock behavior identified for each DDL statement (exclusive lock, no lock, etc.)
+- [ ] Migration duration estimated using production-scale data, not dev fixtures
+- [ ] Rollback plan documented with specific steps and data preservation guarantees
+- [ ] Concurrent write impact assessed — what happens to in-flight transactions during migration
+- [ ] Replication lag impact assessed for multi-replica configurations

--- a/skills/package-evaluator/SKILL.md
+++ b/skills/package-evaluator/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: review
   tags: [quality, audit, scoring, frontmatter]
   difficulty: intermediate
+  phase: review
 ---
 
 # Package Evaluator

--- a/skills/paper-to-skill/SKILL.md
+++ b/skills/paper-to-skill/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: research
   tags: [paper, arxiv, research, skill-generation, methodology-extraction]
   difficulty: advanced
+  phase: build
 ---
 
 # Paper-to-Skill Pipeline

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: review
   tags: [code-review, pull-request, quality, diff-analysis]
   difficulty: intermediate
+  phase: review
 ---
 
 # PR Review
@@ -175,3 +176,32 @@ When a specific aspect is requested, load only that reference file and skip rout
    what's done well, even briefly.
 6. **Code-refiner handles simplification.** This skill reviews and reports. It does not
    refactor or simplify — that's the `code-refiner` skill's job. Keep the roles separate.
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Tests pass, so the code is fine" | Tests are necessary but insufficient — they miss architecture, security, readability, and maintainability concerns |
+| "It's a small diff, no real review needed" | Small changes cause most production incidents; a 3-line auth bypass is worse than a 300-line refactor |
+| "We'll clean it up later" | Later never comes — the review IS the quality gate before code becomes legacy |
+| "The author is senior, I trust them" | Seniority doesn't prevent mistakes; fresh eyes catch what familiarity blinds |
+| "I already reviewed similar code recently" | Each diff has unique context — assumptions from past reviews cause missed issues |
+| "This is just a refactor, nothing can break" | Refactors change behavior in subtle ways — verify with tests and trace call sites |
+
+## Red Flags
+
+- Approving without reading every changed file in full (not just diff hunks)
+- No file:line references in findings — vague feedback is not actionable
+- Skipping a review dimension because "it looks fine"
+- Reporting only style issues while ignoring logic, security, or architecture
+- Reviewing generated code (migrations, protobuf stubs) with the same rigor as hand-written code
+- Merging findings from different dimensions without deduplication
+
+## Verification
+
+- [ ] Every changed file read in full, not just diff hunks
+- [ ] Each review dimension scored: correctness, security, performance, readability, architecture
+- [ ] Every finding includes a file:line reference
+- [ ] At least one actionable finding per 100 lines changed, or explicit "no issues found" with justification
+- [ ] Review summary includes risk level (LOW/MEDIUM/HIGH/CRITICAL) and blocking vs. non-blocking classification
+- [ ] Strengths acknowledged — review is not 100% negative

--- a/skills/pre-landing-review/SKILL.md
+++ b/skills/pre-landing-review/SKILL.md
@@ -14,6 +14,7 @@ metadata:
   category: review
   tags: [pre-merge, safety-gate, code-review, checklist]
   difficulty: intermediate
+  phase: review
 ---
 
 # Pre-Landing Review

--- a/skills/prompt-lab/SKILL.md
+++ b/skills/prompt-lab/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: development
   tags: [prompt-engineering, evaluation, few-shot, chain-of-thought]
   difficulty: intermediate
+  phase: build
 ---
 
 # Prompt Lab

--- a/skills/qa-systematic/SKILL.md
+++ b/skills/qa-systematic/SKILL.md
@@ -14,6 +14,7 @@ metadata:
   category: development
   tags: [qa, testing, browser, regression]
   difficulty: advanced
+  phase: verify
 ---
 
 # Systematic QA Testing

--- a/skills/rag-auditor/SKILL.md
+++ b/skills/rag-auditor/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: review
   tags: [rag, retrieval, hallucination, grounding]
   difficulty: advanced
+  phase: build
 ---
 
 # RAG Auditor

--- a/skills/repo-sentinel/SKILL.md
+++ b/skills/repo-sentinel/SKILL.md
@@ -20,6 +20,7 @@ metadata:
   category: review
   tags: [security, public-repo, secret-scanning, audit]
   difficulty: advanced
+  phase: review
 ---
 
 # Repo Sentinel

--- a/skills/research-critique/SKILL.md
+++ b/skills/research-critique/SKILL.md
@@ -20,6 +20,7 @@ metadata:
   category: review
   tags: [research, methodology, claims-evidence, peer-review]
   difficulty: intermediate
+  phase: review
 ---
 
 # Research Paper Critique

--- a/skills/ship-workflow/SKILL.md
+++ b/skills/ship-workflow/SKILL.md
@@ -14,6 +14,7 @@ metadata:
   category: review
   tags: [release, ci-cd, pull-request, changelog]
   difficulty: intermediate
+  phase: ship
 ---
 
 # Ship Workflow

--- a/skills/skill-distiller/SKILL.md
+++ b/skills/skill-distiller/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: development
   tags: [distillation, cross-model, optimization, haiku, deterministic]
   difficulty: advanced
+  phase: build
 ---
 
 # Skill Distiller

--- a/skills/sql-optimizer/SKILL.md
+++ b/skills/sql-optimizer/SKILL.md
@@ -15,6 +15,7 @@ metadata:
   category: data
   tags: [sql, performance, database, optimization]
   difficulty: intermediate
+  phase: build
 ---
 
 # SQL Optimizer

--- a/skills/surrogate-verifier/SKILL.md
+++ b/skills/surrogate-verifier/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: review
   tags: [verification, assertions, testing, co-evolution, diagnostics, eval]
   difficulty: advanced
+  phase: verify
 ---
 
 # Surrogate Verifier

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -17,6 +17,7 @@ metadata:
   category: development
   tags: [task-breakdown, dependencies, planning, phased]
   difficulty: intermediate
+  phase: plan
 ---
 
 # Task Decomposer

--- a/skills/test-harness/SKILL.md
+++ b/skills/test-harness/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   category: development
   tags: [testing, pytest, test-generation, python]
   difficulty: intermediate
+  phase: build
 ---
 
 # Test Harness
@@ -239,3 +240,33 @@ Push back if:
 - The request is for UI/E2E tests — this skill generates unit and integration tests only
 - The code has no clear behavior to test (pure configuration, constant definitions)
 - The user wants tests for third-party library code — test your usage of the library, not the library itself
+
+## Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Manual testing is sufficient" | Manual testing doesn't run in CI, doesn't catch regressions, and doesn't scale with the codebase |
+| "This code is too simple to test" | Simple code becomes complex code — tests document expected behavior and catch regressions from future changes |
+| "I'll add tests later" | Tests are specifications; without them, code behavior is undefined and later never comes |
+| "Mocking everything makes the test fast" | Over-mocked tests pass when the real system fails — mock at boundaries, not deep in the call chain |
+| "100% coverage means the code is correct" | Coverage measures execution, not correctness — a test that runs code without meaningful assertions adds no value |
+| "The happy path test is enough" | Edge cases and error paths cause most production incidents — happy-path-only testing is false confidence |
+
+## Red Flags
+
+- Tests that only cover the happy path with no edge cases or error paths
+- Test names that describe implementation ("test_calls_function") instead of behavior ("test_returns_404_when_not_found")
+- More than two mocks per test — indicates the unit under test is too coupled
+- Tests that depend on execution order or shared mutable state
+- Assertions on implementation details (mock call counts) instead of observable behavior
+- Skipping integration tests because "unit tests cover it"
+
+## Verification
+
+- [ ] Tests follow Arrange-Act-Assert structure with clear phase separation
+- [ ] Test names describe behavior: `test_<unit>_<scenario>_<expected_outcome>`
+- [ ] Edge cases covered: empty input, boundary values, error paths, null/None
+- [ ] Coverage meets thresholds: 80% overall, 90% new code, 95% critical paths
+- [ ] All tests pass: `pytest` / `npm test` exits 0 with output captured
+- [ ] No test depends on execution order — can run in any sequence
+- [ ] Mocks used only at boundaries (external APIs, system clock, filesystem in unit tests)

--- a/skills/ux-expert/SKILL.md
+++ b/skills/ux-expert/SKILL.md
@@ -18,6 +18,7 @@ metadata:
   category: review
   tags: [ux, dashboard, audit, redesign, b2b-saas]
   difficulty: intermediate
+  phase: review
 ---
 # UX Expert
 

--- a/tests/test_hooks_installer.py
+++ b/tests/test_hooks_installer.py
@@ -2,10 +2,15 @@
 from __future__ import annotations
 
 import copy
+from pathlib import Path
 
 import pytest
 
-from scripts.hooks_installer import merge_hook_config, remove_hook_config
+from scripts.hooks_installer import (
+    _resolve_hook_command,
+    merge_hook_config,
+    remove_hook_config,
+)
 
 
 @pytest.fixture
@@ -62,6 +67,7 @@ class TestMergeHookConfig:
         assert groups[0]["matcher"] == "Bash"
         assert len(groups[0]["hooks"]) == 1
         assert groups[0]["hooks"][0]["_hook_name"] == "git-protection"
+        # Without claude_dir, command stays relative
         assert groups[0]["hooks"][0]["command"] == "bash handler.sh"
 
     def test_merge_appends_different_matcher(
@@ -216,3 +222,65 @@ class TestRoundTrip:
         result = remove_hook_config(result, "pre-edit-backup")
         result = remove_hook_config(result, "cost-tracker")
         assert result == original
+
+
+class TestResolveHookCommand:
+    """Tests for _resolve_hook_command path rewriting."""
+
+    def test_rewrites_bare_handler_sh(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/git-protection")
+        result = _resolve_hook_command("bash handler.sh", hook_dir)
+        assert result == "bash /home/user/.claude/hooks/git-protection/handler.sh"
+
+    def test_rewrites_arbitrary_script_name(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/cost-tracker")
+        result = _resolve_hook_command("bash my-script.sh", hook_dir)
+        assert result == "bash /home/user/.claude/hooks/cost-tracker/my-script.sh"
+
+    def test_leaves_absolute_path_untouched(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/test")
+        cmd = "bash /usr/local/bin/handler.sh"
+        assert _resolve_hook_command(cmd, hook_dir) == cmd
+
+    def test_leaves_tilde_path_untouched(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/test")
+        cmd = "bash ~/.claude/hooks/test/handler.sh"
+        assert _resolve_hook_command(cmd, hook_dir) == cmd
+
+    def test_leaves_non_bash_command_untouched(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/test")
+        cmd = "python3 handler.py"
+        assert _resolve_hook_command(cmd, hook_dir) == cmd
+
+    def test_leaves_path_with_slashes_untouched(self) -> None:
+        hook_dir = Path("/home/user/.claude/hooks/test")
+        cmd = "bash ./scripts/handler.sh"
+        # Contains a slash — not a bare filename — should NOT be rewritten
+        assert _resolve_hook_command(cmd, hook_dir) == cmd
+
+
+class TestMergeWithClaudeDir:
+    """Tests for merge_hook_config with claude_dir path rewriting."""
+
+    def test_merge_rewrites_relative_handler(self) -> None:
+        claude_dir = Path("/home/user/.claude")
+        meta = {
+            "events": ["Stop"],
+            "matcher": "",
+            "handler": {"type": "command", "command": "bash handler.sh", "timeout_ms": 5000},
+        }
+        result = merge_hook_config({}, "cost-tracker", meta, claude_dir)
+
+        hook_cmd = result["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert hook_cmd == "bash /home/user/.claude/hooks/cost-tracker/handler.sh"
+
+    def test_merge_without_claude_dir_keeps_relative(self) -> None:
+        meta = {
+            "events": ["Stop"],
+            "matcher": "",
+            "handler": {"type": "command", "command": "bash handler.sh", "timeout_ms": 5000},
+        }
+        result = merge_hook_config({}, "cost-tracker", meta)
+
+        hook_cmd = result["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert hook_cmd == "bash handler.sh"


### PR DESCRIPTION
## Summary

Adopts 7 concepts from [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) into armory, plus fixes a critical bug affecting all installed hooks. Changes span 59 files across bug fix, 2 new packages, content enrichment for 7 packages, metadata additions to 39 packages, quality improvements from evaluations, and documentation updates.

### Bug Fix

- **Hook handler relative path resolution** — All 6 hook packages defined `command: bash handler.sh` (relative) in frontmatter. The installer wrote this verbatim into `settings.json`, but Claude Code runs hooks from the project CWD, causing `bash: handler.sh: No such file or directory` on every hook invocation. Added `_resolve_hook_command()` to rewrite bare script filenames to absolute installed paths at install time. 8 new tests.

### New Packages

- **`/route` command** — Skill-router decision tree mapping user tasks to the best armory packages across 9 categories (define, plan, build, verify, review, ship, research, content, orchestration). Solves the 108-package discoverability problem without requiring MCP server configuration. 7 eval cases.

- **`simplify-ignore` hook** — Collapses code blocks marked with `simplify-ignore-start`/`simplify-ignore-end` comment markers before the agent reads a file. Uses PreToolUse `updatedInput` to redirect Read to a collapsed temp file and `additionalContext` to warn the agent about hidden regions. Language-agnostic markers. Session cache cleaned on Stop. 5 eval cases.

### Content Enrichment (7 Packages)

Three new optional content sections added to packages where partial compliance is dangerous:

- **Rationalizations** — Tables pairing common agent excuses with factual rebuttals (e.g., "Tests pass, so it's fine" → "Tests are necessary but insufficient — they miss architecture, security, readability")
- **Red Flags** — Observable symptoms indicating the skill workflow is being shortcut during execution
- **Verification** — Concrete evidence checklists proving correct execution (test output, scores, artifacts)

Packages: `pr-review`, `architecture-reviewer`, `test-harness`, `code-refiner`, `dependency-audit`, `migration-risk-analyzer`, `security-reviewer`

### Lifecycle Phase Taxonomy (39 Packages)

Added optional `phase` metadata field to package frontmatter with 6 values: `define`, `plan`, `build`, `verify`, `review`, `ship`. Enables the `/route` command and orchestrator agents to sequence work by development lifecycle stage. Updated `generate_manifest.py` to extract phase into manifest entries.

| Phase | Count | Examples |
|-------|-------|---------|
| define | 4 | idea-validator, market-analyzer, competitive-analyzer, feasibility-assessor |
| plan | 4 | task-decomposer, estimate-calibrator, adr-writer, route |
| build | 10 | test-harness, debug-investigator, sql-optimizer, prompt-lab, env-validator |
| verify | 2 | benchmark-runner, qa-systematic |
| review | 15 | pr-review, architecture-reviewer, code-refiner, dependency-audit, security-scan |
| ship | 4 | ship-workflow, changelog-composer, api-docs-generator, engineering-retro |

### Quality Improvements from Evaluations

All 14 new/recent packages evaluated across 6 dimensions (D1-D6). Fixes applied:

- Added trigger phrases to 4 hooks + 1 preset scoring below 75% on D2 (Trigger Coverage): `anatomy-index`, `read-dedup`, `prompt-context`, `terse-mode`
- Added imperative/interrogative triggers to `token-efficiency` rule
- Fixed `test-engineer` agent category from invalid `meta` to `development`
- Added missing `phase` metadata to `paper-to-skill`, `skill-distiller`, `surrogate-verifier`
- Rewrote `simplify-ignore` handler from non-functional (stderr-only) to proper `hookSpecificOutput` JSON with `updatedInput` + `additionalContext`

### Documentation

- **CONTRIBUTING.md**: Documented `phase` metadata field with 6 lifecycle phases. Documented three new optional content sections (Rationalizations, Red Flags, Verification) with examples and guidance on when to include them.
- **NEW_PACKAGE_CHECKLIST.md**: Added `phase` to frontmatter template. Added optional sections to Phase 3 content checklist.

### Manifest

Regenerated: 108 packages (63 skills, 15 agents, 7 hooks, 4 rules, 5 commands, 3 utilities, 11 presets).

## Post-Fix Evaluation Scores

| Package | Type | Score | Verdict |
|---------|------|-------|---------|
| skill-evolution | preset | 97% | Exemplary |
| surrogate-verifier | skill | 95% | Exemplary |
| evolve | command | 93% | Exemplary |
| test-engineer | agent | 93% | Exemplary |
| env-validator | skill | 92% | Exemplary |
| skill-distiller | skill | 92% | Exemplary |
| route | command | 90% | Exemplary |
| token-efficiency | rule | 90% | Exemplary |
| paper-to-skill | skill | 88% | Strong |
| prompt-context | hook | 88% | Strong |
| simplify-ignore | hook | 80% | Strong |
| terse-mode | preset | 78% | Adequate |
| read-dedup | hook | 76% | Adequate |
| anatomy-index | hook | 74% | Adequate |

All 14 packages pass the 70% quality gate. No CRITICAL or HIGH findings remain.

## Test plan

- [x] 213 tests pass (`uv run pytest -v`)
- [x] 8 new tests for hook path resolution (rewrites, passthrough, round-trip)
- [x] All 106 eval files validate (`uv run python scripts/validate_evals.py`)
- [x] Manifest regenerated with correct package counts
- [x] All 14 packages evaluated at 70%+ with no CRITICAL/HIGH findings
- [ ] Re-install hooks to verify absolute paths in settings.json: `uv run scripts/install.py --type hooks`
- [ ] Test `/route` command activation in Claude Code session
- [ ] Test `simplify-ignore` markers on a file with `simplify-ignore-start`/`end` comments