### PR TITLE
fix(ci): repair router index summary step quoting

### DIFF
--- a/.github/workflows/router-index.yml
+++ b/.github/workflows/router-index.yml
@@ -45,16 +45,18 @@ jobs:
         run: |
           echo "### Router Index Rebuild" >> "$GITHUB_STEP_SUMMARY"
           if [ -f dist/router_index.json ]; then
-            python -c '
-          import json, pathlib
+            python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import pathlib
+
           data = json.loads(pathlib.Path("dist/router_index.json").read_text())
           meta = data["metadata"]
-          print(f"- Built at: {meta[\"built_at\"]}")
-          print(f"- Source entries: {meta[\"source_entries\"]}")
-          print(f"- Unique signatures: {meta[\"unique_signatures\"]}")
-          print(f"- Unique packages: {meta[\"unique_packages\"]}")
-          print(f"- Min samples: {meta[\"min_samples\"]}")
-            ' >> "$GITHUB_STEP_SUMMARY"
+          print(f"- Built at: {meta['built_at']}")
+          print(f"- Source entries: {meta['source_entries']}")
+          print(f"- Unique signatures: {meta['unique_signatures']}")
+          print(f"- Unique packages: {meta['unique_packages']}")
+          print(f"- Min samples: {meta['min_samples']}")
+          PY
           else
             echo "- Index build failed." >> "$GITHUB_STEP_SUMMARY"
             exit 1


### PR DESCRIPTION
## Summary

CI run [24215707813](https://github.com/Mathews-Tom/armory/actions/runs/24215707813/job/70695596474) failed on the \`Summary\` step of \`.github/workflows/router-index.yml\` with:

\`\`\`
File \"<string>\", line 5
    print(f\"- Built at: {meta[\\\"built_at\\\"]}\")
                               ^
SyntaxError: unexpected character after line continuation character
\`\`\`

### Root cause

The step invoked \`python -c '...'\` inside a single-quoted shell string containing \`meta[\\\"built_at\\\"]\`. Bash passed the backslashes through verbatim, so Python parsed \`\\\"\` as a source-level line-continuation token followed by a bare quote. PEP 701 (Python 3.12) lifted the restriction on backslashes inside f-string *expressions*, but \`\\\"\` is still a line-continuation token at the tokenizer level — relaxing the f-string rules does not rescue this snippet.

### Fix

- Switch from \`python -c '...'\` to a \`python - <<'PY' ... PY\` heredoc so the Python source is passed literally and no shell escaping is involved.
- Use single-quoted dict key access inside the f-strings (\`meta['built_at']\` instead of \`meta[\\\"built_at\\\"]\`).

### Verification

Reproduced the \`run:\` block in a local bash shell against a synthetic \`dist/router_index.json\` (\`bash -e <<'SCRIPT' ... SCRIPT\`) and confirmed the heredoc executes cleanly and writes the expected lines to \`\$GITHUB_STEP_SUMMARY\`:

\`\`\`
### Router Index Rebuild
- Built at: 2026-04-09T00:00:00Z
- Source entries: 10
- Unique signatures: 8
- Unique packages: 4
- Min samples: 3
\`\`\`

## Test plan

- [ ] Re-run the \`Router Index Rebuild\` workflow on this branch and confirm the \`Summary\` step exits 0.
- [ ] Verify the GitHub Actions step summary panel shows the five metadata lines.