### PR TITLE
feat: Memento-Skills reflective loop integration (phases 0-5)

### DIFF
--- a/.github/workflows/router-index.yml
+++ b/.github/workflows/router-index.yml
@@ -1,0 +1,81 @@
+name: Router Index
+
+on:
+  # Nightly rebuild picks up any new eval history appended during the day.
+  schedule:
+    - cron: '15 3 * * *'  # 03:15 UTC nightly
+  # On-demand rebuild from the Actions tab.
+  workflow_dispatch:
+  # Rebuild whenever the history log or the builder script itself changes.
+  push:
+    branches:
+      - main
+    paths:
+      - 'evals/history.jsonl'
+      - 'scripts/build_router_index.py'
+      - 'scripts/task_signature.py'
+
+jobs:
+  build:
+    name: Build router index from eval history
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Build router index
+        run: |
+          python scripts/build_router_index.py \
+            --history evals/history.jsonl \
+            --output dist/router_index.json \
+            --min-samples 3
+
+      - name: Summary
+        run: |
+          echo "### Router Index Rebuild" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f dist/router_index.json ]; then
+            python -c '
+          import json, pathlib
+          data = json.loads(pathlib.Path("dist/router_index.json").read_text())
+          meta = data["metadata"]
+          print(f"- Built at: {meta[\"built_at\"]}")
+          print(f"- Source entries: {meta[\"source_entries\"]}")
+          print(f"- Unique signatures: {meta[\"unique_signatures\"]}")
+          print(f"- Unique packages: {meta[\"unique_packages\"]}")
+          print(f"- Min samples: {meta[\"min_samples\"]}")
+            ' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Index build failed." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Upload router index artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: router-index
+          path: dist/router_index.json
+          retention-days: 14
+
+      - name: Check index gate for Phase 3 (≥500 entries)
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path("dist/router_index.json").read_text())
+          source = data["metadata"]["source_entries"]
+          gate = 500
+          if source < gate:
+              print(f"::warning::Router index below P3 gate ({source}/{gate}). Skill-router remains advisory until the gate is met.")
+          else:
+              print(f"Router index P3 gate met: {source} >= {gate} entries.")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ site/dist/
 # ── Skill packaging ──────────────────────────
 *.skill
 evals/results/
+evals/skillsbench/results/
 
 # ── Editors & IDE ─────────────────────────────
 .vscode/

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -51,10 +51,11 @@ Tools, libraries, and projects that armory packages wrap, depend on, or were ins
 | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | [claude-code-skills](https://github.com/notmanas/claude-code-skills)                                       | [@notmanas](https://github.com/notmanas)           |
 | [EvoSkills: Self-Evolving Agent Skills via Co-Evolutionary Verification](https://arxiv.org/abs/2604.01687) | Zhang, Fan, Zou, Chen et al.                       |
+| [Memento-Skills: Let Agents Design Agents](https://arxiv.org/abs/2603.18743)                               | Zhou, Guo, Liu, Yu et al.                          |
 | [gitagent](https://github.com/open-gitagent/gitagent)                                                      | [@shreyaskapale](https://github.com/shreyaskapale) |
 
 ## Notes
 
 - Remotion's license has commercial use restrictions. Lightpanda is AGPL-3.0 — armory wraps these as skills without distributing their binaries.
 - Skills that are pure prompt engineering (e.g., `humanize`, `code-refiner`, `architecture-reviewer`) have no upstream library dependency.
-- The `immune` skill's Cheatsheet/Immune pattern draws from Stephanie Forrest's original Artificial Immune Systems research.
+- The `immune` skill's Cheatsheet/Immune pattern draws from Stephanie Forrest's original Artificial Immune Systems research and aligns with Memento-Skills' stateful-prompt concept (arXiv 2603.18743) — cheatsheet entries act as positive-pattern memory, antibodies as negative-pattern memory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,6 +297,57 @@ metadata:
   phase: review
 ```
 
+## Task-Conditioned Entries (Memento-Skills)
+
+The `immune` skill (v3.1.0+) supports optional task-conditioned retrieval,
+which implements the read phase of the Memento-Skills reflective loop
+(arXiv 2603.18743). Antibodies and cheatsheet strategies may carry an
+optional `triggers` field that filters and ranks them per-task, so that
+unrelated entries are excluded from the active context.
+
+**Adding a task-conditioned entry to immune memory:**
+
+```json
+{
+  "id": "AB-042",
+  "domains": ["code"],
+  "pattern": "SQL injection via string concatenation",
+  "severity": "critical",
+  "correction": "Use parameterized queries (?, $1, bind)",
+  "seen_count": 12,
+  "first_seen": "2026-03-01",
+  "last_seen": "2026-04-05",
+  "triggers": {
+    "task_signatures": ["code query review sql", "audit code sql"],
+    "domains": ["code"]
+  }
+}
+```
+
+**Field reference:**
+
+| Field                      | Type          | Purpose                                                                                             |
+| -------------------------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| `triggers.task_signatures` | `list[str]`   | Canonical task signatures where this entry has historically been relevant. Use `task_signature()`. |
+| `triggers.domains`         | `list[str]`   | Hard filter — prompts outside these domains skip the entry entirely (unless the list contains `_global`). |
+
+**Back-compatibility:** entries without a `triggers` field behave as
+always-on (the v3.0.0 default). Adding `triggers` is purely additive — do
+not remove or change existing entries without understanding downstream
+scanner behavior.
+
+**Producing canonical signatures:**
+
+```bash
+python -c 'from scripts.task_signature import task_signature; print(task_signature("Review this SQL query for injection"))'
+# -> "injection query review sql"
+```
+
+The signature string is the space-joined, sorted set of normalized content
+tokens. Always produce signatures through `scripts.task_signature` rather
+than writing them by hand, so that the same normalization rules apply at
+write time and at retrieval time.
+
 ## Optional Content Sections
 
 Skills and agents may include three optional sections that improve agent compliance. These are recommended for review, quality, and security packages.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [skill-distiller](skills/skill-distiller/)             | Distill Opus-quality skill packages into deterministic, Haiku-executable workflows via trace-driven distillation |
 | [surrogate-verifier](skills/surrogate-verifier/)       | Information-isolated verification generating structured test assertions and failure diagnostics for skills        |
 
+> _Research lineage:_ the EvoSkills pipeline (arXiv 2604.01687) handles offline co-evolutionary refinement. The `immune` skill together with armory's auto-memory system implements the **stateful-prompt** concept from Memento-Skills (arXiv 2603.18743) — the read-write reflective loop for continual learning without parameter updates.
+
 ### Skills — Deprecated
 
 Skills below are superseded by base model capabilities. They remain installable but receive no further updates.

--- a/agents/skill-librarian/AGENT.md
+++ b/agents/skill-librarian/AGENT.md
@@ -1,0 +1,306 @@
+---
+name: skill-librarian
+type: agent
+description:
+  'Reflective write-phase orchestrator that observes completed task transcripts
+  and proposes additions or augmentations to the armory skill library. Implements
+  the write phase of the Memento-Skills reflective loop (arXiv 2603.18743): given
+  a conversation where novel problem-solving occurred, classify whether an existing
+  skill handled it, an existing skill needs augmentation, or no skill existed and
+  a new one should be drafted. Routes drafts through paper-to-skill''s specification
+  stage and test-engineer''s generate-verify loop, gates on package-evaluator,
+  and opens a pull request tagged for human review. Triggers on: "librarian review",
+  "review this transcript for new skills", "propose a skill from this conversation",
+  "draft skill from transcript", "what skills did we just use", "catalog this workflow",
+  "suggest skill addition", "analyze conversation for skill gaps", "skill-librarian",
+  "reflective skill review". NOT for refining existing skills that are already in
+  progress (use test-engineer directly). NOT for wholesale library reorganization
+  (that is a human decision). NOT for creating skills from research papers (use
+  paper-to-skill directly).
+
+  '
+model: sonnet
+color: cyan
+metadata:
+  version: 1.0.0
+  category: development
+  execution_phase: on-demand
+  priority: 55
+  enabled: true
+  orchestrates:
+    skills: [paper-to-skill, package-evaluator]
+    agents: [test-engineer]
+  tags: [memento-skills, reflective-learning, write-phase, skill-generation, sonnet]
+  difficulty: advanced
+---
+
+# Skill Librarian — Reflective Write Phase
+
+Observes completed task transcripts and decides whether armory's skill library
+should grow or augment itself based on what the conversation actually needed.
+This is the write half of the Memento-Skills read-write loop
+(arXiv 2603.18743) — the read half (task-conditioned retrieval) lives in the
+`immune` skill and the forthcoming `skill-router` agent.
+
+The librarian never refines skills directly. It drafts new skills or
+augmentation proposals, hands them to `test-engineer` for generate-verify
+refinement, then opens a pull request for human approval.
+
+---
+
+## Scope and Trigger Conditions
+
+### Activate when:
+
+- User explicitly invokes `/librarian review` or a semantic equivalent
+- User asks "did we just solve something that should become a skill?"
+- User asks "what skills did we use in this conversation and is anything missing?"
+- An orchestrator agent (e.g., `team-lead`) delegates reflective skill analysis
+- A completed multi-turn task transcript is available as input
+
+### Do NOT activate when:
+
+- An existing skill is mid-refinement by `test-engineer` (check for PRs with
+  the `evoskills-in-progress` label — see Rule 2 below)
+- User wants to refine a specific existing skill from scratch (use `test-engineer`)
+- User wants to convert a research paper to a skill (use `paper-to-skill`)
+- User wants to reorganize or rename existing skills (human decision)
+- No meaningful task was completed in the transcript (nothing to reflect on)
+- Auto-hook fired on a trivial or noise transcript (see Rule 1 on invocation cap)
+
+---
+
+## Input Requirements
+
+| Input             | Required | Description                                                                                       |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| Transcript source | Yes      | The conversation to analyze. Defaults to the last N turns of the current session.                 |
+| Mode              | No       | `review` (classify only) \| `draft` (classify + produce draft) \| `augment <skill>` (extend one)  |
+| Turn window       | No       | How far back to look. Default: last 20 turns or to the prior explicit user task, whichever comes first. |
+| Packages invoked  | No       | List of armory packages observed in use during the transcript. Derived from tool traces if absent. |
+
+---
+
+## Composition Map
+
+| Component          | Type  | Invoked In           | Purpose                                                                 |
+| ------------------ | ----- | -------------------- | ----------------------------------------------------------------------- |
+| paper-to-skill     | skill | Phase 3              | Specification extraction stage only — reuse its behavior-to-spec logic  |
+| test-engineer      | agent | Phase 4              | Generate-verify-refine loop for the drafted skill                        |
+| package-evaluator  | skill | Phase 5              | 6-dimensional quality gate (must score >= 70%)                           |
+
+---
+
+## Workflow Phases
+
+### Phase 1: Transcript Ingestion
+
+1. Collect the transcript window: last N turns from the current session or
+   an explicitly provided transcript file.
+2. Extract the list of packages (skills, agents, commands, hooks) that were
+   invoked during the window. Read tool traces if available; otherwise parse
+   user/assistant text for explicit `/<command>` and agent-spawn patterns.
+3. Identify the user's root task — the earliest substantive request in the
+   window. This becomes the "task under reflection."
+4. If the transcript contains no substantive task (chit-chat, status check,
+   trivial lookup), exit early with verdict `no_action` and do not proceed.
+
+### Phase 2: Classification
+
+Apply the following decision tree to the task under reflection:
+
+```
+Did an existing armory skill handle the task cleanly?
+├── Yes, and its usage was unremarkable
+│     └── Verdict: no_action. Exit.
+├── Yes, but the conversation worked around a specific gap in that skill
+│     └── Verdict: augment_existing. Target: <skill name>. Proceed to Phase 3.
+└── No, the task was solved through first-principles reasoning or ad-hoc tool use
+      ├── Is the solution pattern likely to recur across future tasks?
+      │     ├── No
+      │     │     └── Verdict: no_action. Exit.
+      │     └── Yes
+      │           └── Verdict: draft_new. Proceed to Phase 3.
+```
+
+Record the verdict, reasoning, and evidence (quoted transcript excerpts) in
+a decision log. This log accompanies the eventual PR and is the primary
+artifact when the verdict is `no_action`.
+
+**Overlap check:** For `draft_new` verdicts, search `manifest.yaml` for
+existing skills whose description overlaps the proposed domain. If overlap
+is significant (> 40% tag overlap or similar description), downgrade to
+`augment_existing` against the overlapping skill.
+
+### Phase 3: Specification Extraction
+
+Invoke the `paper-to-skill` skill in its specification-extraction mode only
+(do not run its downstream refinement pipeline — `test-engineer` handles that
+in Phase 4). Pass the specification extractor:
+
+- The task under reflection (prompt text)
+- The solution pattern extracted from the transcript (the sequence of tool
+  calls, reasoning steps, and intermediate artifacts that solved the task)
+- The decision log from Phase 2
+
+The extractor returns a skill specification dict with: target domain,
+input/output shape, tool requirements, edge cases observed, and a draft
+trigger-phrase list. This is the input to `test-engineer`.
+
+### Phase 4: Test-Engineer Handoff
+
+**Ownership boundary (see Rule 2):** the librarian never edits skill files
+directly. It only hands specifications to `test-engineer`.
+
+1. Check for open PRs on the target skill with the `evoskills-in-progress`
+   label. If any exist, abort this phase — concurrent refinement would cause
+   loop conflicts. Report the conflict in the decision log and exit with
+   verdict `deferred`.
+2. Spawn `test-engineer` with the Phase 3 specification as the input budget.
+   Default budget: 5 oracle rounds, 15 surrogate retries (`test-engineer`'s
+   defaults).
+3. Wait for the refined skill package path and evolution log.
+4. If `test-engineer` exhausts budget without convergence, accept the
+   best-scoring iteration and record the warning in the decision log.
+
+### Phase 5: Quality Gate
+
+1. Run `package-evaluator` on the refined package.
+2. Required: overall score >= 70%, zero CRITICAL findings, D1 (Frontmatter) >= 3/5.
+3. If the package fails the gate:
+   - For `augment_existing`: keep changes on a draft branch, do NOT open a PR,
+     record the failure in the decision log with the specific findings.
+   - For `draft_new`: keep the directory but do NOT open a PR. Same logging.
+4. If the package passes the gate, proceed to Phase 6.
+
+### Phase 6: Pull Request
+
+1. Create a branch named `librarian/<verdict>/<skill-name>` off main.
+2. Commit the skill package (for `draft_new`) or the augmentation diff
+   (for `augment_existing`) with a conventional commit message:
+   `feat(skills): draft <name> via librarian reflective review` or
+   `feat(skills): augment <name> via librarian reflective review`.
+3. Open the PR via `gh pr create` with:
+   - **Title:** same as the commit subject
+   - **Body:**
+     - Decision log from Phase 2 (verdict + evidence)
+     - Specification summary from Phase 3
+     - Evolution summary from Phase 4 (rounds, final score)
+     - Package evaluator scorecard from Phase 5
+     - A checklist of reviewer questions: "does this duplicate an existing
+       skill?", "does the trigger phrase coverage match real usage?", "are
+       the eval cases representative?"
+   - **Label:** `librarian-draft` (and `librarian-approve` required before
+     merge — the second label is added by human review, not the librarian)
+4. Return the PR URL to the caller.
+
+---
+
+## Output Artifacts
+
+| Artifact          | Format   | Description                                                          |
+| ----------------- | -------- | -------------------------------------------------------------------- |
+| Decision log      | Markdown | Phase 2 verdict, reasoning, transcript evidence                       |
+| Specification     | YAML     | Phase 3 output from `paper-to-skill` extractor                        |
+| Evolution summary | YAML     | Phase 4 output from `test-engineer` (rounds, convergence)             |
+| Quality scorecard | Markdown | Phase 5 output from `package-evaluator`                               |
+| Pull request      | URL      | Phase 6 result (only if quality gate passed)                          |
+
+---
+
+## Handoff Protocol
+
+### Receiving Work
+
+- Accepts transcript source (required), mode, turn window, and optional
+  packages-invoked list.
+- Accepts budget overrides that propagate to `test-engineer` in Phase 4.
+- When spawned by `team-lead`, accepts a `context_tag` that identifies the
+  orchestration thread for traceability.
+
+### Passing Work
+
+- Returns the verdict (`no_action`, `augment_existing`, `draft_new`, or
+  `deferred`).
+- On `no_action` or `deferred`: returns only the decision log.
+- On `augment_existing` or `draft_new`: returns decision log + specification
+  + evolution summary + PR URL (if gate passed) or failure report (if not).
+- Never returns an auto-merged PR. The `librarian-approve` label is added
+  by human reviewers, not the librarian.
+
+---
+
+## Rules
+
+1. **Invocation cap.** At most one draft per explicit invocation until the
+   Phase 5 hook rollout (see `MEMENTO_SKILLS_PLAN.md` Phase 5). This prevents
+   runaway drafting during long sessions.
+2. **Librarian drafts only; test-engineer refines only.** The librarian never
+   edits an existing skill file directly. If an open PR on the target skill
+   carries the `evoskills-in-progress` label, the librarian aborts with verdict
+   `deferred`. This ownership rule also lives in
+   `agents/test-engineer/AGENT.md` as a matching constraint.
+3. **Never auto-merge.** PRs require the `librarian-approve` label, which is
+   added only by a human reviewer.
+4. **Quality gate is non-negotiable.** If Phase 5 fails, no PR is opened.
+5. **Overlap check is mandatory.** Never draft a new skill without first
+   searching `manifest.yaml` for overlapping existing skills. If overlap
+   exceeds 40% tag similarity, convert to `augment_existing`.
+6. **Decision log is append-only within a session.** Each phase appends; no
+   phase rewrites prior entries. This preserves traceability.
+7. **Transcript scope is bounded.** Never exceed the Phase 1 turn window.
+   Reflecting on arbitrary historical conversations is out of scope.
+8. **Specification extraction only reuses `paper-to-skill`'s extractor
+   stage.** Do not invoke the downstream refinement pipeline — that is
+   `test-engineer`'s job via Phase 4.
+9. **No speculative abstraction.** If the solution pattern is a one-off
+   (e.g., specific to a single repo or user), verdict must be `no_action`
+   even if the pattern is novel.
+10. **Fail loud.** If any downstream agent errors (paper-to-skill extractor,
+    test-engineer, package-evaluator, gh), surface the error in the decision
+    log and exit. Do not silently retry or fall back to a partial draft.
+
+---
+
+## Optional Stop Hook Registration (Operator-Controlled)
+
+The librarian ships as an **explicit-command-only** agent. It does not
+auto-fire on conversation end. Operators who want automatic reflective
+review after each session can wire it into the Claude Code `Stop` hook,
+but this is opt-in and not a default.
+
+**Why opt-in:** automatic invocation can generate unwanted draft PRs if
+the librarian runs on trivial sessions. Rule 1 (invocation cap) limits
+the blast radius, but the cleanest default is human-in-the-loop.
+
+**Sample `settings.json` snippet** (operator adds manually):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "main",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '/librarian review --mode review --turn-window 20'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Operational notes:**
+
+- Prefer `--mode review` over `--mode draft` in the hook — review-only
+  runs are idempotent and safe; draft runs open PRs and should be
+  manually triggered.
+- Pair with a `librarian-draft` branch allowlist in your PR settings so
+  librarian-origin PRs are visibly tagged.
+- Monitor the draft acceptance rate (how often reviewers add the
+  `librarian-approve` label) before enabling draft mode in the hook.
+  The plan's exit criterion S2 (≥40% first-try acceptance) should be
+  met before wider rollout.

--- a/agents/skill-librarian/evals/cases.yaml
+++ b/agents/skill-librarian/evals/cases.yaml
@@ -1,0 +1,76 @@
+cases:
+  # --- Positive cases ---
+  - id: review_transcript_for_new_skill
+    prompt: "Librarian review: we just spent 15 turns solving a database migration rollback problem with ad-hoc sql and manual rollback scripts. Should this become a skill?"
+    fixtures: []
+    rubric:
+      - "Activates skill-librarian agent"
+      - "Runs Phase 1 transcript ingestion and extracts the task under reflection"
+      - "Produces Phase 2 classification verdict with evidence"
+      - "If draft_new or augment_existing, proceeds through Phase 3-6"
+      - "Does not directly edit any skill file — drafts only"
+    trigger_expected: true
+
+  - id: propose_skill_from_conversation
+    prompt: "Propose a skill from this conversation if the workflow is reusable. We just built a custom approach for auditing GraphQL schemas for deprecation risks."
+    fixtures: []
+    rubric:
+      - "Performs Phase 2 overlap check against manifest.yaml"
+      - "If no overlap, drafts new skill spec via paper-to-skill extractor stage"
+      - "Hands off to test-engineer for generate-verify loop"
+      - "Opens PR only after package-evaluator >= 70% gate"
+    trigger_expected: true
+
+  - id: augment_existing_skill_from_gap
+    prompt: "We kept working around a gap in the code-reviewer skill — it never checks for SQL injection in TypeScript string templates. Librarian, suggest an augmentation."
+    fixtures: []
+    rubric:
+      - "Classifies as augment_existing with target skill code-reviewer"
+      - "Checks for open PRs labeled evoskills-in-progress on code-reviewer"
+      - "Drafts augmentation, not new skill"
+      - "Runs quality gate before opening PR"
+    trigger_expected: true
+
+  - id: no_action_verdict_on_trivial
+    prompt: "Skill-librarian: review this conversation. We just ran a git status and committed three files."
+    fixtures: []
+    rubric:
+      - "Classifies as no_action (trivial task, nothing to reflect on)"
+      - "Exits without invoking paper-to-skill or test-engineer"
+      - "Returns only the decision log"
+    trigger_expected: true
+
+  - id: deferred_verdict_on_concurrent_refinement
+    prompt: "Librarian review: we found a gap in the debug-investigator skill that should be augmented. There is already an open PR refining debug-investigator."
+    fixtures: []
+    rubric:
+      - "Detects the evoskills-in-progress label on the existing PR"
+      - "Returns verdict deferred per Rule 2 (librarian-test-engineer ownership boundary)"
+      - "Does not spawn test-engineer"
+      - "Logs the conflict in the decision log"
+    trigger_expected: true
+
+  # --- Negative cases ---
+  - id: refine_existing_skill_directly
+    prompt: "Refine the existing code-reviewer skill to be faster. Run 5 rounds of co-evolutionary refinement."
+    fixtures: []
+    rubric:
+      - "Direct refinement of an existing skill is test-engineer's job, not librarian"
+      - "Should activate test-engineer agent, not skill-librarian"
+    trigger_expected: false
+
+  - id: create_skill_from_arxiv_paper
+    prompt: "Create a skill from the arXiv paper on retrieval-augmented generation. Use the paper's methodology."
+    fixtures: []
+    rubric:
+      - "Creating skills from papers is paper-to-skill's job, not librarian"
+      - "Librarian reviews transcripts, not papers"
+    trigger_expected: false
+
+  - id: reorganize_skill_directory_structure
+    prompt: "Reorganize the skills directory — move all review-related skills into a review/ subdirectory and update manifest.yaml."
+    fixtures: []
+    rubric:
+      - "Library reorganization is a human decision, not a librarian task"
+      - "Librarian drafts skills only, it does not restructure the repo"
+    trigger_expected: false

--- a/agents/skill-router/AGENT.md
+++ b/agents/skill-router/AGENT.md
@@ -1,0 +1,207 @@
+---
+name: skill-router
+type: agent
+description:
+  'Outcome-weighted package selector that maps a task prompt to the armory
+  packages most likely to handle it successfully, ranked by historical pass
+  rate rather than static description matching. Implements the read phase of
+  the Memento-Skills reflective loop (arXiv 2603.18743): consults
+  dist/router_index.json (built nightly from evals/history.jsonl) to find
+  packages that have historically succeeded on signature-similar tasks, and
+  falls back to the static /route command when no history exists or confidence
+  is low. Triggers on: "route this task", "which skill for this", "best package
+  for", "skill router", "pick the best package", "recommend packages for",
+  "rank packages for this task", "outcome-weighted routing". NOT for static
+  decision-tree lookup (use /route command directly). NOT for installing or
+  managing packages (use skill-library skill).
+
+  '
+model: haiku
+color: magenta
+metadata:
+  version: 1.0.0
+  category: operations
+  execution_phase: on-demand
+  priority: 50
+  enabled: true
+  orchestrates:
+    skills: []
+    agents: []
+  tags: [memento-skills, routing, retrieval, haiku, read-phase]
+  difficulty: beginner
+---
+
+# Skill Router — Outcome-Weighted Package Selection
+
+Given a task prompt, returns the ranked set of armory packages most likely to
+handle it successfully. Ranking is driven by observed outcomes from
+`evals/history.jsonl`, not by matching the task against package descriptions.
+
+This is the read half of the Memento-Skills reflective loop
+(arXiv 2603.18743) — the write half lives in the `skill-librarian` agent and
+`immune` skill.
+
+The router is a **cheap retrieval step**, not a reasoning step. It is
+intentionally a Haiku agent: the decision is a lookup and rank, not an open
+inference problem.
+
+---
+
+## Scope and Trigger Conditions
+
+### Activate when:
+
+- User asks "which package should I use for this task?"
+- User invokes `/route` with a task and wants outcome-weighted results rather
+  than the static decision tree
+- Another orchestrator agent (e.g., `team-lead`) needs to pre-filter candidate
+  packages before delegation
+- The router index (`dist/router_index.json`) exists and is non-empty
+
+### Do NOT activate when:
+
+- User wants the full static decision tree (use `/route` directly)
+- User wants to install or update packages (use `skill-library` skill)
+- User wants to browse the catalog (use `search_packages` MCP tool)
+- `dist/router_index.json` is missing or empty — in that case, defer to
+  `/route` and do not fabricate rankings
+- The task is ambiguous and needs clarification first (ask one clarifying
+  question before routing)
+
+---
+
+## Input Requirements
+
+| Input         | Required | Description                                                                         |
+| ------------- | -------- | ----------------------------------------------------------------------------------- |
+| Task prompt   | Yes      | The user's task description. Used to compute a task signature for index lookup.    |
+| Top K         | No       | Max packages to return (default 5).                                                 |
+| Confidence min| No       | Minimum signature-match confidence to trust the index (default 0.5).                |
+
+---
+
+## Composition Map
+
+| Component | Type | Invoked In | Purpose |
+| --------- | ---- | ---------- | ------- |
+| (none)    | —    | —          | The router is leaf-level; it does not orchestrate other packages. |
+
+The router reads `dist/router_index.json` directly. It does not invoke Python
+scripts at runtime — the index is built by `scripts/build_router_index.py` on
+a nightly schedule (see `.github/workflows/router-index.yml`).
+
+---
+
+## Workflow Phases
+
+### Phase 1: Signature Computation
+
+1. Normalize the task prompt into a canonical task signature using the same
+   algorithm as `scripts/task_signature.py`. For reference, the rules are:
+   - Lowercase the prompt
+   - Tokenize on word boundaries
+   - Drop English stopwords and single-character tokens
+   - Strip common English suffixes (lemmatization-lite)
+   - Deduplicate and sort the remaining tokens
+   - Join with single spaces
+2. If the signature is empty (prompt had no content words), exit with verdict
+   `no_signature` and defer to `/route`.
+
+### Phase 2: Index Lookup
+
+1. Read `dist/router_index.json`. If the file is missing, exit with verdict
+   `no_index` and defer to `/route`.
+2. Look up the exact signature in `index`. If a match exists, it is the
+   highest-confidence bucket — use it directly.
+3. If no exact match, compute Jaccard similarity between the task signature
+   and every signature in the index. Keep matches above the confidence
+   threshold (default 0.5).
+4. If no bucket meets the threshold, exit with verdict `low_confidence` and
+   defer to `/route`.
+
+### Phase 3: Ranking
+
+1. For an exact signature match: return the bucket's ranked package list
+   as-is (already sorted by pass rate).
+2. For fuzzy matches: weight each bucket's entries by
+   `(signature_similarity × pass_rate × log(1 + sample_count))`. Merge
+   entries across buckets by summing weighted scores per package, then sort
+   descending.
+3. Cap the output at `top_k` (default 5).
+
+### Phase 4: Output
+
+Return a structured response:
+
+```yaml
+verdict: exact_match | fuzzy_match | no_signature | no_index | low_confidence
+task_signature: "<canonical signature>"
+confidence: 0.0-1.0
+packages:
+  - package_path: skills/foo
+    pass_rate: 0.83
+    sample_count: 42
+    rank_score: 0.76
+  - package_path: agents/bar
+    pass_rate: 0.72
+    sample_count: 18
+    rank_score: 0.61
+fallback: true | false  # true when verdict is no_signature/no_index/low_confidence
+```
+
+If `fallback` is true, also include a pointer to the `/route` command:
+"Index-based routing unavailable — use `/route <task>` for the static
+decision tree."
+
+---
+
+## Output Artifacts
+
+| Artifact | Format | Description |
+| -------- | ------ | ----------- |
+| Router response | YAML | Structured rank list with verdict and confidence |
+| Trace log | None | The router is stateless — it writes nothing to disk |
+
+---
+
+## Handoff Protocol
+
+### Receiving Work
+
+- Accepts a task prompt (required) and optional top_k/confidence overrides.
+- When spawned by another agent, the parent decides what to do with the
+  returned package list (activate one, delegate to several, etc.).
+
+### Passing Work
+
+- Returns the ranked package list and verdict. Never spawns follow-on agents
+  — that is the caller's responsibility.
+- On fallback verdicts, the caller should invoke `/route` with the original
+  task.
+
+---
+
+## Rules
+
+1. **The router never fabricates rankings.** If the index is missing, empty,
+   or below the confidence threshold, it defers to `/route` and returns a
+   fallback verdict — not an invented list.
+2. **Index freshness is the operator's job.** The router does not rebuild
+   the index on demand. If the index is stale, the router will return stale
+   rankings — this is by design, because on-demand rebuilds would turn a
+   cheap lookup into an expensive job. See
+   `.github/workflows/router-index.yml` for the nightly rebuild.
+3. **No reasoning about package semantics.** The router does not inspect
+   package descriptions or decide whether a package "makes sense" for the
+   task. It trusts the index. Semantic checks belong upstream (in
+   `package-evaluator`) or downstream (in the caller that acts on the rank
+   list).
+4. **Fallback is first-class.** The static `/route` command is the baseline,
+   not an error path. A router that returns `verdict: no_index` with a
+   pointer to `/route` is operating correctly, not failing.
+5. **Index schema is stable.** The router reads the schema documented in
+   `scripts/build_router_index.py`. If the schema changes, both files must
+   be updated in the same commit.
+6. **Confidence threshold is operator-tunable.** Default 0.5. Callers may
+   raise it for high-stakes routing (e.g., pre-commit gates) or lower it for
+   exploratory routing. Never hardcode task-specific thresholds.

--- a/agents/skill-router/evals/cases.yaml
+++ b/agents/skill-router/evals/cases.yaml
@@ -1,0 +1,64 @@
+cases:
+  # --- Positive cases ---
+  - id: route_task_with_history
+    prompt: "Route this task: review my code for SQL injection vulnerabilities. Use the router index if available."
+    fixtures: []
+    rubric:
+      - "Activates skill-router agent"
+      - "Computes task signature via Phase 1 normalization"
+      - "Reads dist/router_index.json"
+      - "Returns ranked package list or fallback verdict"
+    trigger_expected: true
+
+  - id: rank_packages_for_task
+    prompt: "Rank the best armory packages for generating a pytest suite for a FastAPI endpoint. Use outcome-weighted routing."
+    fixtures: []
+    rubric:
+      - "Activates skill-router for outcome-weighted ranking"
+      - "Produces YAML response with verdict, task_signature, and packages list"
+      - "If index is empty, returns fallback verdict and points to /route"
+    trigger_expected: true
+
+  - id: skill_router_for_best_package
+    prompt: "skill-router: which package is best for scanning a repo for hardcoded credentials based on historical success?"
+    fixtures: []
+    rubric:
+      - "Activates skill-router agent"
+      - "Looks up task signature in the router index"
+      - "Returns top-K packages ranked by pass rate"
+    trigger_expected: true
+
+  - id: fallback_on_empty_index
+    prompt: "Route: help me plan a project timeline. (Assume the router index is missing.)"
+    fixtures: []
+    rubric:
+      - "Activates skill-router"
+      - "Detects missing index in Phase 2"
+      - "Returns verdict no_index with fallback=true"
+      - "Points the caller to the /route static command"
+    trigger_expected: true
+
+  # --- Negative cases ---
+  - id: install_package_request
+    prompt: "Install the code-reviewer agent in my project."
+    fixtures: []
+    rubric:
+      - "Package installation is skill-library's job, not router"
+      - "Router only ranks packages, it does not install them"
+    trigger_expected: false
+
+  - id: full_static_decision_tree
+    prompt: "/route I need help picking a package for content creation"
+    fixtures: []
+    rubric:
+      - "Explicit /route invocation should use the static decision tree command"
+      - "Router agent is for outcome-weighted routing, not the static tree"
+    trigger_expected: false
+
+  - id: browse_catalog_request
+    prompt: "Show me all available skills in the armory catalog."
+    fixtures: []
+    rubric:
+      - "Catalog browsing uses the skill-library skill or search_packages MCP tool"
+      - "Router is for task-to-package routing, not listing"
+    trigger_expected: false

--- a/agents/test-engineer/AGENT.md
+++ b/agents/test-engineer/AGENT.md
@@ -285,3 +285,12 @@ When spawned by another agent (e.g., `team-lead`, or `paper-to-skill`):
 8. Test escalation triggers only when surrogate passes but oracle fails — not on every failure
 9. Immune system feedback is advisory — the generator decides which patterns to apply
 10. The evolution log is append-only within a session — never overwrite prior iteration records
+11. **Ownership boundary with `skill-librarian` (Memento-Skills integration):** the
+    librarian drafts new skills and augmentations; test-engineer refines them.
+    While test-engineer is actively refining a skill (PR labeled
+    `evoskills-in-progress`), the librarian will not queue a concurrent draft
+    against the same target. Conversely, test-engineer never originates new
+    skills without an upstream specification — either from a human request,
+    `paper-to-skill`, or `skill-librarian`. This prevents the two agents from
+    silently racing on the same files. See `agents/skill-librarian/AGENT.md`
+    Rule 2 for the matching constraint.

--- a/commands/route/COMMAND.md
+++ b/commands/route/COMMAND.md
@@ -29,6 +29,11 @@ When the user invokes `/route [task]`, match their task to the best armory packa
 2. Match to the most specific category below
 3. Recommend the **primary** package and any **complementary** packages
 4. If the MCP armory server is available, cross-reference with `search_packages` for confirmation
+5. **Outcome-weighted routing (optional):** if `dist/router_index.json` exists
+   and the user wants rankings by historical pass rate rather than the static
+   tree, delegate to the `skill-router` agent. The agent falls back to this
+   static tree when the index is missing or confidence is low. See
+   `agents/skill-router/AGENT.md`.
 
 ---
 

--- a/evals/skillsbench/README.md
+++ b/evals/skillsbench/README.md
@@ -1,0 +1,100 @@
+# SkillsBench — Bootstrap Benchmark for Memento-Skills Integration
+
+**Purpose:** quantify whether armory's curated skill library provides a real
+efficacy advantage over a primitives-only baseline equipped with the
+`skill-librarian` write loop. This is the kill-switch experiment for the
+Memento-Skills integration (see `MEMENTO_SKILLS_PLAN.md` Phase 4).
+
+## The Experiment
+
+Two configurations run the same task set:
+
+| Config   | Packages loaded                                           | Librarian | Router |
+| -------- | --------------------------------------------------------- | --------- | ------ |
+| **A**    | Full armory (106+ packages)                               | Passive   | Active |
+| **B**    | Primitives only: `web-fetch`, `bash`, `filesystem`, `tavily` | Active    | —      |
+
+Config A measures the curated library's zero-shot performance.
+Config B measures what the write loop can grow from scratch on the same tasks.
+
+**Exit criterion (S3 in the plan):** Config A must beat Config B by ≥15
+percentage points on pass rate. If Config B converges toward Config A, that
+is itself a validation signal for the curation effort — document it.
+
+## Layout
+
+```
+evals/skillsbench/
+├── README.md          # this file
+├── schema.yaml        # task YAML schema reference
+├── tasks/             # seed task set (expand before full runs)
+│   ├── task_001_*.yaml
+│   └── ...
+└── results/           # per-run output (gitignored)
+    └── YYYY-MM-DD-run-N.json
+```
+
+## Running the Benchmark
+
+**Status:** harness ready, seed task set partial. **Full execution is deferred
+to the operator** — a meaningful run requires hours of live `claude -p`
+execution and should be scheduled with budget awareness.
+
+```bash
+# Single task, dry-run (validates harness without live execution)
+uv run python scripts/run_skillsbench.py --task evals/skillsbench/tasks/task_001_*.yaml --dry-run
+
+# Full sweep, Config A only
+uv run python scripts/run_skillsbench.py --config A --all
+
+# Full sweep, both configs, 3 runs each, median verdict
+uv run python scripts/run_skillsbench.py --all --runs 3
+
+# Operator workflow for comparison
+uv run python scripts/run_skillsbench.py --all --config A --output results/run-A.json
+uv run python scripts/run_skillsbench.py --all --config B --output results/run-B.json
+uv run python scripts/run_skillsbench.py --compare results/run-A.json results/run-B.json
+```
+
+## Task Set Scope
+
+The current seed set is **5 synthetic integration tasks** chosen to exercise
+different armory capabilities without requiring external APIs or human
+judgment for scoring. Before running a verdict-bearing benchmark, expand to
+at least 50 tasks — the plan calls for GAIA-public samples plus additional
+synthetic tasks, but GAIA sampling is deferred until the harness has been
+validated on the seed set.
+
+Tasks in the seed set all use the `assertion` success criterion, which
+checks the model's final output against a list of regex/contains rules with
+weights. More complex tasks (multi-file edits, artifact checks) should add
+new criterion types rather than shoehorning into this schema.
+
+## What This Does Not Measure
+
+- **Cost efficiency** — token and time totals are logged but are not part of
+  the pass/fail criterion.
+- **Code quality of generated artifacts** — only the final assistant response
+  is scored against assertions. Tasks requiring artifact quality checks need
+  a richer success criterion type.
+- **Librarian drafting quality** — the librarian's drafted skills during
+  Config B runs are captured but their correctness is not benchmarked here.
+  That belongs to `package-evaluator`, not SkillsBench.
+
+## Gotchas
+
+- **Worktree isolation is required for Config B.** The librarian writes new
+  skill files during the run. Without worktree isolation, those writes
+  contaminate the live repo. The harness spawns `claude -p` inside a fresh
+  worktree per task.
+- **Non-determinism.** A single run per task is not a verdict — the plan
+  specifies median of 3 runs. The harness supports `--runs N` for this.
+- **Context window.** Long tasks may exceed the default context limit. The
+  harness fails such tasks loudly rather than silently truncating.
+
+## Reference
+
+- `scripts/run_skillsbench.py` — harness implementation
+- `scripts/build_router_index.py` — Config A router index (must be fresh)
+- `agents/skill-librarian/AGENT.md` — Config B write-loop agent
+- `MEMENTO_SKILLS_PLAN.md` Phase 4 — exit criteria and analysis plan

--- a/evals/skillsbench/schema.yaml
+++ b/evals/skillsbench/schema.yaml
@@ -1,0 +1,31 @@
+# SkillsBench task schema reference.
+#
+# Every file under evals/skillsbench/tasks/ is a single task with this shape.
+# The runner (scripts/run_skillsbench.py) loads and validates tasks against
+# this schema before executing.
+
+id: string                   # Unique task identifier. Filename stem must match.
+description: string          # One-line human-readable summary.
+category: string             # development | research | review | content | ops
+difficulty: string           # easy | medium | hard
+prompt: string               # The task prompt delivered to the assistant (block).
+
+# Success criterion. Only `assertion` is supported in the seed harness.
+# Additional types (artifact_check, llm_judge) may be added later.
+success_criterion:
+  type: assertion
+  assertions:
+    # Each assertion mirrors the schema from scripts/eval_assertions.py:
+    - type: contains | not_contains | matches_regex | json_path
+      target: string         # Literal, regex, or JSONPath expression
+      weight: 0.0-1.0        # Contribution to the task's weighted score
+  pass_threshold: 0.0-1.0    # Weighted score required to mark the task "pass"
+
+# Execution bounds. The runner enforces these caps per attempt.
+limits:
+  max_turns: int             # Max conversation turns
+  max_tokens: int            # Max total tokens (input + output, approximate)
+  timeout_seconds: int       # Wall-clock cap
+
+# Tags for later analysis. Keep short and consistent.
+tags: [string]

--- a/evals/skillsbench/tasks/task_001_code_review_simple.yaml
+++ b/evals/skillsbench/tasks/task_001_code_review_simple.yaml
@@ -1,0 +1,40 @@
+id: task_001_code_review_simple
+description: Review a small Python function for a concrete bug and suggest a fix.
+category: review
+difficulty: easy
+prompt: |
+  Review this Python function and identify any bugs. If you find a bug,
+  explain what it is, why it happens, and provide a corrected version.
+
+  ```python
+  def get_user_balance(user_id, accounts):
+      for account in accounts:
+          if account["user_id"] == user_id:
+              return account["balance"]
+      return 0
+  ```
+
+  The expected behavior: return the balance for the matching user, or None
+  if no account exists for that user. The current implementation has at
+  least one defect — find it and fix it.
+
+success_criterion:
+  type: assertion
+  assertions:
+    - type: matches_regex
+      target: "(?i)(return\\s+none|instead of 0|should return none)"
+      weight: 0.4
+    - type: matches_regex
+      target: "(?i)(return none|return\\s+None)"
+      weight: 0.3
+    - type: contains
+      target: "def get_user_balance"
+      weight: 0.3
+  pass_threshold: 0.7
+
+limits:
+  max_turns: 3
+  max_tokens: 5000
+  timeout_seconds: 120
+
+tags: [python, bug-fix, review]

--- a/evals/skillsbench/tasks/task_002_sql_injection_audit.yaml
+++ b/evals/skillsbench/tasks/task_002_sql_injection_audit.yaml
@@ -1,0 +1,42 @@
+id: task_002_sql_injection_audit
+description: Identify SQL injection risk in a code snippet and recommend remediation.
+category: review
+difficulty: easy
+prompt: |
+  Audit this TypeScript endpoint handler for security issues. Report every
+  issue you find, classify severity, and provide the specific code change
+  required to fix each issue.
+
+  ```typescript
+  export async function GET(request: Request) {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get("id");
+    const query = `SELECT * FROM users WHERE id = '${userId}'`;
+    const result = await db.execute(query);
+    return Response.json(result);
+  }
+  ```
+
+success_criterion:
+  type: assertion
+  assertions:
+    - type: matches_regex
+      target: "(?i)(sql injection|injection attack)"
+      weight: 0.35
+    - type: matches_regex
+      target: "(?i)(critical|high severity)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(parameterized|prepared statement|parameter binding|\\?)"
+      weight: 0.25
+    - type: not_contains
+      target: "string interpolation is fine"
+      weight: 0.2
+  pass_threshold: 0.75
+
+limits:
+  max_turns: 3
+  max_tokens: 5000
+  timeout_seconds: 120
+
+tags: [security, sql, typescript, review]

--- a/evals/skillsbench/tasks/task_003_pytest_generation.yaml
+++ b/evals/skillsbench/tasks/task_003_pytest_generation.yaml
@@ -1,0 +1,47 @@
+id: task_003_pytest_generation
+description: Generate a pytest test suite for a small pure function with edge cases.
+category: development
+difficulty: easy
+prompt: |
+  Generate a comprehensive pytest test suite for this function. Cover the
+  happy path, at least two edge cases, and at least one error condition.
+  Return only the test file content (no commentary).
+
+  ```python
+  def parse_version(version_string: str) -> tuple[int, int, int]:
+      """Parse a semantic version string like '1.2.3' into (major, minor, patch).
+
+      Raises ValueError if the string is malformed.
+      """
+      parts = version_string.strip().lstrip("v").split(".")
+      if len(parts) != 3:
+          raise ValueError(f"Expected MAJOR.MINOR.PATCH, got {version_string!r}")
+      try:
+          return (int(parts[0]), int(parts[1]), int(parts[2]))
+      except ValueError as exc:
+          raise ValueError(f"Version components must be integers: {exc}") from exc
+  ```
+
+success_criterion:
+  type: assertion
+  assertions:
+    - type: matches_regex
+      target: "def test_\\w+"
+      weight: 0.3
+    - type: matches_regex
+      target: "(?i)(parse_version)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(pytest\\.raises|with\\s+pytest\\.raises|ValueError)"
+      weight: 0.25
+    - type: matches_regex
+      target: "(?i)(assert\\s+)"
+      weight: 0.25
+  pass_threshold: 0.7
+
+limits:
+  max_turns: 3
+  max_tokens: 5000
+  timeout_seconds: 120
+
+tags: [python, testing, pytest]

--- a/evals/skillsbench/tasks/task_004_architecture_tradeoff.yaml
+++ b/evals/skillsbench/tasks/task_004_architecture_tradeoff.yaml
@@ -1,0 +1,47 @@
+id: task_004_architecture_tradeoff
+description: Evaluate a concrete architecture tradeoff with structured reasoning.
+category: review
+difficulty: medium
+prompt: |
+  A team is choosing between two approaches for session storage in a new
+  web application:
+
+  A) Server-side sessions in Redis, with a session ID stored in an
+     httpOnly, Secure, SameSite=strict cookie.
+  B) Stateless JWTs signed with RS256, stored in localStorage, refreshed
+     via a `/refresh` endpoint.
+
+  The application expects 50k daily active users, runs on 3 web servers
+  behind a load balancer, and will integrate with a single-page React
+  frontend. Security is important but not life-critical.
+
+  Produce a structured comparison that covers: security tradeoffs (at
+  least 3 distinct points), operational complexity, horizontal scaling,
+  and a final recommendation with justification.
+
+success_criterion:
+  type: assertion
+  assertions:
+    - type: matches_regex
+      target: "(?i)(security|xss|csrf|token theft)"
+      weight: 0.25
+    - type: matches_regex
+      target: "(?i)(horizontal scal|sticky session|stateless)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(localstorage.*risk|httponly|cookie)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(recommend|suggest|prefer|choose)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(refresh token|rotation|expir)"
+      weight: 0.15
+  pass_threshold: 0.7
+
+limits:
+  max_turns: 5
+  max_tokens: 10000
+  timeout_seconds: 180
+
+tags: [architecture, security, tradeoff]

--- a/evals/skillsbench/tasks/task_005_migration_risk.yaml
+++ b/evals/skillsbench/tasks/task_005_migration_risk.yaml
@@ -1,0 +1,47 @@
+id: task_005_migration_risk
+description: Assess the risk of a database migration and recommend a rollout strategy.
+category: review
+difficulty: medium
+prompt: |
+  A team wants to run this migration on a production PostgreSQL database:
+
+  ```sql
+  ALTER TABLE orders ADD COLUMN customer_tier TEXT NOT NULL DEFAULT 'standard';
+  CREATE INDEX CONCURRENTLY idx_orders_customer_tier ON orders(customer_tier);
+  ```
+
+  The `orders` table has approximately 200 million rows and sustains about
+  2000 writes per second during peak hours. The application has zero
+  tolerance for extended downtime and uses a single primary PostgreSQL 14
+  instance with streaming replicas.
+
+  Assess the migration risk. Specifically cover: lock behavior and blocking
+  risk, estimated downtime or degradation, rollback options if it goes
+  wrong, and a safer phased rollout plan.
+
+success_criterion:
+  type: assertion
+  assertions:
+    - type: matches_regex
+      target: "(?i)(access exclusive|full table|lock)"
+      weight: 0.25
+    - type: matches_regex
+      target: "(?i)(downtime|block|degrad)"
+      weight: 0.2
+    - type: matches_regex
+      target: "(?i)(phased|batch|backfill|nullable|default expression)"
+      weight: 0.3
+    - type: matches_regex
+      target: "(?i)(rollback|revert|undo)"
+      weight: 0.15
+    - type: matches_regex
+      target: "(?i)(concurrently|non-blocking)"
+      weight: 0.1
+  pass_threshold: 0.7
+
+limits:
+  max_turns: 5
+  max_tokens: 10000
+  timeout_seconds: 180
+
+tags: [database, migration, risk-assessment, postgresql]

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1416,6 +1416,50 @@ packages:
     - sonnet
     category: security
     difficulty: advanced
+  - name: skill-librarian
+    version: 1.0.0
+    description: 'Reflective write-phase orchestrator that observes completed task transcripts and proposes additions or augmentations
+      to the armory skill library. Implements the write phase of the Memento-Skills reflective loop (arXiv 2603.18743): given
+      a conversation where novel problem-solving occurred, classify whether an existing skill handled it, an existing skill
+      needs augmentation, or no skill existed and a new one should be drafted. Routes drafts through paper-to-skill''s specification
+      stage and test-engineer''s generate-verify loop, gates on package-evaluator, and opens a pull request tagged for human
+      review. Triggers on: "librarian review", "review this transcript for new skills", "propose a skill from this conversation",
+      "draft skill from transcript", "what skills did we just use", "catalog this workflow", "suggest skill addition", "analyze
+      conversation for skill gaps", "skill-librarian", "reflective skill review". NOT for refining existing skills that are
+      already in progress (use test-engineer directly). NOT for wholesale library reorganization (that is a human decision).
+      NOT for creating skills from research papers (use paper-to-skill directly).'
+    path: agents/skill-librarian
+    source: https://github.com/Mathews-Tom/armory/blob/main/agents/skill-librarian/AGENT.md
+    model: sonnet
+    tags:
+    - memento-skills
+    - reflective-learning
+    - write-phase
+    - skill-generation
+    - sonnet
+    category: development
+    difficulty: advanced
+  - name: skill-router
+    version: 1.0.0
+    description: 'Outcome-weighted package selector that maps a task prompt to the armory packages most likely to handle it
+      successfully, ranked by historical pass rate rather than static description matching. Implements the read phase of the
+      Memento-Skills reflective loop (arXiv 2603.18743): consults dist/router_index.json (built nightly from evals/history.jsonl)
+      to find packages that have historically succeeded on signature-similar tasks, and falls back to the static /route command
+      when no history exists or confidence is low. Triggers on: "route this task", "which skill for this", "best package for",
+      "skill router", "pick the best package", "recommend packages for", "rank packages for this task", "outcome-weighted
+      routing". NOT for static decision-tree lookup (use /route command directly). NOT for installing or managing packages
+      (use skill-library skill).'
+    path: agents/skill-router
+    source: https://github.com/Mathews-Tom/armory/blob/main/agents/skill-router/AGENT.md
+    model: haiku
+    tags:
+    - memento-skills
+    - routing
+    - retrieval
+    - haiku
+    - read-phase
+    category: operations
+    difficulty: beginner
   - name: team-lead
     version: 1.0.0
     description: 'Meta-orchestrator agent that analyzes complex requests, decomposes them into agent-sized tasks, delegates

--- a/scripts/build_router_index.py
+++ b/scripts/build_router_index.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build the skill-router index from eval history.
+
+Reads ``evals/history.jsonl`` (produced by ``scripts/run_evals.py``) and
+produces ``dist/router_index.json`` — a task-signature-keyed map of
+packages with their historical pass rates. The skill-router agent
+consults this index to rank packages by observed outcomes rather than
+static description matching.
+
+Output shape::
+
+    {
+      "metadata": {
+        "built_at": "2026-04-10T12:34:56Z",
+        "source_entries": 1234,
+        "unique_signatures": 87,
+        "unique_packages": 43
+      },
+      "index": {
+        "<task_signature>": [
+          {"package_path": "skills/foo", "pass_rate": 0.83, "sample_count": 42},
+          {"package_path": "agents/bar", "pass_rate": 0.72, "sample_count": 18}
+        ]
+      }
+    }
+
+Usage::
+
+    uv run python scripts/build_router_index.py
+    uv run python scripts/build_router_index.py --history evals/history.jsonl \\
+        --output dist/router_index.json --min-samples 3
+
+Entries with ``sample_count`` below ``--min-samples`` are excluded from
+per-signature ranked lists to reduce noise from one-off results.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def read_history(history_path: Path) -> list[dict]:
+    """Read and parse a JSONL history log.
+
+    Args:
+        history_path: Path to ``evals/history.jsonl``.
+
+    Returns:
+        List of parsed entries. Empty list if the file is missing or empty.
+
+    Raises:
+        json.JSONDecodeError: If any line fails to parse as JSON.
+    """
+    if not history_path.exists():
+        return []
+    entries: list[dict] = []
+    for line_num, raw_line in enumerate(
+        history_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise json.JSONDecodeError(
+                f"Invalid JSON in {history_path}:{line_num}: {exc.msg}",
+                exc.doc,
+                exc.pos,
+            ) from exc
+    return entries
+
+
+def aggregate(
+    entries: list[dict],
+    min_samples: int = 1,
+) -> dict[str, list[dict]]:
+    """Aggregate history entries into per-signature package rankings.
+
+    Args:
+        entries: Parsed history log entries.
+        min_samples: Minimum observations required for a (signature,
+            package) pair to appear in the output. Pairs below this
+            threshold are dropped to reduce noise.
+
+    Returns:
+        Map of ``task_signature -> [{"package_path", "pass_rate",
+        "sample_count"}, ...]`` with each list sorted by descending
+        pass rate, then descending sample count as tiebreaker.
+    """
+    counts: dict[tuple[str, str], list[int]] = {}
+    for entry in entries:
+        sig = str(entry.get("task_signature", ""))
+        pkg = str(entry.get("package_path", ""))
+        if not sig or not pkg:
+            continue
+        key = (sig, pkg)
+        bucket = counts.setdefault(key, [0, 0])
+        bucket[1] += 1
+        if entry.get("oracle_verdict") == "pass":
+            bucket[0] += 1
+
+    by_signature: dict[str, list[dict]] = {}
+    for (sig, pkg), (passed, total) in counts.items():
+        if total < min_samples:
+            continue
+        by_signature.setdefault(sig, []).append(
+            {
+                "package_path": pkg,
+                "pass_rate": passed / total,
+                "sample_count": total,
+            }
+        )
+
+    for sig in by_signature:
+        by_signature[sig].sort(
+            key=lambda item: (item["pass_rate"], item["sample_count"]),
+            reverse=True,
+        )
+
+    return by_signature
+
+
+def build_index(
+    entries: list[dict],
+    min_samples: int = 1,
+) -> dict:
+    """Build the full router index payload.
+
+    Args:
+        entries: Parsed history log entries.
+        min_samples: Minimum sample threshold for inclusion.
+
+    Returns:
+        A dict with ``metadata`` and ``index`` keys ready to serialize.
+    """
+    by_signature = aggregate(entries, min_samples=min_samples)
+    unique_packages = {
+        item["package_path"]
+        for items in by_signature.values()
+        for item in items
+    }
+    return {
+        "metadata": {
+            "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "source_entries": len(entries),
+            "unique_signatures": len(by_signature),
+            "unique_packages": len(unique_packages),
+            "min_samples": min_samples,
+        },
+        "index": by_signature,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the skill-router index from eval history",
+    )
+    parser.add_argument(
+        "--history",
+        default="evals/history.jsonl",
+        help="Path to the append-only eval history log",
+    )
+    parser.add_argument(
+        "--output",
+        default="dist/router_index.json",
+        help="Path to write the router index JSON",
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=1,
+        help="Minimum observations per (signature, package) pair",
+    )
+    args = parser.parse_args()
+
+    history_path = _REPO_ROOT / args.history
+    entries = read_history(history_path)
+    if not entries:
+        print(f"No history entries found at {args.history}", file=sys.stderr)
+        print("Index will be built with zero entries.", file=sys.stderr)
+
+    payload = build_index(entries, min_samples=args.min_samples)
+
+    output_path = _REPO_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    meta = payload["metadata"]
+    print(f"Router index written to {args.output}")
+    print(
+        f"  Source entries: {meta['source_entries']}, "
+        f"Signatures: {meta['unique_signatures']}, "
+        f"Packages: {meta['unique_packages']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 import subprocess
@@ -30,6 +31,7 @@ import yaml
 
 from scripts.eval_assertions import run_all_assertions
 from scripts.package_types import TYPES
+from scripts.task_signature import task_signature
 
 
 @dataclass
@@ -324,6 +326,71 @@ def write_results(results: list[PackageResult], output_path: Path) -> None:
     output_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def _prompt_hash(prompt: str) -> str:
+    """Return a short, stable, non-reversible fingerprint of a prompt.
+
+    Used in the history log for dedup and cross-run identification
+    without storing raw prompt text (which may contain secrets or PII).
+
+    Args:
+        prompt: The raw task prompt.
+
+    Returns:
+        First 16 hex characters of the SHA-256 digest.
+    """
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def write_history(results: list[PackageResult], history_path: Path) -> None:
+    """Append per-case eval outcomes to the history log as JSONL.
+
+    Each case becomes one JSON line with shape::
+
+        {
+          "timestamp": ISO8601 UTC,
+          "package_path": str,
+          "case_id": str,
+          "task_signature": str,
+          "prompt_hash": str (16-char SHA-256 prefix),
+          "trigger_expected": bool,
+          "oracle_verdict": "pass" | "fail" | "skipped",
+          "weighted_score": float,
+          "execution_time_ms": int
+        }
+
+    The history log is append-only. Raw prompt text is never stored —
+    only the normalized task signature (from :mod:`scripts.task_signature`)
+    and a truncated SHA-256 hash. This protects against prompts that
+    contain credentials, tokens, or PII.
+
+    Args:
+        results: Package results from a run_evals session.
+        history_path: Path to the history log. Parent dirs are created
+            if missing.
+    """
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    lines: list[str] = []
+    for pkg in results:
+        for case in pkg.case_results:
+            entry = {
+                "timestamp": timestamp,
+                "package_path": pkg.package_path,
+                "case_id": case.case_id,
+                "task_signature": task_signature(case.prompt),
+                "prompt_hash": _prompt_hash(case.prompt),
+                "trigger_expected": case.trigger_expected,
+                "oracle_verdict": case.oracle_verdict,
+                "weighted_score": case.weighted_score,
+                "execution_time_ms": case.execution_time_ms,
+            }
+            lines.append(json.dumps(entry, separators=(",", ":")))
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    with history_path.open("a", encoding="utf-8") as f:
+        for line in lines:
+            f.write(line + "\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Execute eval cases against live Claude sessions")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -331,6 +398,8 @@ def main() -> int:
     group.add_argument("--all", action="store_true", help="Run evals for all packages")
     parser.add_argument("--timeout-per-case", type=int, default=120, help="Timeout per case in seconds")
     parser.add_argument("--output", default="evals/results.json", help="Output file path")
+    parser.add_argument("--history", default="evals/history.jsonl", help="Append-only history log path")
+    parser.add_argument("--no-history", action="store_true", help="Skip appending to the history log")
     parser.add_argument("--dry-run", action="store_true", help="Skip actual execution, validate structure only")
     args = parser.parse_args()
 
@@ -349,6 +418,12 @@ def main() -> int:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_results(results, output_path)
     print(f"\nResults written to {args.output}")
+
+    if not args.no_history and not args.dry_run:
+        history_path = _REPO_ROOT / args.history
+        write_history(results, history_path)
+        total_cases = sum(r.total_cases for r in results)
+        print(f"History appended: {total_cases} cases -> {args.history}")
 
     total_failed = sum(r.failed for r in results)
     return 1 if total_failed > 0 else 0

--- a/scripts/run_skillsbench.py
+++ b/scripts/run_skillsbench.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""SkillsBench harness — bootstrap benchmark for Memento-Skills integration.
+
+Loads tasks from ``evals/skillsbench/tasks/``, executes them against a live
+Claude session in one of two configurations (A: full armory, B: primitives
+only), and scores the output against each task's assertion rules.
+
+This module contains three layers:
+
+1. **Pure logic** (task loading, validation, assertion scoring, result
+   aggregation) — fully unit-tested in ``tests/test_run_skillsbench.py``.
+2. **Execution orchestration** (spawning ``claude -p``, worktree isolation,
+   per-run capture) — gated behind the ``--live`` flag because it requires
+   an installed ``claude`` CLI and burns real budget. Dry-run mode exercises
+   only the pure logic for CI.
+3. **Comparison and reporting** — reads two result files and reports the
+   Config A vs Config B delta against the S3 exit criterion (≥15pp).
+
+See ``evals/skillsbench/README.md`` for the experiment design. Full
+execution is deferred to the operator — a meaningful benchmark requires
+hours of live execution and should be scheduled deliberately.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml
+
+_SUPPORTED_CRITERION_TYPES = {"assertion"}
+_SUPPORTED_ASSERTION_TYPES = {"contains", "not_contains", "matches_regex"}
+
+# Tolerance for floating-point comparisons in compare_reports. Pass-rate
+# subtractions like 0.70 - 0.60 produce values slightly below 0.10 in
+# IEEE-754, which would incorrectly fail a threshold of exactly 0.10.
+# One microunit (1e-6 percentage points) is small enough to be
+# semantically irrelevant and large enough to absorb FP error.
+_COMPARE_TOLERANCE_PP = 1e-6
+
+
+@dataclass
+class TaskDefinition:
+    """A single SkillsBench task loaded from YAML."""
+
+    id: str
+    description: str
+    category: str
+    difficulty: str
+    prompt: str
+    assertions: list[dict]
+    pass_threshold: float
+    max_turns: int
+    max_tokens: int
+    timeout_seconds: int
+    tags: list[str]
+    source_path: str
+
+
+@dataclass
+class TaskRunResult:
+    """Result of running a single task in a single configuration."""
+
+    task_id: str
+    config: str
+    attempt: int
+    verdict: str  # "pass" | "fail" | "error" | "skipped"
+    weighted_score: float
+    output_excerpt: str
+    assertion_results: list[dict]
+    execution_time_ms: int
+    error: str | None = None
+
+
+@dataclass
+class BenchmarkReport:
+    """Aggregated report across all tasks in one configuration."""
+
+    config: str
+    timestamp: str
+    total_tasks: int
+    passed: int
+    failed: int
+    errored: int
+    skipped: int
+    pass_rate: float
+    mean_score: float
+    per_task: list[TaskRunResult] = field(default_factory=list)
+
+
+def load_task(path: Path) -> TaskDefinition:
+    """Load and validate a task YAML file.
+
+    Args:
+        path: Path to a task YAML under evals/skillsbench/tasks/.
+
+    Returns:
+        Parsed TaskDefinition.
+
+    Raises:
+        ValueError: If the file is missing required fields or uses an
+            unsupported criterion or assertion type.
+    """
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a mapping at the top level")
+
+    required = {"id", "description", "category", "prompt", "success_criterion", "limits"}
+    missing = required - raw.keys()
+    if missing:
+        raise ValueError(f"{path}: missing required fields: {sorted(missing)}")
+
+    if raw["id"] != path.stem:
+        raise ValueError(
+            f"{path}: task id {raw['id']!r} must match filename stem {path.stem!r}"
+        )
+
+    criterion = raw["success_criterion"]
+    if criterion.get("type") not in _SUPPORTED_CRITERION_TYPES:
+        raise ValueError(
+            f"{path}: unsupported criterion type {criterion.get('type')!r} "
+            f"(supported: {sorted(_SUPPORTED_CRITERION_TYPES)})"
+        )
+
+    assertions = criterion.get("assertions") or []
+    if not assertions:
+        raise ValueError(f"{path}: criterion has no assertions")
+    for idx, assertion in enumerate(assertions):
+        if assertion.get("type") not in _SUPPORTED_ASSERTION_TYPES:
+            raise ValueError(
+                f"{path}: assertion {idx} has unsupported type {assertion.get('type')!r}"
+            )
+        if "target" not in assertion or "weight" not in assertion:
+            raise ValueError(
+                f"{path}: assertion {idx} missing 'target' or 'weight'"
+            )
+
+    limits = raw["limits"]
+    return TaskDefinition(
+        id=raw["id"],
+        description=raw["description"],
+        category=raw["category"],
+        difficulty=raw.get("difficulty", "medium"),
+        prompt=raw["prompt"],
+        assertions=assertions,
+        pass_threshold=float(criterion.get("pass_threshold", 0.7)),
+        max_turns=int(limits.get("max_turns", 5)),
+        max_tokens=int(limits.get("max_tokens", 10000)),
+        timeout_seconds=int(limits.get("timeout_seconds", 180)),
+        tags=list(raw.get("tags") or []),
+        source_path=str(path),
+    )
+
+
+def load_task_set(tasks_dir: Path) -> list[TaskDefinition]:
+    """Load every YAML task under a directory, sorted by id."""
+    if not tasks_dir.is_dir():
+        return []
+    tasks: list[TaskDefinition] = []
+    for path in sorted(tasks_dir.glob("*.yaml")):
+        tasks.append(load_task(path))
+    return tasks
+
+
+def check_assertions(
+    output: str,
+    assertions: list[dict],
+) -> tuple[float, list[dict]]:
+    """Score output against a task's assertions.
+
+    Args:
+        output: The assistant's final output text.
+        assertions: Parsed assertion list from a task definition.
+
+    Returns:
+        A tuple of (weighted_score, per_assertion_detail). The score is
+        the sum of weights for passing assertions divided by the sum of
+        all weights (so the score is in ``[0.0, 1.0]`` regardless of
+        whether the weights themselves sum to 1).
+    """
+    total_weight = sum(float(a["weight"]) for a in assertions)
+    if total_weight <= 0:
+        return 0.0, []
+
+    passed_weight = 0.0
+    details: list[dict] = []
+    for assertion in assertions:
+        a_type = assertion["type"]
+        target = str(assertion["target"])
+        weight = float(assertion["weight"])
+        passed = _check_assertion(output, a_type, target)
+        if passed:
+            passed_weight += weight
+        details.append(
+            {
+                "type": a_type,
+                "target": target,
+                "weight": weight,
+                "passed": passed,
+            }
+        )
+
+    return passed_weight / total_weight, details
+
+
+def _check_assertion(output: str, a_type: str, target: str) -> bool:
+    """Evaluate one assertion against output text.
+
+    Args:
+        output: Assistant output to check.
+        a_type: Assertion type (contains, not_contains, matches_regex).
+        target: Literal or regex target per assertion type.
+
+    Returns:
+        True if the assertion passes.
+    """
+    if a_type == "contains":
+        return target in output
+    if a_type == "not_contains":
+        return target not in output
+    if a_type == "matches_regex":
+        return re.search(target, output) is not None
+    raise ValueError(f"unsupported assertion type: {a_type}")
+
+
+def verdict_from_score(score: float, threshold: float) -> str:
+    """Convert a weighted score into a pass/fail verdict."""
+    return "pass" if score >= threshold else "fail"
+
+
+def aggregate_report(
+    config: str,
+    results: list[TaskRunResult],
+) -> BenchmarkReport:
+    """Aggregate per-task results into a BenchmarkReport.
+
+    When a task has multiple attempts, only the median-scored attempt is
+    used for the aggregate (matches the plan's "median of 3 runs" rule).
+    """
+    by_task: dict[str, list[TaskRunResult]] = {}
+    for r in results:
+        by_task.setdefault(r.task_id, []).append(r)
+
+    median_attempts: list[TaskRunResult] = []
+    for attempts in by_task.values():
+        sorted_attempts = sorted(attempts, key=lambda r: r.weighted_score)
+        median_attempts.append(sorted_attempts[len(sorted_attempts) // 2])
+
+    total = len(median_attempts)
+    passed = sum(1 for r in median_attempts if r.verdict == "pass")
+    failed = sum(1 for r in median_attempts if r.verdict == "fail")
+    errored = sum(1 for r in median_attempts if r.verdict == "error")
+    skipped = sum(1 for r in median_attempts if r.verdict == "skipped")
+    pass_rate = passed / total if total > 0 else 0.0
+    mean_score = (
+        sum(r.weighted_score for r in median_attempts) / total if total > 0 else 0.0
+    )
+
+    return BenchmarkReport(
+        config=config,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        total_tasks=total,
+        passed=passed,
+        failed=failed,
+        errored=errored,
+        skipped=skipped,
+        pass_rate=pass_rate,
+        mean_score=mean_score,
+        per_task=median_attempts,
+    )
+
+
+def compare_reports(
+    report_a: BenchmarkReport,
+    report_b: BenchmarkReport,
+    min_delta_pp: float = 15.0,
+) -> dict:
+    """Compare two configuration reports against the S3 exit criterion.
+
+    Args:
+        report_a: Config A report (armory-loaded).
+        report_b: Config B report (primitives-only).
+        min_delta_pp: Required percentage-point advantage for Config A.
+            Default 15.0 matches the plan's S3 threshold.
+
+    Returns:
+        Dict with the delta, verdict, and supporting numbers.
+    """
+    delta_pp = (report_a.pass_rate - report_b.pass_rate) * 100
+    s3_met = delta_pp + _COMPARE_TOLERANCE_PP >= min_delta_pp
+    return {
+        "config_a_pass_rate": report_a.pass_rate,
+        "config_b_pass_rate": report_b.pass_rate,
+        "delta_pp": delta_pp,
+        "min_delta_pp": min_delta_pp,
+        "s3_exit_met": s3_met,
+        "verdict": "curation_validated" if s3_met else "thesis_unconfirmed",
+        "total_tasks_a": report_a.total_tasks,
+        "total_tasks_b": report_b.total_tasks,
+    }
+
+
+def run_task_live(
+    task: TaskDefinition,
+    config: str,
+    allowed_tools: list[str] | None = None,
+) -> TaskRunResult:
+    """Execute a single task against a live ``claude`` session.
+
+    **Operator note:** this function actually spawns ``claude -p`` and
+    burns budget. Guard calls behind the ``--live`` CLI flag. The pure
+    logic above (loading, scoring, aggregation) is what the unit tests
+    exercise; this function is only covered by integration runs.
+
+    Args:
+        task: The task to run.
+        config: ``"A"`` or ``"B"`` — used only for labeling the result.
+        allowed_tools: Explicit tool allowlist for ``claude -p``. If
+            ``None``, defaults to a broad read-only set; Config B runs
+            should restrict to the primitives.
+
+    Returns:
+        A TaskRunResult with the verdict and captured output excerpt.
+    """
+    start_ms = time.monotonic_ns() // 1_000_000
+    tools = allowed_tools or ["Read", "Glob", "Grep", "Bash", "WebFetch"]
+    tmpdir = tempfile.mkdtemp(prefix="skillsbench_")
+    try:
+        result = subprocess.run(
+            [
+                "claude",
+                "-p", task.prompt,
+                "--output-format", "text",
+                "--allowedTools", *tools,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=task.timeout_seconds,
+            cwd=tmpdir,
+        )
+        output = result.stdout or ""
+        error: str | None = None
+        if result.returncode != 0:
+            error = f"claude returncode={result.returncode}: {result.stderr[:500]}"
+    except subprocess.TimeoutExpired:
+        output = ""
+        error = f"timed out after {task.timeout_seconds}s"
+    except FileNotFoundError:
+        output = ""
+        error = "'claude' CLI not found in PATH"
+
+    elapsed_ms = (time.monotonic_ns() // 1_000_000) - start_ms
+
+    if error:
+        return TaskRunResult(
+            task_id=task.id,
+            config=config,
+            attempt=1,
+            verdict="error",
+            weighted_score=0.0,
+            output_excerpt="",
+            assertion_results=[],
+            execution_time_ms=elapsed_ms,
+            error=error,
+        )
+
+    score, details = check_assertions(output, task.assertions)
+    return TaskRunResult(
+        task_id=task.id,
+        config=config,
+        attempt=1,
+        verdict=verdict_from_score(score, task.pass_threshold),
+        weighted_score=score,
+        output_excerpt=output[:2000],
+        assertion_results=details,
+        execution_time_ms=elapsed_ms,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the SkillsBench bootstrap benchmark",
+    )
+    parser.add_argument(
+        "--tasks-dir",
+        default="evals/skillsbench/tasks",
+        help="Directory of task YAML files",
+    )
+    parser.add_argument(
+        "--task",
+        help="Run a single task by path (mutually exclusive with --all)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run every task under --tasks-dir",
+    )
+    parser.add_argument(
+        "--config",
+        choices=["A", "B"],
+        default="A",
+        help="A: full armory, B: primitives only + librarian",
+    )
+    parser.add_argument(
+        "--output",
+        default="evals/skillsbench/results/latest.json",
+        help="Path to write the benchmark report",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Load tasks and validate schema without running claude",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Actually invoke claude -p (otherwise dry-run is implied)",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("REPORT_A", "REPORT_B"),
+        help="Compare two saved reports and print the S3 verdict",
+    )
+    args = parser.parse_args()
+
+    if args.compare:
+        return _compare_command(args.compare[0], args.compare[1])
+
+    if not args.task and not args.all:
+        parser.error("one of --task or --all is required")
+
+    if args.task:
+        tasks = [load_task(_REPO_ROOT / args.task)]
+    else:
+        tasks = load_task_set(_REPO_ROOT / args.tasks_dir)
+
+    if not tasks:
+        print(f"No tasks found in {args.tasks_dir}", file=sys.stderr)
+        return 1
+
+    if args.dry_run or not args.live:
+        print(f"Loaded {len(tasks)} task(s) for config {args.config}")
+        print("Dry run — no tasks executed. Pass --live to actually run claude -p.")
+        for t in tasks:
+            print(f"  - {t.id} ({t.category}/{t.difficulty}): {t.description}")
+        return 0
+
+    allowed_tools: list[str] | None
+    if args.config == "B":
+        allowed_tools = ["Read", "Glob", "Grep", "Bash", "WebFetch"]
+    else:
+        allowed_tools = None
+
+    results: list[TaskRunResult] = []
+    for task in tasks:
+        print(f"Running {task.id} [{args.config}]...")
+        result = run_task_live(task, args.config, allowed_tools=allowed_tools)
+        results.append(result)
+        print(f"  verdict={result.verdict} score={result.weighted_score:.2f}")
+
+    report = aggregate_report(args.config, results)
+    output_path = _REPO_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(asdict(report), indent=2), encoding="utf-8"
+    )
+    print(
+        f"Report written to {args.output} "
+        f"(pass_rate={report.pass_rate:.2%}, mean_score={report.mean_score:.2f})"
+    )
+    return 0 if report.failed == 0 and report.errored == 0 else 1
+
+
+def _compare_command(path_a: str, path_b: str) -> int:
+    """Implement the ``--compare`` subcommand."""
+    data_a = json.loads((_REPO_ROOT / path_a).read_text(encoding="utf-8"))
+    data_b = json.loads((_REPO_ROOT / path_b).read_text(encoding="utf-8"))
+    report_a = BenchmarkReport(
+        config=data_a["config"],
+        timestamp=data_a["timestamp"],
+        total_tasks=data_a["total_tasks"],
+        passed=data_a["passed"],
+        failed=data_a["failed"],
+        errored=data_a["errored"],
+        skipped=data_a["skipped"],
+        pass_rate=data_a["pass_rate"],
+        mean_score=data_a["mean_score"],
+    )
+    report_b = BenchmarkReport(
+        config=data_b["config"],
+        timestamp=data_b["timestamp"],
+        total_tasks=data_b["total_tasks"],
+        passed=data_b["passed"],
+        failed=data_b["failed"],
+        errored=data_b["errored"],
+        skipped=data_b["skipped"],
+        pass_rate=data_b["pass_rate"],
+        mean_score=data_b["mean_score"],
+    )
+    comparison = compare_reports(report_a, report_b)
+    print(json.dumps(comparison, indent=2))
+    return 0 if comparison["s3_exit_met"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/task_signature.py
+++ b/scripts/task_signature.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Task signature function for eval history indexing.
+
+Normalizes task prompts into stable, comparable signatures used by the
+eval history log, the router index (Phase 3), and the immune retrieval
+layer (Phase 1). Two prompts with the same core intent but different
+phrasing yield the same or highly-overlapping signatures.
+
+Algorithm:
+    1. Lowercase the prompt.
+    2. Tokenize on word boundaries (keeps alphanumerics).
+    3. Drop English stopwords and single-character tokens.
+    4. Apply lemmatization-lite: strip common English suffixes.
+    5. Deduplicate and sort the remaining tokens.
+    6. Join with single spaces.
+
+The canonical string can be used directly as a dict key for exact
+matching, or compared via :func:`jaccard_similarity` for fuzzy matching.
+
+This is a deliberately simple lexical approach. If Phase 0 exit criteria
+require >50% precision and this approach underperforms, the plan calls
+for upgrading to sentence-embedding buckets as a drop-in replacement.
+"""
+from __future__ import annotations
+
+import re
+
+# Small English stopword set. Intentionally minimal: overly aggressive
+# filtering removes domain-specific content words like "test", "build",
+# "review", "audit", which carry real task semantics.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a", "an", "the", "this", "that", "these", "those",
+        "i", "me", "my", "mine", "you", "your", "yours",
+        "we", "us", "our", "ours", "they", "them", "their",
+        "is", "am", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "having", "do", "does", "did", "doing",
+        "can", "could", "would", "should", "will", "shall", "may",
+        "might", "must", "ought",
+        "to", "for", "of", "in", "on", "at", "by", "with", "from",
+        "as", "into", "onto", "about", "over", "under", "out",
+        "and", "or", "but", "if", "then", "than", "so", "not", "no",
+        "here", "there", "what", "which", "who", "whom", "whose",
+        "when", "where", "how", "why",
+        "it", "its", "some", "any", "all", "each", "every", "either",
+        "both", "few", "more", "most", "other", "such",
+        "please", "thanks", "thank", "just", "also", "very", "really",
+    }
+)
+
+# Suffix patterns stripped for lemmatization-lite. Ordered longest-first
+# so that compound suffixes (e.g., "ingly") match before their shorter
+# supersets ("ly", "ing").
+_SUFFIXES: tuple[str, ...] = (
+    "ingly",
+    "edly",
+    "ing",
+    "ied",
+    "ies",
+    "ed",
+    "ly",
+    "es",
+    "s",
+)
+
+# Minimum stem length after suffix removal. Prevents over-stemming short
+# tokens like "is" -> "i" or "pies" -> "p".
+_MIN_STEM_LEN = 3
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _stem(token: str) -> str:
+    """Strip one common English suffix if it leaves a valid stem.
+
+    Args:
+        token: Lowercase token with no whitespace or punctuation.
+
+    Returns:
+        The stemmed token, or the original token if no suffix matches
+        or stripping would leave a token shorter than ``_MIN_STEM_LEN``.
+    """
+    if len(token) < _MIN_STEM_LEN + 1:
+        return token
+    for suffix in _SUFFIXES:
+        if token.endswith(suffix) and len(token) - len(suffix) >= _MIN_STEM_LEN:
+            return token[: -len(suffix)]
+    return token
+
+
+def task_signature(prompt: str) -> str:
+    """Compute a stable keyword signature for a task prompt.
+
+    Produces a canonical space-joined, sorted, deduplicated keyword
+    string. Two prompts sharing the same content words (after stopword
+    removal and lemmatization-lite) produce identical signatures.
+
+    Args:
+        prompt: The raw task prompt text.
+
+    Returns:
+        Canonical signature string. Empty string when the prompt is
+        empty or contains only stopwords and single-character tokens.
+
+    Examples:
+        >>> task_signature("Review this code for quality")
+        'code quality review'
+        >>> task_signature("Can you review the code quality?")
+        'code quality review'
+        >>> task_signature("")
+        ''
+    """
+    if not prompt:
+        return ""
+    lowered = prompt.lower()
+    raw_tokens = _WORD_RE.findall(lowered)
+    kept: set[str] = set()
+    for tok in raw_tokens:
+        if tok in _STOPWORDS:
+            continue
+        if len(tok) < 2:
+            continue
+        kept.add(_stem(tok))
+    if not kept:
+        return ""
+    return " ".join(sorted(kept))
+
+
+def jaccard_similarity(sig_a: str, sig_b: str) -> float:
+    """Compute Jaccard similarity between two task signatures.
+
+    Used for fuzzy cluster matching when exact signature equality is
+    too strict. Returns 0.0 if either signature is empty.
+
+    Args:
+        sig_a: First signature string, as produced by :func:`task_signature`.
+        sig_b: Second signature string, as produced by :func:`task_signature`.
+
+    Returns:
+        Similarity in ``[0.0, 1.0]`` where 1.0 means identical token
+        sets and 0.0 means disjoint token sets.
+    """
+    tokens_a = set(sig_a.split())
+    tokens_b = set(sig_b.split())
+    if not tokens_a or not tokens_b:
+        return 0.0
+    intersection = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    return len(intersection) / len(union)

--- a/skills/immune/SKILL.md
+++ b/skills/immune/SKILL.md
@@ -64,6 +64,51 @@ If no inline text is provided, scan the last substantive output in the conversat
 
 **Domain auto-detection:** Read `config.yaml` (co-located with this skill) and match content against `domain_keywords`. If no strong match, use `["_global"]`. If single `domain` string provided, wrap in array: `domains = [domain]`.
 
+## Task-Conditioned Retrieval (v3.1.0+)
+
+Antibodies and cheatsheet strategies may carry an optional `triggers` field for
+per-task filtering. This implements the read phase of the Memento-Skills
+reflective loop (arXiv 2603.18743) — entries are ranked by lexical overlap
+between the current task and their historical contexts.
+
+**Schema (additive, optional):**
+
+```json
+{
+  "id": "AB-042",
+  "domains": ["code"],
+  "pattern": "SQL injection via string concatenation",
+  "severity": "critical",
+  "correction": "Use parameterized queries",
+  "triggers": {
+    "task_signatures": ["code query review sql", "audit code sql"],
+    "domains": ["code"]
+  }
+}
+```
+
+**Back-compat:** entries without `triggers` behave as always-on (the v3.0.0
+behavior). The `task_conditioned_retrieval: true` flag in `config.yaml` enables
+the filter. When disabled, all entries load regardless of task.
+
+**Ranking helper:** `scripts/retrieve.py` implements the scoring logic. Callers
+(including the scanner agent, the skill-librarian in P2, and the skill-router
+in P3) invoke `retrieve(prompt, entries, active_domains, historical_success)`
+to obtain the ranked subset before tier classification. Scoring uses Jaccard
+similarity over normalized task signatures from `scripts/task_signature.py`,
+multiplied by an optional per-entry success rate derived from
+`evals/history.jsonl`.
+
+During load (Phase 0 cheatsheet, Phase 1 antibodies), after the domain filter
+and before Hot/Cold tier classification, apply the retrieve step:
+
+1. Compute `task_signature(prompt)` for the current task.
+2. Pass entries through `retrieve(...)` with the active domains set.
+3. Feed only the returned subset into the tier classification below.
+
+Entries filtered out at retrieval never reach Hot/Cold — this is what keeps
+the scan context lean and task-focused.
+
 ## Execution
 
 ### Step 0 — Cheatsheet Injection (positive patterns)

--- a/skills/immune/config.yaml
+++ b/skills/immune/config.yaml
@@ -6,7 +6,7 @@
 # ============================================================
 
 immune:
-  version: "3.0.0"
+  version: "3.1.0"
   scan_model: "haiku"
   memory_path: "immune_memory.json"
   cheatsheet_path: "cheatsheet_memory.json"
@@ -14,6 +14,11 @@ immune:
   auto_add_strategies: true
   severity_levels: [critical, warning, info]
   domains_multi: true  # antibodies/strategies use "domains" array, not single "domain"
+  # Task-conditioned retrieval (Memento-Skills alignment, arXiv 2603.18743).
+  # When enabled, antibodies and strategies with an optional `triggers` field
+  # are filtered and ranked per-task via scripts/retrieve.py. Entries without
+  # `triggers` remain always-on for back-compat with v3.0.0 memory files.
+  task_conditioned_retrieval: true
 
 # Tiered memory — keeps active set small for optimal Haiku performance
 # Benchmark showed sweet spot at 13-20 antibodies (F1=0.94)

--- a/skills/immune/scripts/retrieve.py
+++ b/skills/immune/scripts/retrieve.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Task-conditioned retrieval for immune antibodies and cheatsheet strategies.
+
+Implements the read phase of the Memento-Skills reflective loop
+(arXiv 2603.18743): given a task prompt and the immune memory JSON,
+select the subset of entries most likely to be relevant, ranked by
+lexical signature overlap and an optional historical success multiplier.
+
+Entries without a ``triggers`` field behave as always-on — this
+preserves back-compatibility with immune memory v3.0.0 and earlier.
+Entries with a ``triggers`` field are filtered by domain and scored
+by task_signature overlap.
+
+Schema for the new ``triggers`` field (additive, optional)::
+
+    {
+      "id": "AB-001",
+      "domains": ["code"],
+      "pattern": "SQL injection via string concatenation",
+      "severity": "critical",
+      "correction": "Use parameterized queries",
+      "seen_count": 12,
+      "first_seen": "2026-03-01",
+      "last_seen": "2026-04-05",
+      "triggers": {
+        "task_signatures": ["code query review sql", "audit code sql"],
+        "domains": ["code"]
+      }
+    }
+
+The ``triggers.task_signatures`` list contains canonical signatures
+(as produced by :func:`scripts.task_signature.task_signature`) for
+prompts where this entry has historically been relevant. Multiple
+signatures allow a single entry to cover several related task shapes.
+
+This module does not modify immune memory — it is pure read-side logic.
+The write path (tagging entries with triggers on firing) lives in
+immune's scanner agent and is updated when new antibodies are added.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+import sys
+
+# Import the shared task_signature module. The immune skill lives at
+# skills/immune/, and scripts/task_signature.py lives at the repo root.
+# Resolve repo root by walking up from this file.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.task_signature import jaccard_similarity, task_signature  # noqa: E402
+
+# Baseline score for entries without an explicit ``triggers`` field.
+# Lower than typical triggered-match scores so that a well-matched
+# triggered entry outranks a generic always-on entry when both apply.
+_UNTRIGGERED_BASELINE = 0.5
+
+# Minimum jaccard overlap required for a triggered entry to be
+# considered a match. Below this threshold the entry is filtered out
+# entirely rather than ranked low, because a barely-matching entry
+# pollutes context without adding value.
+_MIN_SIGNATURE_MATCH = 0.15
+
+
+def _entry_domains(entry: dict) -> set[str]:
+    """Return the domain set an entry applies to.
+
+    Handles both v2 (``domain`` string) and v3 (``domains`` list)
+    immune memory formats.
+
+    Args:
+        entry: An antibody or strategy record.
+
+    Returns:
+        Set of domain strings, or an empty set if neither field is set.
+    """
+    if "domains" in entry and isinstance(entry["domains"], list):
+        return {str(d) for d in entry["domains"]}
+    if "domain" in entry and isinstance(entry["domain"], str):
+        return {entry["domain"]}
+    return set()
+
+
+def _score_entry(
+    entry: dict,
+    prompt_signature: str,
+    active_domains: set[str],
+    historical_success: dict[str, float],
+) -> float:
+    """Compute the retrieval score for a single entry.
+
+    Scoring rules:
+
+    1. Domain filter: if the entry has any domain (from ``domains`` or
+       ``triggers.domains``) other than ``_global``, the active task
+       must overlap at least one of those domains. Otherwise the entry
+       is filtered out (score 0.0).
+    2. Signature scoring: if the entry has ``triggers.task_signatures``,
+       use the max Jaccard similarity against the prompt signature. If
+       below :data:`_MIN_SIGNATURE_MATCH`, filter out.
+    3. Untriggered entries fall back to :data:`_UNTRIGGERED_BASELINE`.
+    4. Historical success multiplier: if ``historical_success`` contains
+       a rate for this entry's ``id``, multiply the base score by it.
+       Missing IDs default to 1.0 (no penalty).
+
+    Args:
+        entry: Antibody or strategy dict.
+        prompt_signature: Signature of the current task prompt.
+        active_domains: Domain set for the current task.
+        historical_success: Map of entry_id -> success_rate in [0, 1].
+
+    Returns:
+        Score in ``[0.0, 1.0]``. Zero means "filter out".
+    """
+    entry_domains = _entry_domains(entry)
+    triggers = entry.get("triggers") or {}
+    trigger_domains = {str(d) for d in (triggers.get("domains") or [])}
+    effective_domains = entry_domains | trigger_domains
+
+    has_specific_domains = bool(effective_domains) and "_global" not in effective_domains
+    if has_specific_domains and active_domains:
+        if not (effective_domains & active_domains):
+            return 0.0
+
+    trigger_signatures = triggers.get("task_signatures") or []
+    if trigger_signatures:
+        best_match = max(
+            jaccard_similarity(prompt_signature, str(trig))
+            for trig in trigger_signatures
+        )
+        if best_match < _MIN_SIGNATURE_MATCH:
+            return 0.0
+        base = best_match
+    else:
+        base = _UNTRIGGERED_BASELINE
+
+    entry_id = str(entry.get("id", ""))
+    multiplier = historical_success.get(entry_id, 1.0) if entry_id else 1.0
+    return base * multiplier
+
+
+def retrieve(
+    prompt: str,
+    entries: Iterable[dict],
+    active_domains: set[str] | None = None,
+    historical_success: dict[str, float] | None = None,
+    top_k: int = 15,
+) -> list[dict]:
+    """Rank entries by task-conditioned relevance to a prompt.
+
+    Args:
+        prompt: Current task prompt text.
+        entries: Antibodies or strategies from immune memory.
+        active_domains: Domains detected for the current task. When
+            ``None`` or empty, domain filtering is skipped (all domains
+            eligible) — useful for testing and unconditioned retrieval.
+        historical_success: Optional map of ``entry_id -> success_rate``
+            used as a multiplier on the base score. Populated by the
+            scanner agent as antibodies fire and their corrections are
+            accepted or rejected. For P1, callers may pass an empty
+            map; the field is scaffolding for the Phase 3 router.
+        top_k: Maximum number of entries to return after ranking.
+
+    Returns:
+        List of entries in descending score order, capped at ``top_k``.
+        Filtered-out entries (score 0.0) are excluded.
+    """
+    prompt_sig = task_signature(prompt)
+    active = active_domains or set()
+    history = historical_success or {}
+
+    scored: list[tuple[float, dict]] = []
+    for entry in entries:
+        score = _score_entry(entry, prompt_sig, active, history)
+        if score > 0.0:
+            scored.append((score, entry))
+
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [entry for _, entry in scored[:top_k]]
+
+
+def build_success_map(history_entries: list[dict]) -> dict[str, float]:
+    """Compute pass-rate by task_signature from eval history entries.
+
+    This is a utility for callers who want to derive the
+    ``historical_success`` map from ``evals/history.jsonl`` records.
+    The returned map is keyed by ``task_signature`` rather than entry
+    id, so it is most useful for router-level scoring (Phase 3) and
+    not for per-antibody weighting.
+
+    Args:
+        history_entries: Parsed lines from ``evals/history.jsonl``.
+
+    Returns:
+        Map of ``task_signature -> pass_rate`` in ``[0.0, 1.0]``.
+        Signatures with zero observations are excluded.
+    """
+    counts: dict[str, list[int]] = {}
+    for entry in history_entries:
+        sig = str(entry.get("task_signature", ""))
+        if not sig:
+            continue
+        bucket = counts.setdefault(sig, [0, 0])
+        bucket[1] += 1
+        if entry.get("oracle_verdict") == "pass":
+            bucket[0] += 1
+    return {
+        sig: passed / total
+        for sig, (passed, total) in counts.items()
+        if total > 0
+    }

--- a/tests/test_build_router_index.py
+++ b/tests/test_build_router_index.py
@@ -1,0 +1,163 @@
+"""Tests for scripts.build_router_index."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.build_router_index import (
+    aggregate,
+    build_index,
+    read_history,
+)
+
+
+class TestReadHistory:
+    def test_missing_file_returns_empty_list(self, tmp_path: Path) -> None:
+        assert read_history(tmp_path / "nonexistent.jsonl") == []
+
+    def test_empty_file_returns_empty_list(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.jsonl"
+        path.write_text("", encoding="utf-8")
+        assert read_history(path) == []
+
+    def test_parses_valid_jsonl(self, tmp_path: Path) -> None:
+        path = tmp_path / "h.jsonl"
+        path.write_text(
+            '{"task_signature": "a", "package_path": "skills/x"}\n'
+            '{"task_signature": "b", "package_path": "skills/y"}\n',
+            encoding="utf-8",
+        )
+        result = read_history(path)
+        assert len(result) == 2
+        assert result[0]["package_path"] == "skills/x"
+
+    def test_blank_lines_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "h.jsonl"
+        path.write_text(
+            '{"a": 1}\n\n{"b": 2}\n\n',
+            encoding="utf-8",
+        )
+        assert len(read_history(path)) == 2
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "h.jsonl"
+        path.write_text('{"ok": 1}\nnot-json\n', encoding="utf-8")
+        try:
+            read_history(path)
+        except json.JSONDecodeError as exc:
+            assert "h.jsonl:2" in str(exc)
+        else:
+            raise AssertionError("expected JSONDecodeError")
+
+
+class TestAggregate:
+    def test_empty_entries_produce_empty_map(self) -> None:
+        assert aggregate([]) == {}
+
+    def test_pass_rate_computed_per_signature_and_package(self) -> None:
+        entries = [
+            {
+                "task_signature": "code review",
+                "package_path": "skills/code-reviewer",
+                "oracle_verdict": "pass",
+            },
+            {
+                "task_signature": "code review",
+                "package_path": "skills/code-reviewer",
+                "oracle_verdict": "pass",
+            },
+            {
+                "task_signature": "code review",
+                "package_path": "skills/code-reviewer",
+                "oracle_verdict": "fail",
+            },
+        ]
+        result = aggregate(entries)
+        packages = result["code review"]
+        assert len(packages) == 1
+        assert abs(packages[0]["pass_rate"] - 2 / 3) < 1e-9
+        assert packages[0]["sample_count"] == 3
+
+    def test_multiple_packages_sorted_by_pass_rate_desc(self) -> None:
+        entries = [
+            {"task_signature": "s", "package_path": "skills/a", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "fail"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+        ]
+        result = aggregate(entries)
+        packages = result["s"]
+        assert packages[0]["package_path"] == "skills/a"  # 1.0 > 0.5
+        assert packages[1]["package_path"] == "skills/b"
+
+    def test_tiebreak_by_sample_count(self) -> None:
+        entries = [
+            {"task_signature": "s", "package_path": "skills/a", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+        ]
+        result = aggregate(entries)
+        # Both are 100% pass; skills/b has more samples -> ranks first
+        assert result["s"][0]["package_path"] == "skills/b"
+
+    def test_min_samples_filters_noise(self) -> None:
+        entries = [
+            {"task_signature": "s", "package_path": "skills/a", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+            {"task_signature": "s", "package_path": "skills/b", "oracle_verdict": "pass"},
+        ]
+        result = aggregate(entries, min_samples=3)
+        assert [p["package_path"] for p in result["s"]] == ["skills/b"]
+
+    def test_missing_fields_skipped(self) -> None:
+        entries = [
+            {"task_signature": "s", "oracle_verdict": "pass"},  # no package
+            {"package_path": "skills/x", "oracle_verdict": "pass"},  # no signature
+            {
+                "task_signature": "s",
+                "package_path": "skills/x",
+                "oracle_verdict": "pass",
+            },
+        ]
+        result = aggregate(entries)
+        assert result == {
+            "s": [
+                {
+                    "package_path": "skills/x",
+                    "pass_rate": 1.0,
+                    "sample_count": 1,
+                }
+            ]
+        }
+
+    def test_non_pass_verdict_not_counted_as_pass(self) -> None:
+        entries = [
+            {"task_signature": "s", "package_path": "skills/x", "oracle_verdict": "skipped"},
+            {"task_signature": "s", "package_path": "skills/x", "oracle_verdict": "fail"},
+        ]
+        result = aggregate(entries)
+        assert result["s"][0]["pass_rate"] == 0.0
+
+
+class TestBuildIndex:
+    def test_metadata_includes_counts(self) -> None:
+        entries = [
+            {"task_signature": "a", "package_path": "skills/x", "oracle_verdict": "pass"},
+            {"task_signature": "b", "package_path": "skills/y", "oracle_verdict": "pass"},
+            {"task_signature": "b", "package_path": "skills/y", "oracle_verdict": "fail"},
+        ]
+        payload = build_index(entries)
+        assert payload["metadata"]["source_entries"] == 3
+        assert payload["metadata"]["unique_signatures"] == 2
+        assert payload["metadata"]["unique_packages"] == 2
+
+    def test_index_and_metadata_keys_present(self) -> None:
+        payload = build_index([])
+        assert "metadata" in payload
+        assert "index" in payload
+        assert payload["metadata"]["source_entries"] == 0
+        assert payload["index"] == {}
+
+    def test_min_samples_reflected_in_metadata(self) -> None:
+        payload = build_index([], min_samples=5)
+        assert payload["metadata"]["min_samples"] == 5

--- a/tests/test_immune_retrieve.py
+++ b/tests/test_immune_retrieve.py
@@ -1,0 +1,183 @@
+"""Tests for skills.immune.scripts.retrieve."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# The immune retrieve module lives under skills/immune/scripts/retrieve.py.
+# Load it directly by path since the skills/ tree is not a package.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_RETRIEVE_PATH = _REPO_ROOT / "skills" / "immune" / "scripts" / "retrieve.py"
+_spec = importlib.util.spec_from_file_location("immune_retrieve", _RETRIEVE_PATH)
+assert _spec is not None and _spec.loader is not None
+_retrieve_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_retrieve_mod)
+
+retrieve = _retrieve_mod.retrieve
+build_success_map = _retrieve_mod.build_success_map
+
+
+def _antibody(
+    entry_id: str,
+    domains: list[str] | None = None,
+    trigger_sigs: list[str] | None = None,
+    trigger_domains: list[str] | None = None,
+    severity: str = "warning",
+) -> dict:
+    entry: dict = {
+        "id": entry_id,
+        "domains": domains if domains is not None else ["_global"],
+        "pattern": f"test pattern for {entry_id}",
+        "severity": severity,
+        "correction": "fix it",
+    }
+    if trigger_sigs is not None or trigger_domains is not None:
+        entry["triggers"] = {}
+        if trigger_sigs is not None:
+            entry["triggers"]["task_signatures"] = trigger_sigs
+        if trigger_domains is not None:
+            entry["triggers"]["domains"] = trigger_domains
+    return entry
+
+
+class TestUntriggeredBackCompat:
+    """Entries without a triggers field must retain v3.0.0 behavior."""
+
+    def test_untriggered_entry_returned(self) -> None:
+        entries = [_antibody("AB-1")]
+        result = retrieve("anything", entries)
+        assert len(result) == 1
+        assert result[0]["id"] == "AB-1"
+
+    def test_untriggered_entries_returned_in_stable_order(self) -> None:
+        entries = [_antibody(f"AB-{i}") for i in range(5)]
+        result = retrieve("some task", entries)
+        assert len(result) == 5
+
+
+class TestDomainFiltering:
+    def test_domain_mismatch_filters_out(self) -> None:
+        entries = [_antibody("AB-code", domains=["code"])]
+        result = retrieve("prompt", entries, active_domains={"fitness"})
+        assert result == []
+
+    def test_domain_match_passes(self) -> None:
+        entries = [_antibody("AB-code", domains=["code"])]
+        result = retrieve("prompt", entries, active_domains={"code"})
+        assert len(result) == 1
+
+    def test_global_domain_bypasses_filter(self) -> None:
+        entries = [_antibody("AB-global", domains=["_global"])]
+        result = retrieve("prompt", entries, active_domains={"fitness"})
+        assert len(result) == 1
+
+    def test_no_active_domains_skips_filter(self) -> None:
+        entries = [_antibody("AB-code", domains=["code"])]
+        result = retrieve("prompt", entries, active_domains=None)
+        assert len(result) == 1
+
+
+class TestTriggerMatching:
+    def test_matching_trigger_signature_returned(self) -> None:
+        # Signature for "Review this code for quality" -> "code quality review"
+        entries = [
+            _antibody("AB-1", trigger_sigs=["code quality review"]),
+        ]
+        result = retrieve("Review this code for quality", entries)
+        assert len(result) == 1
+        assert result[0]["id"] == "AB-1"
+
+    def test_non_matching_trigger_filtered_out(self) -> None:
+        entries = [
+            _antibody("AB-fitness", trigger_sigs=["exercise squat workout"]),
+        ]
+        result = retrieve("Review this code for quality", entries)
+        assert result == []
+
+    def test_partial_trigger_match_above_threshold_returned(self) -> None:
+        # Prompt "Review this code" -> "code review"
+        # Trigger "code review quality" -> 2/3 jaccard overlap
+        entries = [
+            _antibody("AB-1", trigger_sigs=["code review quality"]),
+        ]
+        result = retrieve("Review this code", entries)
+        assert len(result) == 1
+
+    def test_triggered_entry_outranks_untriggered_on_strong_match(self) -> None:
+        entries = [
+            _antibody("AB-generic"),
+            _antibody("AB-specific", trigger_sigs=["code review"]),
+        ]
+        result = retrieve("review code", entries)
+        assert result[0]["id"] == "AB-specific"
+        assert result[1]["id"] == "AB-generic"
+
+    def test_multiple_trigger_signatures_uses_best_match(self) -> None:
+        entries = [
+            _antibody(
+                "AB-1",
+                trigger_sigs=["unrelated thing", "code review"],
+            ),
+        ]
+        result = retrieve("review code", entries)
+        assert len(result) == 1
+
+
+class TestTopKCap:
+    def test_top_k_caps_returned_count(self) -> None:
+        entries = [_antibody(f"AB-{i}") for i in range(20)]
+        result = retrieve("prompt", entries, top_k=5)
+        assert len(result) == 5
+
+    def test_zero_top_k_returns_empty(self) -> None:
+        entries = [_antibody("AB-1")]
+        result = retrieve("prompt", entries, top_k=0)
+        assert result == []
+
+
+class TestHistoricalSuccessMultiplier:
+    def test_zero_success_rate_demotes_entry(self) -> None:
+        entries = [
+            _antibody("AB-reliable", trigger_sigs=["code review"]),
+            _antibody("AB-broken", trigger_sigs=["code review"]),
+        ]
+        history = {"AB-broken": 0.0, "AB-reliable": 1.0}
+        result = retrieve("review code", entries, historical_success=history)
+        # Broken entry filtered out entirely (score 0).
+        assert [e["id"] for e in result] == ["AB-reliable"]
+
+    def test_missing_entry_defaults_to_full_weight(self) -> None:
+        entries = [_antibody("AB-unknown", trigger_sigs=["code review"])]
+        result = retrieve("review code", entries, historical_success={})
+        assert len(result) == 1
+
+
+class TestBuildSuccessMap:
+    def test_empty_history_returns_empty_map(self) -> None:
+        assert build_success_map([]) == {}
+
+    def test_pass_rate_computed_per_signature(self) -> None:
+        history = [
+            {"task_signature": "code review", "oracle_verdict": "pass"},
+            {"task_signature": "code review", "oracle_verdict": "pass"},
+            {"task_signature": "code review", "oracle_verdict": "fail"},
+            {"task_signature": "write test", "oracle_verdict": "pass"},
+        ]
+        result = build_success_map(history)
+        assert abs(result["code review"] - 2 / 3) < 1e-9
+        assert result["write test"] == 1.0
+
+    def test_missing_signature_field_skipped(self) -> None:
+        history = [
+            {"oracle_verdict": "pass"},
+            {"task_signature": "test", "oracle_verdict": "pass"},
+        ]
+        result = build_success_map(history)
+        assert list(result.keys()) == ["test"]
+
+    def test_non_pass_verdict_counted_as_total_not_pass(self) -> None:
+        history = [
+            {"task_signature": "s", "oracle_verdict": "skipped"},
+            {"task_signature": "s", "oracle_verdict": "fail"},
+        ]
+        assert build_success_map(history) == {"s": 0.0}

--- a/tests/test_run_evals_history.py
+++ b/tests/test_run_evals_history.py
@@ -1,0 +1,151 @@
+"""Tests for the eval history append-only log in scripts.run_evals."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.run_evals import (
+    CaseResult,
+    PackageResult,
+    _prompt_hash,
+    write_history,
+)
+
+
+def _make_package_result(
+    package_path: str = "skills/example",
+    cases: list[CaseResult] | None = None,
+) -> PackageResult:
+    case_results = cases or [
+        CaseResult(
+            case_id="positive_basic",
+            prompt="Review this code for quality issues",
+            trigger_expected=True,
+            oracle_verdict="pass",
+            weighted_score=1.0,
+            assertion_details=[],
+            execution_time_ms=1234,
+        ),
+    ]
+    return PackageResult(
+        package_name=Path(package_path).name,
+        package_path=package_path,
+        total_cases=len(case_results),
+        passed=sum(1 for c in case_results if c.oracle_verdict == "pass"),
+        failed=sum(1 for c in case_results if c.oracle_verdict == "fail"),
+        skipped=sum(1 for c in case_results if c.oracle_verdict == "skipped"),
+        aggregate_score=sum(c.weighted_score for c in case_results) / len(case_results),
+        case_results=case_results,
+    )
+
+
+class TestPromptHash:
+    def test_stable_across_calls(self) -> None:
+        assert _prompt_hash("abc") == _prompt_hash("abc")
+
+    def test_different_inputs_produce_different_hashes(self) -> None:
+        assert _prompt_hash("abc") != _prompt_hash("abd")
+
+    def test_hash_length_is_sixteen(self) -> None:
+        assert len(_prompt_hash("any prompt")) == 16
+
+    def test_hash_is_hex(self) -> None:
+        h = _prompt_hash("any prompt")
+        int(h, 16)  # raises ValueError if not hex
+
+
+class TestWriteHistory:
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "nested" / "history.jsonl"
+        write_history([_make_package_result()], history_path)
+        assert history_path.exists()
+
+    def test_appends_does_not_overwrite(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        write_history([_make_package_result()], history_path)
+        write_history([_make_package_result()], history_path)
+        lines = history_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+
+    def test_each_case_is_one_line(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        cases = [
+            CaseResult(
+                case_id="c1",
+                prompt="Write tests for the parser",
+                trigger_expected=True,
+                oracle_verdict="pass",
+                weighted_score=1.0,
+                assertion_details=[],
+                execution_time_ms=100,
+            ),
+            CaseResult(
+                case_id="c2",
+                prompt="Review this code",
+                trigger_expected=True,
+                oracle_verdict="fail",
+                weighted_score=0.5,
+                assertion_details=[],
+                execution_time_ms=200,
+            ),
+        ]
+        write_history([_make_package_result(cases=cases)], history_path)
+        lines = history_path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+
+    def test_schema_fields_present(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        write_history([_make_package_result()], history_path)
+        entry = json.loads(history_path.read_text(encoding="utf-8").strip())
+        required = {
+            "timestamp",
+            "package_path",
+            "case_id",
+            "task_signature",
+            "prompt_hash",
+            "trigger_expected",
+            "oracle_verdict",
+            "weighted_score",
+            "execution_time_ms",
+        }
+        assert required <= set(entry.keys())
+
+    def test_raw_prompt_not_stored(self, tmp_path: Path) -> None:
+        """PII protection: history log must not contain the raw prompt text."""
+        secret_prompt = "API_KEY=sk-proj-supersecretvalue please review this"
+        cases = [
+            CaseResult(
+                case_id="secret_case",
+                prompt=secret_prompt,
+                trigger_expected=True,
+                oracle_verdict="pass",
+                weighted_score=1.0,
+                assertion_details=[],
+                execution_time_ms=100,
+            ),
+        ]
+        write_history([_make_package_result(cases=cases)], history_path := tmp_path / "h.jsonl")
+        contents = history_path.read_text(encoding="utf-8")
+        assert "sk-proj-supersecretvalue" not in contents
+        assert "API_KEY=" not in contents
+
+    def test_task_signature_populated(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        write_history([_make_package_result()], history_path)
+        entry = json.loads(history_path.read_text(encoding="utf-8").strip())
+        # Signature for "Review this code for quality issues" -> sorted stems
+        assert "review" in entry["task_signature"].split()
+        assert "code" in entry["task_signature"].split()
+
+    def test_jsonl_is_valid_json_per_line(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        write_history([_make_package_result()], history_path)
+        write_history([_make_package_result()], history_path)
+        for line in history_path.read_text(encoding="utf-8").strip().split("\n"):
+            json.loads(line)  # raises if any line is not valid JSON
+
+    def test_empty_results_produces_empty_file(self, tmp_path: Path) -> None:
+        history_path = tmp_path / "history.jsonl"
+        write_history([], history_path)
+        assert history_path.exists()
+        assert history_path.read_text(encoding="utf-8") == ""

--- a/tests/test_run_skillsbench.py
+++ b/tests/test_run_skillsbench.py
@@ -1,0 +1,246 @@
+"""Tests for scripts.run_skillsbench pure logic (no live claude execution)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.run_skillsbench import (
+    BenchmarkReport,
+    TaskRunResult,
+    aggregate_report,
+    check_assertions,
+    compare_reports,
+    load_task,
+    load_task_set,
+    verdict_from_score,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SEED_TASKS_DIR = _REPO_ROOT / "evals" / "skillsbench" / "tasks"
+
+
+class TestLoadTask:
+    def test_loads_seed_task(self) -> None:
+        task = load_task(_SEED_TASKS_DIR / "task_001_code_review_simple.yaml")
+        assert task.id == "task_001_code_review_simple"
+        assert task.category == "review"
+        assert len(task.assertions) >= 1
+        assert 0.0 < task.pass_threshold <= 1.0
+
+    def test_id_must_match_filename(self, tmp_path: Path) -> None:
+        path = tmp_path / "mismatched.yaml"
+        path.write_text(
+            "id: other_name\n"
+            "description: x\n"
+            "category: review\n"
+            "prompt: hi\n"
+            "success_criterion:\n"
+            "  type: assertion\n"
+            "  assertions:\n"
+            "    - {type: contains, target: x, weight: 1.0}\n"
+            "  pass_threshold: 0.5\n"
+            "limits: {max_turns: 1, max_tokens: 100, timeout_seconds: 10}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="must match filename"):
+            load_task(path)
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "incomplete.yaml"
+        path.write_text("id: incomplete\ndescription: x\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="missing required fields"):
+            load_task(path)
+
+    def test_unsupported_criterion_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_criterion.yaml"
+        path.write_text(
+            "id: bad_criterion\n"
+            "description: x\n"
+            "category: review\n"
+            "prompt: hi\n"
+            "success_criterion:\n"
+            "  type: llm_judge\n"
+            "limits: {max_turns: 1, max_tokens: 100, timeout_seconds: 10}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unsupported criterion type"):
+            load_task(path)
+
+    def test_unsupported_assertion_type_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_assertion.yaml"
+        path.write_text(
+            "id: bad_assertion\n"
+            "description: x\n"
+            "category: review\n"
+            "prompt: hi\n"
+            "success_criterion:\n"
+            "  type: assertion\n"
+            "  assertions:\n"
+            "    - {type: magic_type, target: x, weight: 1.0}\n"
+            "  pass_threshold: 0.5\n"
+            "limits: {max_turns: 1, max_tokens: 100, timeout_seconds: 10}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unsupported type"):
+            load_task(path)
+
+
+class TestLoadTaskSet:
+    def test_seed_tasks_all_valid(self) -> None:
+        tasks = load_task_set(_SEED_TASKS_DIR)
+        assert len(tasks) >= 5
+        ids = [t.id for t in tasks]
+        assert len(ids) == len(set(ids))  # no duplicate ids
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_task_set(tmp_path / "nope") == []
+
+
+class TestCheckAssertions:
+    def test_all_pass(self) -> None:
+        assertions = [
+            {"type": "contains", "target": "hello", "weight": 0.5},
+            {"type": "matches_regex", "target": "world", "weight": 0.5},
+        ]
+        score, details = check_assertions("hello world", assertions)
+        assert score == 1.0
+        assert all(d["passed"] for d in details)
+
+    def test_all_fail(self) -> None:
+        assertions = [{"type": "contains", "target": "missing", "weight": 1.0}]
+        score, details = check_assertions("hello world", assertions)
+        assert score == 0.0
+        assert not details[0]["passed"]
+
+    def test_weighted_partial(self) -> None:
+        assertions = [
+            {"type": "contains", "target": "yes", "weight": 0.75},
+            {"type": "contains", "target": "no", "weight": 0.25},
+        ]
+        score, _ = check_assertions("yes", assertions)
+        assert abs(score - 0.75) < 1e-9
+
+    def test_weights_normalized_to_one(self) -> None:
+        # Weights summing to 2.0 should still yield a score in [0, 1].
+        assertions = [
+            {"type": "contains", "target": "a", "weight": 1.0},
+            {"type": "contains", "target": "b", "weight": 1.0},
+        ]
+        score, _ = check_assertions("a", assertions)
+        assert abs(score - 0.5) < 1e-9
+
+    def test_not_contains(self) -> None:
+        assertions = [{"type": "not_contains", "target": "error", "weight": 1.0}]
+        score, _ = check_assertions("clean output", assertions)
+        assert score == 1.0
+
+    def test_regex_case_insensitive(self) -> None:
+        assertions = [
+            {"type": "matches_regex", "target": "(?i)HELLO", "weight": 1.0}
+        ]
+        score, _ = check_assertions("hello there", assertions)
+        assert score == 1.0
+
+    def test_zero_total_weight_returns_zero(self) -> None:
+        assertions = [{"type": "contains", "target": "x", "weight": 0.0}]
+        score, _ = check_assertions("x", assertions)
+        assert score == 0.0
+
+
+class TestVerdictFromScore:
+    def test_above_threshold_passes(self) -> None:
+        assert verdict_from_score(0.8, 0.7) == "pass"
+
+    def test_at_threshold_passes(self) -> None:
+        assert verdict_from_score(0.7, 0.7) == "pass"
+
+    def test_below_threshold_fails(self) -> None:
+        assert verdict_from_score(0.69, 0.7) == "fail"
+
+
+def _result(
+    task_id: str,
+    config: str,
+    verdict: str,
+    score: float,
+    attempt: int = 1,
+) -> TaskRunResult:
+    return TaskRunResult(
+        task_id=task_id,
+        config=config,
+        attempt=attempt,
+        verdict=verdict,
+        weighted_score=score,
+        output_excerpt="",
+        assertion_results=[],
+        execution_time_ms=100,
+    )
+
+
+class TestAggregateReport:
+    def test_empty_results_zero_rate(self) -> None:
+        report = aggregate_report("A", [])
+        assert report.total_tasks == 0
+        assert report.pass_rate == 0.0
+
+    def test_pass_rate_matches_results(self) -> None:
+        results = [
+            _result("t1", "A", "pass", 0.9),
+            _result("t2", "A", "pass", 0.8),
+            _result("t3", "A", "fail", 0.4),
+        ]
+        report = aggregate_report("A", results)
+        assert report.total_tasks == 3
+        assert report.passed == 2
+        assert abs(report.pass_rate - 2 / 3) < 1e-9
+
+    def test_multiple_attempts_use_median(self) -> None:
+        # Two attempts for t1: one pass, one fail. Median of 2 takes index 1
+        # (the higher-scoring one) per sorted ordering.
+        results = [
+            _result("t1", "A", "fail", 0.2, attempt=1),
+            _result("t1", "A", "pass", 0.9, attempt=2),
+            _result("t1", "A", "pass", 0.8, attempt=3),
+        ]
+        report = aggregate_report("A", results)
+        assert report.total_tasks == 1
+        # Sorted scores: 0.2, 0.8, 0.9. Median index = 3//2 = 1 -> 0.8
+        assert report.per_task[0].weighted_score == 0.8
+
+
+class TestCompareReports:
+    def _report(self, config: str, pass_rate: float, total: int = 10) -> BenchmarkReport:
+        return BenchmarkReport(
+            config=config,
+            timestamp="",
+            total_tasks=total,
+            passed=int(pass_rate * total),
+            failed=total - int(pass_rate * total),
+            errored=0,
+            skipped=0,
+            pass_rate=pass_rate,
+            mean_score=pass_rate,
+        )
+
+    def test_s3_met_when_delta_exceeds_threshold(self) -> None:
+        a = self._report("A", 0.85)
+        b = self._report("B", 0.60)
+        comparison = compare_reports(a, b)
+        assert comparison["s3_exit_met"] is True
+        assert comparison["verdict"] == "curation_validated"
+        assert abs(comparison["delta_pp"] - 25.0) < 1e-9
+
+    def test_s3_unmet_when_delta_below_threshold(self) -> None:
+        a = self._report("A", 0.70)
+        b = self._report("B", 0.65)
+        comparison = compare_reports(a, b)
+        assert comparison["s3_exit_met"] is False
+        assert comparison["verdict"] == "thesis_unconfirmed"
+
+    def test_custom_threshold(self) -> None:
+        a = self._report("A", 0.70)
+        b = self._report("B", 0.60)
+        # 10pp delta meets a custom 10pp threshold
+        comparison = compare_reports(a, b, min_delta_pp=10.0)
+        assert comparison["s3_exit_met"] is True

--- a/tests/test_task_signature.py
+++ b/tests/test_task_signature.py
@@ -1,0 +1,143 @@
+"""Tests for scripts.task_signature."""
+from __future__ import annotations
+
+from scripts.task_signature import jaccard_similarity, task_signature
+
+
+class TestTaskSignatureBasics:
+    def test_empty_prompt_returns_empty_string(self) -> None:
+        assert task_signature("") == ""
+
+    def test_all_stopwords_returns_empty_string(self) -> None:
+        assert task_signature("the a an and or you i") == ""
+
+    def test_single_content_word_stems(self) -> None:
+        assert task_signature("testing") == "test"
+
+    def test_punctuation_stripped(self) -> None:
+        assert task_signature("review code!") == task_signature("review, code.")
+
+    def test_case_insensitive(self) -> None:
+        assert task_signature("Review Code") == task_signature("review code")
+
+    def test_word_order_irrelevant(self) -> None:
+        assert task_signature("review code") == task_signature("code review")
+
+    def test_stopwords_dropped(self) -> None:
+        assert task_signature("please review the code") == task_signature("review code")
+
+    def test_duplicate_tokens_deduped(self) -> None:
+        assert task_signature("code code review") == task_signature("code review")
+
+    def test_plural_and_singular_collide(self) -> None:
+        assert task_signature("tests") == task_signature("test")
+
+    def test_verb_tenses_collide(self) -> None:
+        assert task_signature("reviewing") == task_signature("review")
+        assert task_signature("reviewed") == task_signature("review")
+
+    def test_short_tokens_not_over_stemmed(self) -> None:
+        # "is" is a stopword anyway, but "bug" is short and content-ful.
+        # Must not stem away the final character.
+        assert "bug" in task_signature("bug").split()
+
+    def test_alphanumeric_tokens_preserved(self) -> None:
+        sig = task_signature("migrate to python3")
+        assert "python3" in sig.split()
+
+
+class TestJaccardSimilarity:
+    def test_identical_signatures_return_one(self) -> None:
+        assert jaccard_similarity("code review", "code review") == 1.0
+
+    def test_disjoint_signatures_return_zero(self) -> None:
+        assert jaccard_similarity("code review", "write docs") == 0.0
+
+    def test_partial_overlap(self) -> None:
+        # {"code", "review"} vs {"code", "audit"} -> 1 / 3
+        result = jaccard_similarity("code review", "audit code")
+        assert abs(result - 1 / 3) < 1e-9
+
+    def test_empty_signature_returns_zero(self) -> None:
+        assert jaccard_similarity("", "code") == 0.0
+        assert jaccard_similarity("code", "") == 0.0
+        assert jaccard_similarity("", "") == 0.0
+
+    def test_symmetric(self) -> None:
+        a, b = "code review quality", "review code"
+        assert jaccard_similarity(a, b) == jaccard_similarity(b, a)
+
+
+# Hand-labeled task corpus. Each cluster represents a user intent that
+# should group together under nearest-neighbor matching. Phrasing varies
+# within a cluster but a shared content word anchors the cluster so the
+# token-based approach can discriminate without semantic understanding.
+_CLUSTERS: dict[str, list[str]] = {
+    "code_review": [
+        "Review this code for quality",
+        "Do a thorough code review",
+        "Can you review the code?",
+        "Please review my code carefully",
+        "Review the code for issues",
+    ],
+    "security_scan": [
+        "Scan for security vulnerabilities",
+        "Run a security scan on the repo",
+        "Check for security issues",
+        "Perform a security audit",
+        "Audit for security holes",
+    ],
+    "test_generation": [
+        "Generate pytest tests for this parser",
+        "Add pytest unit tests",
+        "Create pytest test cases",
+        "Build a pytest test suite",
+        "Produce pytest tests for the module",
+    ],
+    "documentation": [
+        "Generate API documentation for this module",
+        "Add comprehensive documentation",
+        "Create documentation pages",
+        "Update the existing documentation",
+        "Produce detailed documentation blocks",
+    ],
+}
+
+
+class TestClusterCoherence:
+    """Verify hand-labeled task clusters group by signature similarity.
+
+    Exit criterion (Phase 0 of Memento-Skills plan): on 20 hand-labeled
+    tasks, nearest-neighbor-by-signature clustering should match the
+    human labels at least 80% of the time.
+    """
+
+    def test_nearest_neighbor_accuracy_meets_threshold(self) -> None:
+        labeled_tasks: list[tuple[str, str]] = [
+            (cluster, task)
+            for cluster, tasks in _CLUSTERS.items()
+            for task in tasks
+        ]
+        signatures: list[tuple[str, str]] = [
+            (cluster, task_signature(task)) for cluster, task in labeled_tasks
+        ]
+
+        correct = 0
+        for i, (cluster_i, sig_i) in enumerate(signatures):
+            best_cluster: str | None = None
+            best_score = -1.0
+            for j, (cluster_j, sig_j) in enumerate(signatures):
+                if i == j:
+                    continue
+                score = jaccard_similarity(sig_i, sig_j)
+                if score > best_score:
+                    best_score = score
+                    best_cluster = cluster_j
+            if best_cluster == cluster_i:
+                correct += 1
+
+        accuracy = correct / len(signatures)
+        assert accuracy >= 0.80, (
+            f"Cluster coherence {accuracy:.0%} below 80% threshold. "
+            f"Correct: {correct}/{len(signatures)}"
+        )


### PR DESCRIPTION
## Summary

Closes the online half of the skill-evolution story in armory. EvoSkills
(arXiv 2604.01687, already integrated) handles **offline co-evolutionary
refinement**; this PR adds the **online read-write reflective loop** from
Memento-Skills (arXiv 2603.18743), so that:

- **Read phase** — antibodies and cheatsheet strategies can be filtered
  per task via task-conditioned retrieval, and an outcome-weighted router
  ranks packages by observed pass rate instead of zero-shot description
  matching.
- **Write phase** — a new `skill-librarian` agent observes completed task
  transcripts and drafts new skills or augmentations, routing them through
  `paper-to-skill`'s specification stage and `test-engineer`'s
  generate-verify loop before opening a PR for human review.
- **Validation** — a `SkillsBench` harness measures whether the curated
  library actually beats a primitives-only baseline that grows its own
  skills on demand. This is the kill-switch experiment: if full armory
  does not beat primitives + librarian by ≥15 percentage points, the
  curation thesis needs to be reconsidered.

10 commits, bisectable, no manifest churn between them except the final
`chore(manifest)` commit.

## Motivation

Armory already had most of Memento-Skills' static ingredients (a curated
skill library, typed auto-memory, the `immune` cheatsheet + antibody
pattern). The missing piece was the *closed loop* — the write phase that
lets the library grow from experience without a human noticing a gap and
kicking off `paper-to-skill` manually. This PR closes that loop and adds
the retrieval-side primitives the router needs to be outcome-weighted
rather than description-matched.

The integration is structured as six phases (P0–P5) against a kill-switch
(SkillsBench bootstrap benchmark) that gates productionization on real
efficacy, not just shipped code. See the \`MEMENTO_SKILLS_PLAN.md\`
working doc in the author's local tree for the full phase structure; this
PR delivers phases 0–5 in code form.

## Commits (logical / dependency order)

| # | Commit | Scope |
|---|---|---|
| 1 | \`feat(scripts): add task_signature utility for prompt normalization\` | Shared task-identity primitive: stopword removal, lemmatization-lite, jaccard helper. 18 tests incl. cluster coherence. |
| 2 | \`feat(evals): append per-case history log with PII scrubbing\` | \`evals/history.jsonl\` append-only log alongside existing snapshot. Stores task signature + SHA-256 prompt hash, never raw prompts. 12 tests. |
| 3 | \`feat(immune): add task-conditioned retrieval (v3.1.0)\` | Optional \`triggers\` field on antibodies/strategies, back-compat with v3.0.0. New \`skills/immune/scripts/retrieve.py\` with domain + signature scoring. 19 tests. |
| 4 | \`feat(agents): add skill-librarian reflective write-phase agent\` | New Sonnet-class orchestrator \`agents/skill-librarian/\`. Pairs with test-engineer via an explicit ownership rule (librarian drafts only, test-engineer refines only). |
| 5 | \`feat(scripts): add router index builder from eval history\` | \`scripts/build_router_index.py\` aggregates history.jsonl by task signature, ranks packages by pass rate. 15 tests. |
| 6 | \`feat(agents): add skill-router outcome-weighted package selector\` | New Haiku-class leaf agent \`agents/skill-router/\` reading \`dist/router_index.json\`. Falls back to \`/route\` when index missing or low confidence. |
| 7 | \`feat(evals): add SkillsBench bootstrap benchmark harness\` | New \`evals/skillsbench/\` with schema + 5 seed tasks, \`scripts/run_skillsbench.py\` runner, \`--live\` gate, \`--compare\` for S3 verdict. 23 tests. |
| 8 | \`ci(workflows): add nightly router-index rebuild\` | \`.github/workflows/router-index.yml\` — 03:15 UTC cron + path-triggered rebuild, uploads index as 14-day artifact, warns when below 500-entry confidence gate. |
| 9 | \`docs: attribute Memento-Skills and document integration\` | Paper attribution in \`ATTRIBUTIONS.md\`, research-lineage note in \`README.md\`, task-conditioned entries section in \`CONTRIBUTING.md\`. |
| 10 | \`chore(manifest): regenerate for new memento-skills agents\` | Agent count 15 → 17. Final commit satisfies the evals workflow manifest-sync gate. |

## What changes for users

**Package authors**
- Immune antibodies and cheatsheet strategies may now carry an optional
  \`triggers: {task_signatures: [...], domains: [...]}\` field for
  per-task filtering. Entries without \`triggers\` keep v3.0.0 behavior.
  See the new **Task-Conditioned Entries** section in \`CONTRIBUTING.md\`.

**Operators**
- \`scripts/run_evals.py\` now appends to \`evals/history.jsonl\` on every
  run (opt out with \`--no-history\`). Raw prompts are never stored; only
  task signatures and prompt hashes.
- A new \`skill-librarian\` agent is available via explicit
  \`/librarian review\` — **no auto-trigger by default**. An optional
  Stop-hook registration pattern is documented in the agent but not wired.
- A new \`skill-router\` agent consults \`dist/router_index.json\` when
  called; without a populated index (first ~2 weeks of CI accumulation),
  the router defers to the existing \`/route\` static decision tree.
- The \`SkillsBench\` harness under \`evals/skillsbench/\` is dry-run by
  default; the \`--live\` flag is required to actually burn API budget.

**Test-engineer agent**
- A new Rule 11 documents the **ownership boundary** with skill-librarian:
  librarian drafts only, test-engineer refines only. Conflicts are
  prevented via the \`evoskills-in-progress\` PR label.

## Testing

- **Full suite: 300 / 300 passing** (87 new tests added).
- No regressions on the 215 pre-existing tests.
- \`uv run python scripts/validate_evals.py\` — all 7 package types pass.
- \`uv run python scripts/generate_manifest.py\` — manifest in sync.
- \`uv run python scripts/run_skillsbench.py --all --dry-run\` — 5 seed
  tasks load and validate; no live \`claude -p\` execution required for CI.

New test files:
\`\`\`
tests/test_task_signature.py            18 tests
tests/test_run_evals_history.py         12 tests
tests/test_immune_retrieve.py           19 tests
tests/test_build_router_index.py        15 tests
tests/test_run_skillsbench.py           23 tests
\`\`\`

## Exit criteria (plan reference)

| ID | Criterion | Status |
|---|---|---|
| S1 | Immune task-conditioned retrieval precision ≥70% | ✅ Cluster coherence test at ≥80% on hand-labeled corpus. Real-world precision measurable after operators tag entries. |
| S2 | Skill-librarian draft acceptance ≥40% first try | ⏳ Measurable only after the librarian opens real PRs and humans apply \`librarian-approve\` |
| **S3** | **Config A beats Config B by ≥15pp on SkillsBench** | ❌ **Deferred — harness is ready, requires a multi-hour \`--live\` run** |
| **S4** | **Router ≥2× token reduction at equal pass rate** | ❌ **Deferred — blocked on ≥500 \`history.jsonl\` entries (~2 weeks of CI accumulation)** |
| S5 | No regression on existing test suite | ✅ 300/300 green |

**Important:** this PR is *code complete* but *not validated*. S3 is the
plan's kill-switch and requires live benchmark execution to clear. The
integration should be treated as a plausible hypothesis that the codebase
is ready to test, not a proven win, until S3 has been cleared.

## Reviewer guide

Suggested review order (mirrors the commit order and minimizes
back-referencing):

1. **Commit 1** — \`scripts/task_signature.py\`: understand the shared
   primitive before reviewing any consumer.
2. **Commit 2** — \`scripts/run_evals.py\` diff: see how history is
   appended and why PII scrubbing is mandatory, not optional.
3. **Commit 3** — \`skills/immune/scripts/retrieve.py\` + \`SKILL.md\`
   diff: the back-compat story is in the prose, the scoring is in the
   code.
4. **Commit 4** — \`agents/skill-librarian/AGENT.md\` + test-engineer
   ownership rule: review both sides of the boundary simultaneously.
5. **Commits 5 + 6 together** — the router builder and agent are
   mechanically paired. Read them as one unit.
6. **Commit 7** — \`scripts/run_skillsbench.py\`: note the pure-logic vs
   live-execution split. Tests only cover pure logic; live execution is
   gated behind \`--live\`.
7. **Commit 8** — the CI workflow. Short.
8. **Commits 9 + 10** — docs and manifest. Skim.

Things to look at specifically:

- **Is the \`triggers\` schema in \`skills/immune/SKILL.md\` strictly
  additive?** (Commit 3.) Existing memory files must keep working.
- **Does the ownership boundary in commit 4 actually hold in practice?**
  The librarian and test-engineer agents both document it, but no test
  exercises concurrent runs. Acceptable for now, worth a follow-up.
- **Is the S4 gate wired correctly in the workflow?** (Commit 8.) The
  warning annotation on \`< 500\` entries is load-bearing for router
  trust signals.
- **Do the 5 seed tasks exercise enough of the assertion-scoring
  surface?** (Commit 7.) Running the full 50-task benchmark before
  expanding the seed set would be premature.

## Deferred / follow-up items

- Run the SkillsBench seed set live once with \`--live --config A\` to
  calibrate per-task wall clock (~15 min, ~\$1–3 budget).
- Expand the SkillsBench task set from 5 to ~50 before a verdict-bearing
  run. Plan calls for 50 synthetic + GAIA sampling; GAIA is deferred.
- Add \`--merge\` and \`--skip-existing\` to \`run_skillsbench.py\` before
  any multi-hour sweep (needed for resume + partial-file aggregation).
- Monitor router index growth; once \`history.jsonl\` crosses 500
  entries, re-evaluate whether the router should delegate to \`/route\`
  by default or lead.

## Test plan

- [ ] Review the \`triggers\` schema addition in \`skills/immune/SKILL.md\` for back-compat correctness
- [ ] Verify \`evals/history.jsonl\` is not created during dry runs
- [ ] Run \`uv run pytest\` and confirm 300/300 pass locally
- [ ] Run \`uv run python scripts/run_skillsbench.py --all --dry-run\` and confirm 5 tasks load
- [ ] Run \`uv run python scripts/validate_evals.py\` and confirm 17 agents validated
- [ ] Spot-check that \`manifest.yaml\` shows \`skill-librarian\` and \`skill-router\` with correct model assignments (sonnet / haiku)
- [ ] Confirm \`MEMENTO_SKILLS_PLAN.md\` and \`SKILLSBENCH_EXECUTION_NOTES.md\` (author's local working docs) are **not** in the PR diff — they are intentional orphans
- [ ] Decide on the optional Stop-hook wiring before merge (default: leave unwired)