### PR TITLE
feat(concept-to-video): agentic mode — storyboard planner, render auto-fix, VLM critic

### DIFF
--- a/agents/skill-librarian/AGENT.md
+++ b/agents/skill-librarian/AGENT.md
@@ -4,19 +4,16 @@ type: agent
 description:
   'Reflective write-phase orchestrator that observes completed task transcripts
   and proposes additions or augmentations to the armory skill library. Implements
-  the write phase of the Memento-Skills reflective loop (arXiv 2603.18743): given
-  a conversation where novel problem-solving occurred, classify whether an existing
-  skill handled it, an existing skill needs augmentation, or no skill existed and
-  a new one should be drafted. Routes drafts through paper-to-skill''s specification
-  stage and test-engineer''s generate-verify loop, gates on package-evaluator,
-  and opens a pull request tagged for human review. Triggers on: "librarian review",
+  the write phase of the Memento-Skills reflective loop (arXiv 2603.18743):
+  classifies a conversation as handled by an existing skill, needing augmentation,
+  or requiring a new draft. Routes drafts through paper-to-skill''s specification
+  stage and test-engineer''s generate-verify loop, gates on package-evaluator, and
+  opens a pull request tagged for human review. Triggers on: "librarian review",
   "review this transcript for new skills", "propose a skill from this conversation",
-  "draft skill from transcript", "what skills did we just use", "catalog this workflow",
-  "suggest skill addition", "analyze conversation for skill gaps", "skill-librarian",
-  "reflective skill review". NOT for refining existing skills that are already in
-  progress (use test-engineer directly). NOT for wholesale library reorganization
-  (that is a human decision). NOT for creating skills from research papers (use
-  paper-to-skill directly).
+  "draft skill from transcript", "catalog this workflow", "suggest skill addition",
+  "analyze conversation for skill gaps", "reflective skill review". NOT for
+  refining in-progress skills (use test-engineer directly) or creating skills from
+  research papers (use paper-to-skill directly).
 
   '
 model: sonnet

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -190,7 +190,7 @@ packages:
     category: business
     difficulty: intermediate
   - name: concept-to-video
-    version: 1.1.1
+    version: 1.2.0
     description: 'Turn any concept into an animated explainer video using Manim (Python). Use whenever the user wants animated
       visualizations, motion graphics, or video output (MP4/GIF) for technical concepts. Covers: architecture animations,
       data flows, algorithm step-throughs, pipeline explainers, math proofs, comparisons, agent interactions, training loops,

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1419,15 +1419,13 @@ packages:
   - name: skill-librarian
     version: 1.0.0
     description: 'Reflective write-phase orchestrator that observes completed task transcripts and proposes additions or augmentations
-      to the armory skill library. Implements the write phase of the Memento-Skills reflective loop (arXiv 2603.18743): given
-      a conversation where novel problem-solving occurred, classify whether an existing skill handled it, an existing skill
-      needs augmentation, or no skill existed and a new one should be drafted. Routes drafts through paper-to-skill''s specification
-      stage and test-engineer''s generate-verify loop, gates on package-evaluator, and opens a pull request tagged for human
-      review. Triggers on: "librarian review", "review this transcript for new skills", "propose a skill from this conversation",
-      "draft skill from transcript", "what skills did we just use", "catalog this workflow", "suggest skill addition", "analyze
-      conversation for skill gaps", "skill-librarian", "reflective skill review". NOT for refining existing skills that are
-      already in progress (use test-engineer directly). NOT for wholesale library reorganization (that is a human decision).
-      NOT for creating skills from research papers (use paper-to-skill directly).'
+      to the armory skill library. Implements the write phase of the Memento-Skills reflective loop (arXiv 2603.18743): classifies
+      a conversation as handled by an existing skill, needing augmentation, or requiring a new draft. Routes drafts through
+      paper-to-skill''s specification stage and test-engineer''s generate-verify loop, gates on package-evaluator, and opens
+      a pull request tagged for human review. Triggers on: "librarian review", "review this transcript for new skills", "propose
+      a skill from this conversation", "draft skill from transcript", "catalog this workflow", "suggest skill addition", "analyze
+      conversation for skill gaps", "reflective skill review". NOT for refining in-progress skills (use test-engineer directly)
+      or creating skills from research papers (use paper-to-skill directly).'
     path: agents/skill-librarian
     source: https://github.com/Mathews-Tom/armory/blob/main/agents/skill-librarian/AGENT.md
     model: sonnet

--- a/skills/concept-to-video/SKILL.md
+++ b/skills/concept-to-video/SKILL.md
@@ -15,7 +15,7 @@ description:
 
   '
 metadata:
-  version: 1.1.1
+  version: 1.2.0
   category: visualization
   tags: [video, manim, animation, explainer]
   difficulty: advanced
@@ -265,6 +265,76 @@ If LaTeX is not available, avoid `MathTex` and `Tex`. Use `Text` with Unicode ma
 # Instead of: MathTex(r"\frac{1}{n} \sum_{i=1}^{n} x_i")
 # Use:        Text("(1/n) Σ xᵢ", font_size=36)
 ```
+
+## Agentic Mode (Opt-In)
+
+Single-shot mode (default) is fast and cheap — the coder writes scene.py directly from a concept. Use agentic mode for production-quality renders where layout correctness and asset resolution matter enough to justify additional LLM and VLM calls.
+
+### Pipeline
+
+```
+concept
+  └─► plan_storyboard.py ──► storyboard.json
+            │
+            ▼
+      fetch_assets.py (optional)
+            │
+            ▼
+      coder writes scene.py
+            │
+            ▼
+      render_video.py --max-fix-attempts N
+            │  ▲
+            │  └─ LLM fixup loop (on failure, up to N retries)
+            ▼
+      critic_pass.py --critic
+            │  ▲
+            │  └─ VLM layout patch (1 call with M image blocks)
+            ▼
+       final MP4
+```
+
+### Flag Reference
+
+| Script            | Flag                  | Default     | Hard cap | Effect                                                        | Cost impact                                    |
+| ----------------- | --------------------- | ----------- | -------- | ------------------------------------------------------------- | ---------------------------------------------- |
+| `render_video.py` | `--max-fix-attempts`  | `0`         | `3`      | LLM-assisted auto-fix on render failure; 0 = disabled         | +1 LLM call per retry                          |
+| `critic_pass.py`  | `--critic`            | disabled    | —        | Enable the VLM critic pass; noop without this flag            | +1 VLM call (N image blocks)                   |
+| `critic_pass.py`  | `--critic-budget`     | `50000`     | —        | Token budget for critic call; aborts loudly if exceeded       | Sets ceiling; use to prevent runaway spend     |
+| `critic_pass.py`  | `--frames`            | `5`         | `10`     | Frames sampled from the rendered video for the critic         | More frames → higher token cost per critic run |
+| `fetch_assets.py` | `--adapter`           | `none`      | —        | Asset backend: `local`, `iconfinder`, `none`                  | `iconfinder` adds external API calls           |
+| `fetch_assets.py` | `--asset-dir`         | —           | —        | Root directory for `--adapter=local`; required with local     | None                                           |
+
+### Cost Tradeoffs
+
+The fixup loop adds one LLM call per failed render attempt — with `--max-fix-attempts 3` you may pay up to 3 extra calls before the loop exhausts or succeeds. The critic pass adds one VLM call containing N PNG image blocks (default 5, max 10); each frame adds roughly 1 token per 800 bytes of base64-encoded PNG, so complex scenes at high resolution are materially more expensive. Setting `--critic-budget` to a conservative token ceiling (e.g. `20000`) causes `BudgetExceededError` before the API call is made, so you never pay for an accidentally oversized request — the error is loud and non-recoverable by design.
+
+### Invocation Example
+
+```bash
+# 1. Plan
+python3 scripts/plan_storyboard.py "explain transformer self-attention" \
+    --output storyboard.json
+
+# 2. (Optional) Fetch assets
+python3 scripts/fetch_assets.py storyboard.json \
+    --adapter local --asset-dir ./assets --output resolved.json
+
+# 3. Coder writes scene.py (Claude writes this from storyboard.json)
+
+# 4. Render with auto-fix
+python3 scripts/render_video.py scene.py AttentionScene \
+    --quality high --format mp4 --max-fix-attempts 3 \
+    --output final.mp4
+
+# 5. Critic pass
+python3 scripts/critic_pass.py scene.py final.mp4 \
+    --critic --critic-budget 40000 --frames 5
+```
+
+### Attribution
+
+Agentic pipeline design (storyboard planner, auto-fix loop, VLM critic) is adapted from Code2Video (arXiv 2510.01174, MIT). See [`references/code2video/ATTRIBUTION.md`](references/code2video/ATTRIBUTION.md) for vendoring details and re-sync policy.
 
 ## Limitations
 

--- a/skills/concept-to-video/evals/cases.yaml
+++ b/skills/concept-to-video/evals/cases.yaml
@@ -58,3 +58,106 @@ cases:
     rubric:
       - "static images are outside concept-to-video scope which produces animated video output"
     trigger_expected: false
+
+  - id: autofix_recovery_name_error
+    prompt: "Render the provided scene with --max-fix-attempts 2; the scene has an undefined symbol 'undefined_mobject' that causes a NameError on first render."
+    fixtures: []
+    rubric:
+      - "invokes render_video.py with --max-fix-attempts 2"
+      - "auto-fix loop patches the NameError within 2 attempts"
+      - "render exits with code 0"
+      - "final output MP4 file exists on disk"
+      - ".render-log.jsonl exists and contains exactly 1 entry"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "--max-fix-attempts"
+        weight: 1.0
+      - type: matches_regex
+        target: "(render-log\\.jsonl|autofix|auto.fix)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(exit.0|returncode.*0|succeeded)"
+        weight: 0.8
+
+  - id: autofix_recovery_off_canvas
+    prompt: "Render a scene where a mobject is placed at coordinates (10, 0) — outside the 14.2×8 Manim canvas — using --max-fix-attempts 2. The auto-fix loop should reposition it within bounds."
+    fixtures: []
+    rubric:
+      - "identifies the off-canvas placement as the render defect"
+      - "invokes render_video.py with --max-fix-attempts 2"
+      - "patched scene positions the mobject within ±6 horizontal / ±3.5 vertical"
+      - "render exits with code 0"
+      - ".render-log.jsonl records the repositioning edit in diff_summary"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "--max-fix-attempts"
+        weight: 1.0
+      - type: matches_regex
+        target: "(reposition|shift|move_to|next_to|within.bound)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(render-log\\.jsonl|diff_summary)"
+        weight: 0.7
+
+  - id: autofix_exhaustion
+    prompt: "Render a permanently broken scene (syntax error that cannot be fixed by patching) with --max-fix-attempts 3. Expect non-zero exit after all attempts are exhausted."
+    fixtures: []
+    rubric:
+      - "runs render_video.py with --max-fix-attempts 3"
+      - "all 3 attempts fail and the original error is surfaced"
+      - "process exits with a non-zero exit code"
+      - ".render-log.jsonl contains exactly 3 entries"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "--max-fix-attempts.*3|3.*--max-fix-attempts"
+        weight: 1.0
+      - type: matches_regex
+        target: "(exhausted|non.zero|exit code [^0]|returncode [^0])"
+        weight: 0.9
+      - type: matches_regex
+        target: "(render-log\\.jsonl|3 entr)"
+        weight: 0.8
+
+  - id: critic_driven_layout_fix
+    prompt: "Run the VLM critic pass on a scene where a label Text object overlaps a Rectangle mobject. Use --critic --critic-budget 20000. Expect the critic to return a non-empty patches array with an anchor-based fix."
+    fixtures: []
+    rubric:
+      - "invokes critic_pass.py with --critic and --critic-budget 20000"
+      - "critic identifies the text-over-rectangle overlap"
+      - "patches array is non-empty"
+      - "patch uses an anchor constraint (next_to or to_edge) to resolve the overlap"
+      - "patched scene file is written and renders successfully"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "--critic"
+        weight: 1.0
+      - type: matches_regex
+        target: "--critic-budget.*20000|20000.*--critic-budget"
+        weight: 0.9
+      - type: matches_regex
+        target: "(patches|anchor_constraint|next_to|to_edge)"
+        weight: 0.9
+
+  - id: critic_budget_abort
+    prompt: "Run critic_pass.py with --critic --critic-budget 100 on any rendered scene. The budget is unreachably low; expect BudgetExceededError, zero API calls made, and a non-zero exit code."
+    fixtures: []
+    rubric:
+      - "invokes critic_pass.py with --critic --critic-budget 100"
+      - "raises BudgetExceededError before making any API call"
+      - "no Anthropic API calls are made"
+      - "process exits with a non-zero exit code"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "--critic-budget.*100|100.*--critic-budget"
+        weight: 1.0
+      - type: matches_regex
+        target: "(BudgetExceededError|budget.*exceeded|exceeded.*budget)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(non.zero|exit code [^0]|returncode [^0]|no API call)"
+        weight: 0.8

--- a/skills/concept-to-video/pyrightconfig.json
+++ b/skills/concept-to-video/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": ["scripts", "tests"],
+  "extraPaths": ["scripts"],
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "strict",
+  "reportMissingImports": "error"
+}

--- a/skills/concept-to-video/references/code2video/ATTRIBUTION.md
+++ b/skills/concept-to-video/references/code2video/ATTRIBUTION.md
@@ -1,0 +1,63 @@
+# Attribution — Code2Video
+
+## Paper
+
+**Title:** Code2Video: A Code-Centric Paradigm for Educational Video Generation
+**Authors:** Anno Yanzhe Chen et al., Show Lab, National University of Singapore
+**Venue:** NeurIPS 2025 Workshop on Deep Learning for Code (DL4C)
+**arXiv:** https://arxiv.org/abs/2510.01174
+**arXiv ID:** 2510.01174
+
+## Upstream Repository
+
+**URL:** https://github.com/showlab/Code2Video
+**License:** MIT (see LICENSE in this directory)
+**Pinned commit:** `f579f1e527f9d6684eb581853f8739b6b39f2914`
+
+## What We Vendored
+
+Prompt logic only — no code was copied. The three prompt templates in this directory
+(`planner.md`, `coder.md`, `critic.md`) are adapted from the following upstream files,
+with variable names and output schemas rewritten for Armory's `concept-to-video` schema:
+
+| Armory file  | Upstream source(s)                                   |
+|--------------|------------------------------------------------------|
+| planner.md   | `prompts/stage1.py`, `prompts/stage2.py`             |
+| coder.md     | `prompts/stage3.py`                                  |
+| critic.md    | `prompts/stage4.py`                                  |
+
+The upstream repo structures prompts as Python functions returning f-strings. We extracted
+the prompt text, adapted variable names to match our schema, and reformatted as markdown
+template files. No upstream Python code is included.
+
+## What We Reimplemented
+
+The following patterns are described in the paper and reimplemented independently from
+scratch — no upstream code was copied:
+
+- **Auto-fix loop** (paper §3.3): captures `manim render` stderr, extracts offending line
+  range, calls the coder fixup prompt, patches the scene file in-place, retries up to N
+  times. Our version lives in `scripts/render_video.py` and uses Python `subprocess`.
+- **VLM critic loop** (paper §3.4): samples rendered frames, sends to a vision model with
+  the critic prompt, receives anchor-based layout patches, re-renders. Our version calls
+  Claude vision or Gemini via the existing Anthropic SDK — not Code2Video's custom wrapper.
+
+## What We Skipped
+
+The following upstream components were intentionally excluded:
+
+- **MMMC benchmark** (`eval_TQ.py`, `eval_AES.py`): research evaluation harness, not
+  relevant to a production skill. Would belong in `evals/skillsbench/` if ever adopted.
+- **TeachQuiz metric**: research artifact — no end-user value.
+- **IconFinder integration**: broke October 2025 per the upstream README. Replaced by the
+  pluggable asset sourcing design in P4 (`scripts/fetch_assets.py`), which defaults to
+  local SVG directories with IconFinder as an optional API-key-gated adapter.
+- **Shell entry points** (`run_agent.sh`, `run_agent_single.sh`): our entry point is the
+  SKILL.md workflow, not shell scripts.
+- **3D ThreeDScene support**: excluded upstream and here; unreliable in headless containers.
+
+## Re-sync Policy
+
+These prompt templates are pinned to the commit SHA above. Re-sync opportunistically when
+the upstream repo makes substantive prompt changes — do not auto-update. Compare diffs
+against the pinned commit before merging any upstream changes.

--- a/skills/concept-to-video/references/code2video/LICENSE
+++ b/skills/concept-to-video/references/code2video/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Anno Yanzhe Chen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/concept-to-video/references/code2video/coder.md
+++ b/skills/concept-to-video/references/code2video/coder.md
@@ -1,0 +1,173 @@
+# Coder Prompt Template
+
+Adapted from Code2Video `prompts/stage3.py` (commit `f579f1e`).
+Variable names rewritten for Armory's concept-to-video schema.
+
+---
+
+## Purpose
+
+Generate a single Manim `Scene` subclass for one scene from the storyboard. Each call
+produces one Python file that can be rendered independently with `manim render`. The
+fixup variant (second template below) patches a scene file that failed to render.
+
+---
+
+## Input Variables
+
+### Generation variant
+
+| Variable        | Type   | Description                                               |
+|-----------------|--------|-----------------------------------------------------------|
+| `{storyboard}`  | JSON   | Full storyboard object from the Planner stage             |
+| `{scene_index}` | int    | Zero-based index into `storyboard.scenes`                 |
+
+### Fixup variant
+
+| Variable          | Type   | Description                                              |
+|-------------------|--------|----------------------------------------------------------|
+| `{scene_file}`    | string | Full Python source of the failing scene                  |
+| `{error_stderr}`  | string | Complete stderr captured from `manim render`             |
+| `{offending_lines}` | string | Extracted line range around the error (format: `L12-L18`) |
+
+---
+
+## Output Format
+
+### Generation variant
+
+Return only raw Python source. No markdown fences, no prose, no imports other than
+`from manim import *`. The class must:
+
+- Be named `Scene{scene_index + 1}` (e.g., `Scene1`, `Scene2`).
+- Subclass `Scene`.
+- Implement `def construct(self):` with all animation logic.
+- Use only the 6×6 grid positioning system described in the System Instructions.
+
+### Fixup variant
+
+Return only the full corrected Python source of the scene file. Apply minimal changes —
+fix only the lines identified in `{offending_lines}` plus any cascade errors they cause.
+Do not restructure the file.
+
+---
+
+## System Instructions
+
+You are an expert Manim Community Edition v0.19.0 animator. Generate or fix Manim scenes
+that render cleanly in headless containers.
+
+### Layout grid
+
+Use a 6×6 logical grid occupying the right two-thirds of the frame. The left third is
+reserved for lecture lines. Grid coordinates are `A1`–`F6` (row A = top, column 1 = left).
+
+```
+lecture |  A1  A2  A3  A4  A5  A6
+        |  B1  B2  B3  B4  B5  B6
+        |  C1  C2  C3  C4  C5  C6
+        |  D1  D2  D3  D4  D5  D6
+        |  E1  E2  E3  E4  E5  E6
+        |  F1  F2  F3  F4  F5  F6
+```
+
+Position all animation objects with grid methods only:
+
+- Single-cell: `self.place_at_grid(obj, 'B2', scale_factor=0.8)`
+- Multi-cell area: `self.place_in_area(obj, 'A1', 'C3', scale_factor=0.7)`
+
+Never use `.to_edge()`, `.move_to()`, or raw coordinate tuples for layout.
+
+### Mandatory rules
+
+1. Background: `#000000`. All text and objects use light, high-contrast hex colors.
+2. Lecture lines: render as a left-column list. Apply color changes only — no scale,
+   translate, or Transform animations on lecture lines. Size and position are fixed.
+3. Each beat in the scene has a corresponding `# === Animation for Beat N ===` comment
+   block in `construct()`.
+4. No 3D objects (`ThreeDScene`, `Surface`, `ParametricSurface`).
+5. No external file dependencies unless an asset path is explicitly provided in the
+   scene's `assets` field as `[Asset: path/to/file.png]`.
+6. Use only basic, well-tested Manim classes: `Text`, `MathTex`, `Circle`, `Square`,
+   `Arrow`, `Line`, `VGroup`, `FadeIn`, `FadeOut`, `Create`, `Write`, `Transform`,
+   `Indicate`, `Flash`, `Circumscribe`.
+7. All labels must stay within 1 grid unit of their associated objects.
+8. Elements that are no longer relevant must `FadeOut` before the next beat.
+
+### Fixup rules
+
+1. Fix only the lines in `{offending_lines}`. Do not refactor unrelated code.
+2. Prefer simpler Manim patterns over the failing pattern — downgrade to a basic
+   equivalent if the original approach is unreliable.
+3. Return the complete corrected file — not a diff.
+
+---
+
+## Example Input (generation)
+
+```json
+{
+  "storyboard": { "topic": "Dijkstra's Shortest Path Algorithm", "scenes": ["..."] },
+  "scene_index": 1
+}
+```
+
+Scene 2 beats:
+```
+["Start: all distances set to infinity",
+ "Visit unvisited node with smallest distance",
+ "Relax neighbors if shorter path found",
+ "Mark visited nodes as finalized",
+ "Repeat until destination reached"]
+```
+
+## Example Output (generation, abbreviated)
+
+```python
+from manim import *
+
+class Scene2(Scene):
+    def construct(self):
+        self.camera.background_color = "#000000"
+
+        beats = [
+            "Start: all distances set to infinity",
+            "Visit unvisited node with smallest distance",
+            "Relax neighbors if shorter path found",
+            "Mark visited nodes as finalized",
+            "Repeat until destination reached",
+        ]
+        lecture_lines = VGroup(*[
+            Text(b, font_size=18, color=WHITE) for b in beats
+        ]).arrange(DOWN, aligned_edge=LEFT, buff=0.3).to_edge(LEFT, buff=0.3)
+        self.add(lecture_lines)
+
+        # === Animation for Beat 1 ===
+        nodes = VGroup(*[Circle(radius=0.3, color="#AAAAFF") for _ in range(4)])
+        nodes.arrange(RIGHT, buff=1.0)
+        self.place_in_area(nodes, 'B2', 'D5', scale_factor=0.9)
+        labels = VGroup(*[
+            Text("∞", font_size=20, color="#FFDD88").next_to(n, UP, buff=0.1)
+            for n in nodes
+        ])
+        self.play(Create(nodes), Write(labels))
+        lecture_lines[0].set_color("#AAFFAA")
+        self.wait(0.5)
+        # ... (remaining beats follow same pattern)
+```
+
+---
+
+## Example Input (fixup)
+
+```
+scene_file: <full Python source>
+error_stderr: "AttributeError: 'NoneType' object has no attribute 'get_center'\n  File scene2.py, line 34"
+offending_lines: "L32-L36"
+```
+
+## Example Output (fixup)
+
+Return the full corrected Python source with lines 32–36 patched to avoid the
+`NoneType` error — typically by ensuring the object is added to the scene before
+referencing its position.

--- a/skills/concept-to-video/references/code2video/critic.md
+++ b/skills/concept-to-video/references/code2video/critic.md
@@ -1,0 +1,143 @@
+# Critic Prompt Template
+
+Adapted from Code2Video `prompts/stage4.py` (commit `f579f1e`).
+Variable names rewritten for Armory's concept-to-video schema.
+
+---
+
+## Purpose
+
+Perform a visual layout audit on a rendered Manim scene. Given the scene source and a
+set of sampled frame images, identify spatial defects (overlaps, off-canvas elements,
+lecture-line occlusion) and return anchor-based edit instructions that the P3 critic
+pass applies to the scene file before re-rendering.
+
+---
+
+## Input Variables
+
+| Variable        | Type          | Description                                                          |
+|-----------------|---------------|----------------------------------------------------------------------|
+| `{scene_file}`  | string        | Full Python source of the rendered scene                             |
+| `{frame_paths}` | list[string]  | Absolute paths to sampled frame images (≤5 frames per scene)         |
+| `{scene_title}` | string        | Human-readable scene title (from storyboard)                         |
+| `{beats}`       | list[string]  | Ordered list of lecture beats for this scene                         |
+| `{grid_occupancy}` | JSON       | Current grid cell→mobject mapping (output of grid introspection pass) |
+
+---
+
+## Output Format
+
+Return a single JSON object. Do not include any text outside the JSON block.
+
+```json
+{
+  "layout": {
+    "has_issues": true,
+    "improvements": [
+      {
+        "problem": "string — concise description of the spatial defect",
+        "solution": "string — exact Python method call to fix it (place_at_grid or place_in_area)",
+        "line_number": 42,
+        "target_mobject": "string — variable name of the affected object in scene_file",
+        "anchor_constraint": "string — grid cell or range, e.g. 'C3' or 'A1:C3'",
+        "reason": "string — why this placement fixes the defect"
+      }
+    ]
+  }
+}
+```
+
+**Schema constraints:**
+
+- `has_issues`: `false` if no actionable layout defects found; `improvements` is empty.
+- `improvements`: maximum 3 entries — list only the defects that most impact visual
+  clarity. Do not list cosmetic preferences.
+- `line_number`: the line in `{scene_file}` where the positioning call should be inserted
+  or replaced. Must be a real line number from the provided source.
+- `solution`: must use only `self.place_at_grid(obj, 'XN', scale_factor=F)` or
+  `self.place_in_area(obj, 'XN', 'XN', scale_factor=F)`. No other positioning methods.
+- `anchor_constraint`: single cell (`'B3'`) for point objects and one-word labels;
+  cell range (`'A1:C3'`) for formulas, groups, and multi-word labels.
+- Do not suggest changes to lecture lines, title position, or font size.
+- Do not reference video timestamps.
+
+---
+
+## System Instructions
+
+You are a visual layout critic for Manim educational animations. Analyze the provided
+frame images and scene source strictly for spatial defects. Do not critique animation
+style, color choices, or pedagogical content.
+
+### Layout defects to check (in priority order)
+
+1. **Lecture occlusion**: animation objects overlapping the left-column lecture lines.
+   This is the highest-priority defect — lecture lines must always be fully visible.
+2. **Element overlap**: two or more animation objects (formulas, labels, shapes) occupy
+   the same screen region and obscure each other.
+3. **Off-canvas**: any element is partially or fully outside the visible frame boundary.
+   Pay special attention to long text labels and MathTex expressions.
+4. **Stale elements**: objects that should have faded out by a later beat but remain
+   visible and cause clutter.
+5. **Grid underutilization**: all objects are crammed into one quadrant while large grid
+   areas are empty — suggest redistribution only if it resolves an overlap.
+
+### Analysis method
+
+1. For each frame image, map visible objects to their approximate grid cells.
+2. Cross-reference with `{grid_occupancy}` to identify mismatches between intended and
+   actual placement.
+3. For each defect found, locate the corresponding positioning call in `{scene_file}`
+   using the line numbers.
+4. Produce a concrete replacement call with a grid cell that does not conflict with any
+   other object in `{grid_occupancy}`.
+5. Verify that proposed replacement cells are not already occupied — check all three
+   improvements against each other before emitting the JSON.
+
+### Hard constraints
+
+- Provide solutions only as `place_at_grid` or `place_in_area` calls.
+- Do not alter lecture lines, title, or background color.
+- Do not add new objects or remove existing objects — reposition only.
+- Do not suggest re-renders for non-layout issues (wrong colors, animation speed, etc.).
+
+---
+
+## Example Input
+
+```
+scene_title: "Greedy Relaxation Intuition"
+beats: ["Start: all distances set to infinity", "Visit unvisited node with smallest distance", ...]
+grid_occupancy: {"B2": "node_group", "C3": "dist_label_0", "C3": "dist_label_1"}
+frame_paths: ["/tmp/frames/scene2_f001.png", "/tmp/frames/scene2_f045.png"]
+scene_file: <full Python source>
+```
+
+## Example Output
+
+```json
+{
+  "layout": {
+    "has_issues": true,
+    "improvements": [
+      {
+        "problem": "dist_label_1 overlaps dist_label_0 at grid cell C3",
+        "solution": "self.place_at_grid(dist_label_1, 'D3', scale_factor=0.75)",
+        "line_number": 47,
+        "target_mobject": "dist_label_1",
+        "anchor_constraint": "D3",
+        "reason": "Moving dist_label_1 one row down clears the overlap while keeping it within 1 grid unit of its associated node"
+      },
+      {
+        "problem": "edge_weight_label extends into left lecture column",
+        "solution": "self.place_at_grid(edge_weight_label, 'B1', scale_factor=0.65)",
+        "line_number": 61,
+        "target_mobject": "edge_weight_label",
+        "anchor_constraint": "B1",
+        "reason": "Repositioning to B1 keeps the label inside the animation grid and away from lecture lines"
+      }
+    ]
+  }
+}
+```

--- a/skills/concept-to-video/references/code2video/planner.md
+++ b/skills/concept-to-video/references/code2video/planner.md
@@ -1,0 +1,143 @@
+# Planner Prompt Template
+
+Adapted from Code2Video `prompts/stage1.py` + `prompts/stage2.py` (commit `f579f1e`).
+Variable names rewritten for Armory's concept-to-video schema.
+
+---
+
+## Purpose
+
+Convert a free-text concept description into a structured storyboard JSON. The storyboard
+drives the Coder stage: each scene maps to one Manim `Scene` subclass. Produce a
+pedagogically ordered sequence — introduce prerequisites before core content, close with
+an application or summary scene.
+
+---
+
+## Input Variables
+
+| Variable        | Type   | Description                                                   |
+|-----------------|--------|---------------------------------------------------------------|
+| `{concept}`     | string | The educational concept to explain (e.g., "Dijkstra's algorithm") |
+| `{duration_min}`| int    | Target total video length in minutes (default: 5)             |
+
+---
+
+## Output Format
+
+Return a single JSON object. Do not include any text outside the JSON block.
+
+```json
+{
+  "topic": "string — canonical topic name",
+  "target_audience": "string — e.g., 'undergraduate CS students'",
+  "scenes": [
+    {
+      "id": "scene_1",
+      "title": "string — scene title, ≤8 words",
+      "beats": [
+        "string — one lecture beat, ≤10 words each"
+      ],
+      "assets": [
+        "string — concrete physical object keyword (lowercase, one word) OR empty array"
+      ]
+    }
+  ]
+}
+```
+
+**Schema constraints:**
+
+- `scenes`: 3–7 scenes for a 5-minute video; scale linearly with `{duration_min}`.
+- `beats`: 3 beats per standard scene; up to 5 beats for the core concept scene (mark at
+  most one scene as the key scene by giving it 5 beats).
+- `assets`: list real-world physical objects that need downloadable icons (animals,
+  devices, vehicles). Omit abstract concepts, shapes, and math symbols. Maximum 4 total
+  across all scenes, only in the first and last scene.
+- Background is always `#000000`; use light, high-contrast colors for all elements.
+- No 3D scenes. No coordinate axes unless the concept requires them explicitly.
+
+---
+
+## System Instructions
+
+You are an expert instructional designer and Manim animator. Produce storyboards that:
+
+1. Follow a progressive logical order — each scene builds on the previous one.
+2. Favor visual demonstrations over text-heavy explanations. Each beat must map to a
+   Manim animation, not a wall of text.
+3. Use concrete worked examples (not abstract diagrams alone) for mathematical concepts.
+4. Keep each beat under 10 words so it fits on-screen as a lecture line without wrapping.
+5. Do not reference external images, web URLs, or file paths in the storyboard — assets
+   are keywords only; the asset-sourcing pipeline resolves them.
+6. Output strict JSON. No markdown fences, no prose, no comments inside the JSON.
+
+---
+
+## Example Input
+
+```
+concept: "Dijkstra's shortest path algorithm"
+duration_min: 5
+```
+
+## Example Output
+
+```json
+{
+  "topic": "Dijkstra's Shortest Path Algorithm",
+  "target_audience": "undergraduate CS students",
+  "scenes": [
+    {
+      "id": "scene_1",
+      "title": "What is a Weighted Graph?",
+      "beats": [
+        "Nodes represent locations or states",
+        "Edges connect nodes with weights",
+        "Goal: find minimum-cost path"
+      ],
+      "assets": ["map"]
+    },
+    {
+      "id": "scene_2",
+      "title": "Greedy Relaxation Intuition",
+      "beats": [
+        "Start: all distances set to infinity",
+        "Visit unvisited node with smallest distance",
+        "Relax neighbors if shorter path found",
+        "Mark visited nodes as finalized",
+        "Repeat until destination reached"
+      ],
+      "assets": []
+    },
+    {
+      "id": "scene_3",
+      "title": "Step-by-Step Trace",
+      "beats": [
+        "Initialize source node distance to zero",
+        "Priority queue orders nodes by distance",
+        "Trace path A→C→D with cost 7"
+      ],
+      "assets": []
+    },
+    {
+      "id": "scene_4",
+      "title": "Complexity and Limitations",
+      "beats": [
+        "O((V + E) log V) with a min-heap",
+        "Fails with negative-weight edges"
+      ],
+      "assets": []
+    },
+    {
+      "id": "scene_5",
+      "title": "Real-World Navigation",
+      "beats": [
+        "GPS routing uses Dijkstra variants",
+        "Minimize travel time across road network"
+      ],
+      "assets": ["car"]
+    }
+  ]
+}
+```

--- a/skills/concept-to-video/references/storyboard-schema.md
+++ b/skills/concept-to-video/references/storyboard-schema.md
@@ -1,0 +1,101 @@
+# Storyboard JSON Schema
+
+Schema produced by `scripts/plan_storyboard.py` (Phase 1, Planner stage).
+Consumed by `scripts/critic_pass.py` (Phase 3) and `scripts/fetch_assets.py` (Phase 4).
+
+---
+
+## Top-level object
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `concept` | string (non-empty) | yes | The original concept text passed to the planner |
+| `duration_estimate_seconds` | number (> 0) | yes | Total estimated video duration in seconds |
+| `scenes` | array (non-empty) | yes | Ordered list of scenes |
+
+---
+
+## Scene object
+
+Each element of `scenes`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `index` | integer | yes | Zero-based scene index; must match position in array |
+| `title` | string (non-empty) | yes | Human-readable scene title |
+| `duration_seconds` | number (> 0) | yes | Estimated duration for this scene in seconds |
+| `beats` | array of strings (non-empty) | yes | Narrative or visual beats to animate; at least one entry |
+| `assets` | array of Asset objects | yes | Assets required for this scene; may be empty list |
+
+---
+
+## Asset object
+
+Each element of a scene's `assets`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | `"icon"` \| `"image"` \| `"text"` | yes | Asset category |
+| `query` | string (non-empty) | yes | Search query or literal text for the asset |
+| `required` | boolean | yes | Whether the asset is required for the scene to render |
+
+---
+
+## Example
+
+```json
+{
+  "concept": "How TCP/IP handshake works",
+  "duration_estimate_seconds": 90,
+  "scenes": [
+    {
+      "index": 0,
+      "title": "Introduction",
+      "duration_seconds": 15,
+      "beats": [
+        "Show two computers on screen",
+        "Introduce the question: how do they connect?"
+      ],
+      "assets": [
+        {"kind": "icon", "query": "computer server", "required": true},
+        {"kind": "text", "query": "TCP/IP Handshake", "required": true}
+      ]
+    },
+    {
+      "index": 1,
+      "title": "SYN packet",
+      "duration_seconds": 20,
+      "beats": [
+        "Client sends SYN packet to server",
+        "Animate arrow from client to server with label SYN"
+      ],
+      "assets": [
+        {"kind": "icon", "query": "network arrow", "required": false},
+        {"kind": "text", "query": "SYN", "required": true}
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Validation rules (enforced by `validate_storyboard`)
+
+1. All required fields must be present; missing fields raise `ValueError` with the dot-separated field path.
+2. `concept` and `title` must be non-empty strings after stripping whitespace.
+3. `duration_estimate_seconds` and `duration_seconds` must be positive numbers.
+4. `scenes` must contain at least one scene.
+5. `beats` must contain at least one string entry per scene.
+6. `kind` must be exactly one of `"icon"`, `"image"`, `"text"`.
+7. `query` must be a non-empty string.
+8. `required` must be a JSON boolean (`true`/`false`), not a string.
+
+---
+
+## Notes for downstream consumers
+
+- `index` is informational; consumers must not assume gaps are absent. Validate by iterating `scenes` in array order.
+- `assets` may be an empty list if the scene requires no external assets (text-only animation).
+- `duration_estimate_seconds` at the top level may differ from the sum of per-scene `duration_seconds` to account for transitions.
+- The schema is intentionally minimal. Downstream stages (Coder, Critic) may attach additional fields under their own namespaced keys without invalidating this schema.

--- a/skills/concept-to-video/scripts/_fixup_client.py
+++ b/skills/concept-to-video/scripts/_fixup_client.py
@@ -1,0 +1,130 @@
+"""
+_fixup_client.py — LLM-based Manim scene fixup helper.
+
+Sends a failing scene file + stderr to the LLM using the coder fixup prompt
+and returns the patched scene contents as a string.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Protocol, cast, runtime_checkable
+
+import anthropic
+
+_FENCED_PYTHON_RE = re.compile(
+    r"```python\s*\n(.*?)```",
+    re.DOTALL,
+)
+
+_CODER_PROMPT_PATH = (
+    Path(__file__).parent.parent / "references" / "code2video" / "coder.md"
+)
+
+# ---------------------------------------------------------------------------
+# Structural protocol — allows dependency injection of fakes in tests
+# without weakening the production type to Any.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _MessagesAPI(Protocol):
+    def create(self, **kwargs: Any) -> Any:  # noqa: ANN401
+        ...
+
+
+@runtime_checkable
+class ClientProtocol(Protocol):
+    """Structural type accepted by request_patch for DI."""
+
+    @property
+    def messages(self) -> _MessagesAPI:
+        ...
+
+
+# The concrete real type — exported for callers that want to hint explicitly.
+AnthropicClient = anthropic.Anthropic
+
+
+def _load_fixup_prompt() -> str:
+    """Load the coder fixup prompt from the vendored reference file."""
+    if not _CODER_PROMPT_PATH.exists():
+        raise FileNotFoundError(
+            f"Coder fixup prompt not found: {_CODER_PROMPT_PATH}. "
+            "Ensure worker-p0 has created references/code2video/coder.md."
+        )
+    return _CODER_PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def request_patch(
+    scene_path: Path,
+    stderr: str,
+    offending_lines: tuple[int, int] | None,
+    *,
+    client: ClientProtocol | None = None,
+    model: str = "claude-sonnet-4-6",
+) -> str:
+    """
+    Send scene source + stderr to the LLM and return the patched scene content.
+
+    Args:
+        scene_path: Absolute path to the Manim scene .py file.
+        stderr: Full stderr captured from the failed manim render call.
+        offending_lines: Optional (start, end) 1-indexed line range extracted
+            from the traceback. If None, the full file is provided to the LLM.
+        client: Injected client for testing. Pass None to build a real one.
+        model: Model identifier string.
+
+    Returns:
+        New scene file contents as a plain string (no fences).
+
+    Raises:
+        FileNotFoundError: If the coder prompt file is missing.
+        ValueError: If the LLM response contains no fenced ```python block.
+    """
+    fixup_prompt = _load_fixup_prompt()
+    scene_source = scene_path.read_text(encoding="utf-8")
+
+    if offending_lines is not None:
+        lines = scene_source.splitlines()
+        start = max(0, offending_lines[0] - 1)
+        end = min(len(lines), offending_lines[1])
+        excerpt = "\n".join(lines[start:end])
+        scope_note = (
+            f"Offending lines {offending_lines[0]}–{offending_lines[1]}:\n"
+            f"```python\n{excerpt}\n```\n\n"
+        )
+    else:
+        scope_note = ""
+
+    user_message = (
+        f"{fixup_prompt}\n\n"
+        f"## Scene file: {scene_path.name}\n\n"
+        f"```python\n{scene_source}\n```\n\n"
+        f"## Render error (stderr)\n\n"
+        f"```\n{stderr}\n```\n\n"
+        f"{scope_note}"
+        "Return the complete corrected scene file inside a single fenced "
+        "```python ... ``` block. Do not truncate or omit any part of the file."
+    )
+
+    resolved_client: ClientProtocol = (
+        client if client is not None else cast(ClientProtocol, AnthropicClient())
+    )
+
+    response = resolved_client.messages.create(
+        model=model,
+        max_tokens=8192,
+        messages=[{"role": "user", "content": user_message}],
+    )
+
+    raw: str = response.content[0].text
+
+    match = _FENCED_PYTHON_RE.search(raw)
+    if match is None:
+        raise ValueError(
+            f"LLM response contained no fenced ```python block.\n\nRaw response:\n{raw}"
+        )
+
+    return match.group(1)

--- a/skills/concept-to-video/scripts/critic_pass.py
+++ b/skills/concept-to-video/scripts/critic_pass.py
@@ -1,0 +1,403 @@
+"""VLM critic pass: sample frames from a rendered video and apply layout patches."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import anthropic
+from anthropic.types import (
+    Base64ImageSourceParam,
+    ImageBlockParam,
+    MessageParam,
+    TextBlock,
+    TextBlockParam,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_FRAMES = 5
+MAX_FRAMES = 10
+DEFAULT_CRITIC_BUDGET = 50_000
+_CRITIC_PROMPT_PATH = (
+    Path(__file__).parent.parent / "references" / "code2video" / "critic.md"
+)
+
+# ---------------------------------------------------------------------------
+# Custom exceptions
+# ---------------------------------------------------------------------------
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when the estimated token count for the critic call exceeds the budget."""
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Patch = dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Video utilities
+# ---------------------------------------------------------------------------
+
+
+def _probe_duration(video_path: Path) -> float:
+    """Return video duration in seconds via ffprobe.  Raises RuntimeError on failure."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(video_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffprobe failed (exit {result.returncode}) for {video_path}:\n"
+            f"{result.stderr.strip()}"
+        )
+    raw = result.stdout.strip()
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"ffprobe returned non-numeric duration {raw!r} for {video_path}"
+        ) from exc
+
+
+def _sample_frames(
+    video_path: Path,
+    timestamps: list[float],
+    output_dir: Path,
+) -> list[Path]:
+    """Extract one PNG frame per timestamp using ffmpeg.  Returns sorted frame paths."""
+    frame_paths: list[Path] = []
+    for i, ts in enumerate(timestamps):
+        out_path = output_dir / f"frame_{i:03d}.png"
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-ss",
+                f"{ts:.3f}",
+                "-i",
+                str(video_path),
+                "-frames:v",
+                "1",
+                "-q:v",
+                "2",
+                "-y",
+                str(out_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg failed (exit {result.returncode}) extracting frame at {ts:.3f}s "
+                f"from {video_path}:\n{result.stderr.strip()}"
+            )
+        frame_paths.append(out_path)
+    return frame_paths
+
+
+def _compute_timestamps(duration: float, n_frames: int) -> list[float]:
+    """Return n_frames evenly-spaced timestamps within [0, duration)."""
+    if n_frames == 1:
+        return [duration / 2.0]
+    step = duration / n_frames
+    return [step * i + step / 2.0 for i in range(n_frames)]
+
+
+# ---------------------------------------------------------------------------
+# Prompt and request construction
+# ---------------------------------------------------------------------------
+
+
+def _load_critic_prompt(prompt_path: Path) -> str:
+    if not prompt_path.exists():
+        raise FileNotFoundError(
+            f"Critic prompt not found: {prompt_path}. "
+            "Ensure worker-p0 has vendored the prompt templates."
+        )
+    return prompt_path.read_text(encoding="utf-8")
+
+
+def _encode_frame(frame_path: Path) -> str:
+    return base64.standard_b64encode(frame_path.read_bytes()).decode("ascii")
+
+
+def _build_message_content(
+    scene_source: str,
+    frame_paths: list[Path],
+    critic_prompt: str,
+) -> list[TextBlockParam | ImageBlockParam]:
+    """Build the multi-modal content list for the Anthropic Messages API."""
+    content: list[TextBlockParam | ImageBlockParam] = [
+        TextBlockParam(
+            type="text",
+            text=(
+                "## Scene Source\n\n"
+                "```python\n"
+                f"{scene_source}\n"
+                "```\n\n"
+            ),
+        )
+    ]
+    for i, fp in enumerate(frame_paths):
+        source: Base64ImageSourceParam = Base64ImageSourceParam(
+            type="base64",
+            media_type="image/png",
+            data=_encode_frame(fp),
+        )
+        content.append(ImageBlockParam(type="image", source=source))
+        content.append(TextBlockParam(type="text", text=f"(frame {i + 1} of {len(frame_paths)})"))
+
+    content.append(TextBlockParam(type="text", text=critic_prompt))
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Token budget estimation
+# ---------------------------------------------------------------------------
+
+_CHARS_PER_TOKEN_ESTIMATE = 4
+_BYTES_PER_IMAGE_TOKEN_ESTIMATE = 800  # rough: ~1 token per 800 bytes of base64
+
+
+def _estimate_tokens(scene_source: str, frame_paths: list[Path], critic_prompt: str) -> int:
+    """Rough token estimate to check against budget before making the API call."""
+    text_chars = len(scene_source) + len(critic_prompt)
+    text_tokens = text_chars // _CHARS_PER_TOKEN_ESTIMATE
+    image_tokens = sum(
+        fp.stat().st_size // _BYTES_PER_IMAGE_TOKEN_ESTIMATE for fp in frame_paths
+    )
+    return text_tokens + image_tokens
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_python_block(text: str) -> str:
+    """Extract content of the first ```python ... ``` fenced block."""
+    match = re.search(r"```python\s*\n(.*?)```", text, re.DOTALL)
+    if not match:
+        raise ValueError(
+            "Model response did not contain a ```python ... ``` fenced block. "
+            f"Raw response:\n{text[:500]}"
+        )
+    return match.group(1)
+
+
+def _parse_patch_list(text: str) -> list[Patch]:
+    """Parse the JSON patch list from the response.
+
+    Expected schema per patch:
+    {
+      "target_mobject": str,
+      "anchor_constraint": str,
+      "reason": str,
+      "patch_code": str
+    }
+    """
+    # Look for a JSON array in the response
+    match = re.search(r"\[.*?\]", text, re.DOTALL)
+    if not match:
+        raise ValueError(
+            f"Model response does not contain a JSON array of patches.\n"
+            f"Raw response:\n{text[:500]}"
+        )
+    raw_json = match.group(0)
+    try:
+        patches = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Malformed JSON in model response: {exc}\n\nRaw JSON:\n{raw_json}"
+        ) from exc
+    if not isinstance(patches, list):
+        raise ValueError(
+            f"Expected JSON array of patches, got {type(patches).__name__}"
+        )
+    for i, patch in enumerate(patches):
+        for field in ("target_mobject", "anchor_constraint", "reason", "patch_code"):
+            if field not in patch:
+                raise ValueError(
+                    f"Patch [{i}] missing required field {field!r}. "
+                    f"Patch content: {patch!r}"
+                )
+    return patches
+
+
+# ---------------------------------------------------------------------------
+# Core function
+# ---------------------------------------------------------------------------
+
+
+def run_critic_pass(
+    scene_file: Path,
+    video_file: Path,
+    output_path: Path,
+    *,
+    n_frames: int = DEFAULT_FRAMES,
+    critic_budget: int = DEFAULT_CRITIC_BUDGET,
+    model: str = DEFAULT_MODEL,
+    prompt_path: Path = _CRITIC_PROMPT_PATH,
+    client: anthropic.Anthropic | None = None,
+) -> tuple[list[Patch], int]:
+    """Run the VLM critic pass.
+
+    Samples frames from video_file, queries the model with the scene source
+    and frames, parses the layout patches, writes the patched scene to
+    output_path.
+
+    Returns (patches, tokens_used).
+    Raises BudgetExceededError if estimated tokens exceed critic_budget.
+    Raises FileNotFoundError if scene_file or prompt_path is missing.
+    Raises RuntimeError on ffprobe/ffmpeg failure.
+    Raises ValueError on malformed model response.
+    """
+    if not scene_file.exists():
+        raise FileNotFoundError(f"Scene file not found: {scene_file}")
+    if not video_file.exists():
+        raise FileNotFoundError(f"Video file not found: {video_file}")
+
+    n_frames = min(n_frames, MAX_FRAMES)
+    scene_source = scene_file.read_text(encoding="utf-8")
+    critic_prompt = _load_critic_prompt(prompt_path)
+
+    duration = _probe_duration(video_file)
+    timestamps = _compute_timestamps(duration, n_frames)
+
+    actual_client = client if client is not None else anthropic.Anthropic()
+
+    with tempfile.TemporaryDirectory(prefix="critic_frames_") as tmp_dir:
+        frame_paths = _sample_frames(video_file, timestamps, Path(tmp_dir))
+
+        estimated = _estimate_tokens(scene_source, frame_paths, critic_prompt)
+        if estimated > critic_budget:
+            raise BudgetExceededError(
+                f"Estimated token count {estimated} exceeds critic budget {critic_budget}. "
+                "Increase --critic-budget or reduce --frames."
+            )
+
+        content = _build_message_content(scene_source, frame_paths, critic_prompt)
+        messages: list[MessageParam] = [MessageParam(role="user", content=content)]
+        response = actual_client.messages.create(
+            model=model,
+            max_tokens=4096,
+            messages=messages,
+        )
+
+    first_block = response.content[0]
+    if not isinstance(first_block, TextBlock):
+        raise ValueError(
+            f"Unexpected first content block type {type(first_block).__name__!r}; "
+            "expected a text block."
+        )
+    response_text: str = first_block.text
+    tokens_used: int = response.usage.input_tokens + response.usage.output_tokens
+
+    patches = _parse_patch_list(response_text)
+    patched_source = _extract_python_block(response_text)
+
+    output_path.write_text(patched_source, encoding="utf-8")
+    return patches, tokens_used
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "VLM critic pass: sample frames from a rendered Manim video, "
+            "query a vision model for layout defects, and apply patches."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("scene_file", type=Path, help="Path to the scene Python file")
+    parser.add_argument("rendered_video", type=Path, help="Path to the rendered MP4")
+    parser.add_argument(
+        "--frames",
+        type=int,
+        default=DEFAULT_FRAMES,
+        metavar="N",
+        help=f"Number of frames to sample (default: {DEFAULT_FRAMES}, max: {MAX_FRAMES})",
+    )
+    parser.add_argument(
+        "--critic",
+        action="store_true",
+        default=False,
+        help="Enable the critic pass (default: disabled)",
+    )
+    parser.add_argument(
+        "--critic-budget",
+        type=int,
+        default=DEFAULT_CRITIC_BUDGET,
+        metavar="TOKENS",
+        help=f"Maximum token budget for the critic call (default: {DEFAULT_CRITIC_BUDGET})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        metavar="MODEL",
+        help=f"Anthropic model ID (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Write patched scene to this path (default: overwrite scene_file)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if not args.critic:
+        print("critic pass disabled", file=sys.stderr)
+        sys.exit(0)
+
+    output_path: Path = args.output if args.output is not None else args.scene_file
+
+    patches, tokens_used = run_critic_pass(
+        scene_file=args.scene_file,
+        video_file=args.rendered_video,
+        output_path=output_path,
+        n_frames=args.frames,
+        critic_budget=args.critic_budget,
+        model=args.model,
+    )
+    print(
+        f"critic applied {len(patches)} patches, tokens used: {tokens_used}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/concept-to-video/scripts/fetch_assets.py
+++ b/skills/concept-to-video/scripts/fetch_assets.py
@@ -1,0 +1,329 @@
+"""Phase 4 — Pluggable asset sourcing for concept-to-video storyboards.
+
+Adapters: local (directory of SVGs/PNGs/JPGs), iconfinder (API-key gated),
+none (text-only mode). Reads storyboard JSON, resolves each scene's assets,
+writes a resolved mapping JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ICONFINDER_SEARCH_URL = "https://api.iconfinder.com/v4/icons/search"
+SUPPORTED_EXTENSIONS: tuple[str, ...] = (".svg", ".png", ".jpg", ".jpeg")
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class AssetResolutionError(RuntimeError):
+    """Raised when one or more required assets cannot be resolved."""
+
+    missing: list[str]
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = missing
+        super().__init__(
+            f"Failed to resolve {len(missing)} required asset(s): {missing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AssetAdapter(Protocol):
+    name: str
+
+    def resolve(self, query: str, kind: str) -> Path | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+def _normalise_query(query: str) -> str:
+    """Lowercase, collapse whitespace to hyphens for filename matching."""
+    return re.sub(r"[\s_]+", "-", query.strip().lower())
+
+
+class LocalAssetAdapter:
+    """Searches a root directory for asset files by filename stem match."""
+
+    name = "local"
+
+    def __init__(self, root: Path) -> None:
+        if not root.is_dir():
+            raise ValueError(f"asset-dir does not exist or is not a directory: {root}")
+        self._root = root
+
+    def resolve(self, query: str, kind: str) -> Path | None:
+        del kind
+        normalised = _normalise_query(query)
+        for candidate in self._root.iterdir():
+            if candidate.suffix.lower() not in SUPPORTED_EXTENSIONS:
+                continue
+            stem = _normalise_query(candidate.stem)
+            if stem == normalised:
+                return candidate.resolve()
+        return None
+
+
+class IconFinderAdapter:
+    """Resolves assets via the IconFinder API (API-key gated)."""
+
+    name = "iconfinder"
+
+    def __init__(self, api_key: str) -> None:
+        if not api_key:
+            raise ValueError(
+                "ICONFINDER_API_KEY is not set; "
+                "IconFinderAdapter requires an API key at construction time"
+            )
+        self._api_key = api_key
+
+    @classmethod
+    def from_env(cls) -> IconFinderAdapter:
+        key = os.environ.get("ICONFINDER_API_KEY", "")
+        return cls(key)
+
+    def resolve(self, query: str, kind: str) -> Path | None:
+        del kind
+        params = urllib.parse.urlencode(
+            {"query": query, "count": 1, "vector": 1}
+        )
+        url = f"{ICONFINDER_SEARCH_URL}?{params}"
+        req = urllib.request.Request(
+            url,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body: dict[str, Any] = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"IconFinder API returned HTTP {exc.code} for query '{query}'"
+            ) from exc
+
+        icons: list[dict[str, Any]] = body.get("icons", [])
+        if not icons:
+            return None
+
+        # Prefer the first vector (SVG) download URL
+        icon = icons[0]
+        raster_sizes: list[dict[str, Any]] = icon.get("raster_sizes", [])
+        vector_sizes: list[dict[str, Any]] = icon.get("vector_sizes", [])
+
+        download_url: str | None = None
+        if vector_sizes:
+            formats: list[dict[str, Any]] = vector_sizes[0].get("formats", [])
+            if formats:
+                download_url = formats[0].get("download_url")
+        if download_url is None and raster_sizes:
+            formats = raster_sizes[-1].get("formats", [])
+            if formats:
+                download_url = formats[0].get("download_url")
+
+        if download_url is None:
+            return None
+
+        dl_req = urllib.request.Request(
+            download_url,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        suffix = Path(download_url.split("?")[0]).suffix or ".svg"
+        dest = Path(os.environ.get("TMPDIR", "/tmp")) / (
+            _normalise_query(query) + suffix
+        )
+        try:
+            with urllib.request.urlopen(dl_req) as dl_resp:
+                dest.write_bytes(dl_resp.read())
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"IconFinder download returned HTTP {exc.code} for query '{query}'"
+            ) from exc
+
+        return dest
+
+
+class NoneAdapter:
+    """Always returns None; used for text-only storyboards."""
+
+    name = "none"
+
+    def resolve(self, query: str, kind: str) -> Path | None:
+        del query, kind
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Storyboard validation (minimal — full validation lives in plan_storyboard.py)
+# ---------------------------------------------------------------------------
+
+_VALID_KINDS: frozenset[str] = frozenset({"icon", "image", "text"})
+
+
+def _require(obj: dict[str, Any], key: str, path: str) -> Any:
+    if key not in obj:
+        raise ValueError(f"storyboard missing required field '{path}.{key}'")
+    return obj[key]
+
+
+def _validate_storyboard(data: Any) -> None:
+    if not isinstance(data, dict):
+        raise ValueError("storyboard JSON must be a top-level object")
+    _require(data, "scenes", "root")
+    scenes = data["scenes"]
+    if not isinstance(scenes, list) or len(scenes) == 0:
+        raise ValueError("storyboard 'scenes' must be a non-empty array")
+    for i, scene in enumerate(scenes):
+        base = f"scenes[{i}]"
+        if not isinstance(scene, dict):
+            raise ValueError(f"{base} must be an object")
+        _require(scene, "index", base)
+        assets_raw = scene.get("assets")
+        if assets_raw is None:
+            raise ValueError(f"{base} missing required field 'assets'")
+        if not isinstance(assets_raw, list):
+            raise ValueError(f"{base}.assets must be an array")
+        for j, asset in enumerate(assets_raw):
+            abase = f"{base}.assets[{j}]"
+            if not isinstance(asset, dict):
+                raise ValueError(f"{abase} must be an object")
+            for field in ("kind", "query", "required"):
+                _require(asset, field, abase)
+            if asset["kind"] not in _VALID_KINDS:
+                raise ValueError(
+                    f"{abase}.kind must be one of {sorted(_VALID_KINDS)}, "
+                    f"got '{asset['kind']}'"
+                )
+            if not isinstance(asset["query"], str) or not asset["query"].strip():
+                raise ValueError(f"{abase}.query must be a non-empty string")
+            if not isinstance(asset["required"], bool):
+                raise ValueError(f"{abase}.required must be a boolean")
+
+
+# ---------------------------------------------------------------------------
+# Core resolution logic
+# ---------------------------------------------------------------------------
+
+ResolvedMapping = dict[int, dict[str, str | None]]
+
+
+def resolve_storyboard(
+    storyboard: dict[str, Any],
+    adapter: AssetAdapter,
+) -> ResolvedMapping:
+    """Resolve all assets in *storyboard* using *adapter*.
+
+    Returns ``{scene_index: {asset_query: resolved_path_or_null}}``.
+    Raises :class:`AssetResolutionError` if any ``required: true`` asset
+    cannot be resolved — no silent skipping.
+    """
+    _validate_storyboard(storyboard)
+    result: ResolvedMapping = {}
+    missing: list[str] = []
+
+    for scene in storyboard["scenes"]:
+        idx: int = scene["index"]
+        scene_map: dict[str, str | None] = {}
+        for asset in scene.get("assets", []):
+            query: str = asset["query"]
+            kind: str = asset["kind"]
+            required: bool = asset["required"]
+
+            resolved = adapter.resolve(query, kind)
+            scene_map[query] = str(resolved) if resolved is not None else None
+
+            if resolved is None and required:
+                missing.append(query)
+
+        result[idx] = scene_map
+
+    if missing:
+        raise AssetResolutionError(missing)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_adapter(
+    adapter_name: str,
+    asset_dir: Path | None,
+) -> AssetAdapter:
+    if adapter_name == "local":
+        if asset_dir is None:
+            raise ValueError("--asset-dir is required when --adapter=local")
+        return LocalAssetAdapter(asset_dir)
+    if adapter_name == "iconfinder":
+        return IconFinderAdapter.from_env()
+    if adapter_name == "none":
+        return NoneAdapter()
+    raise ValueError(f"unknown adapter '{adapter_name}'")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Resolve storyboard assets to local file paths."
+    )
+    parser.add_argument("storyboard", type=Path, help="Path to storyboard.json")
+    parser.add_argument(
+        "--adapter",
+        choices=["local", "iconfinder", "none"],
+        default="none",
+        help="Asset resolution backend (default: none)",
+    )
+    parser.add_argument(
+        "--asset-dir",
+        type=Path,
+        default=None,
+        help="Root directory for local adapter",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write resolved JSON to this path (default: stdout)",
+    )
+    args = parser.parse_args(argv)
+
+    raw = args.storyboard.read_text(encoding="utf-8")
+    try:
+        storyboard: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed storyboard JSON: {exc}") from exc
+
+    adapter = _build_adapter(args.adapter, args.asset_dir)
+    resolved = resolve_storyboard(storyboard, adapter)
+
+    # Serialise with string keys for JSON compat
+    output = json.dumps({str(k): v for k, v in resolved.items()}, indent=2)
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/concept-to-video/scripts/plan_storyboard.py
+++ b/skills/concept-to-video/scripts/plan_storyboard.py
@@ -1,0 +1,185 @@
+"""Planner stage: concept text → storyboard JSON via Anthropic Messages API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import anthropic
+from anthropic.types import TextBlock
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Asset = dict[str, Any]
+Beat = str
+Scene = dict[str, Any]
+Storyboard = dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+_VALID_ASSET_KINDS: frozenset[str] = frozenset({"icon", "image", "text"})
+
+
+def _validate_asset(asset: Any, path: str) -> None:
+    if not isinstance(asset, dict):
+        raise ValueError(f"{path}: expected object, got {type(asset).__name__}")
+    for field in ("kind", "query", "required"):
+        if field not in asset:
+            raise ValueError(f"{path}.{field}: required field missing")
+    if asset["kind"] not in _VALID_ASSET_KINDS:
+        raise ValueError(
+            f"{path}.kind: must be one of {sorted(_VALID_ASSET_KINDS)!r}, "
+            f"got {asset['kind']!r}"
+        )
+    if not isinstance(asset["query"], str) or not asset["query"].strip():
+        raise ValueError(f"{path}.query: must be a non-empty string")
+    if not isinstance(asset["required"], bool):
+        raise ValueError(f"{path}.required: must be a boolean")
+
+
+def _validate_scene(scene: Any, path: str) -> None:
+    if not isinstance(scene, dict):
+        raise ValueError(f"{path}: expected object, got {type(scene).__name__}")
+    for field in ("index", "title", "duration_seconds", "beats", "assets"):
+        if field not in scene:
+            raise ValueError(f"{path}.{field}: required field missing")
+    if not isinstance(scene["index"], int):
+        raise ValueError(f"{path}.index: must be an integer")
+    if not isinstance(scene["title"], str) or not scene["title"].strip():
+        raise ValueError(f"{path}.title: must be a non-empty string")
+    if not isinstance(scene["duration_seconds"], int | float) or scene["duration_seconds"] <= 0:
+        raise ValueError(f"{path}.duration_seconds: must be a positive number")
+    if not isinstance(scene["beats"], list) or len(scene["beats"]) == 0:
+        raise ValueError(f"{path}.beats: must be a non-empty list")
+    for i, beat in enumerate(scene["beats"]):
+        if not isinstance(beat, str):
+            raise ValueError(f"{path}.beats[{i}]: must be a string")
+    if not isinstance(scene["assets"], list):
+        raise ValueError(f"{path}.assets: must be a list")
+    for i, asset in enumerate(scene["assets"]):
+        _validate_asset(asset, f"{path}.assets[{i}]")
+
+
+def validate_storyboard(data: Any) -> Storyboard:
+    """Validate a parsed storyboard dict.  Raises ValueError with field path on violation."""
+    if not isinstance(data, dict):
+        raise ValueError(f"root: expected object, got {type(data).__name__}")
+    for field in ("concept", "duration_estimate_seconds", "scenes"):
+        if field not in data:
+            raise ValueError(f"root.{field}: required field missing")
+    if not isinstance(data["concept"], str) or not data["concept"].strip():
+        raise ValueError("root.concept: must be a non-empty string")
+    if (
+        not isinstance(data["duration_estimate_seconds"], int | float)
+        or data["duration_estimate_seconds"] <= 0
+    ):
+        raise ValueError("root.duration_estimate_seconds: must be a positive number")
+    if not isinstance(data["scenes"], list) or len(data["scenes"]) == 0:
+        raise ValueError("root.scenes: must be a non-empty list")
+    for i, scene in enumerate(data["scenes"]):
+        _validate_scene(scene, f"root.scenes[{i}]")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Core planner
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+_PROMPT_PATH = Path(__file__).parent.parent / "references" / "code2video" / "planner.md"
+
+
+class StoryboardPlanner:
+    """Wraps the Anthropic client to produce storyboard JSON from a concept."""
+
+    def __init__(
+        self,
+        client: anthropic.Anthropic,
+        model: str = DEFAULT_MODEL,
+        prompt_path: Path = _PROMPT_PATH,
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._prompt_path = prompt_path
+
+    def _load_prompt(self, concept: str) -> str:
+        if not self._prompt_path.exists():
+            raise FileNotFoundError(
+                f"Planner prompt not found: {self._prompt_path}. "
+                "Run worker-p0 first to vendor the prompt templates."
+            )
+        template = self._prompt_path.read_text(encoding="utf-8")
+        return template.replace("{concept}", concept)
+
+    def plan(self, concept: str) -> Storyboard:
+        """Call the model and return a validated storyboard dict."""
+        prompt = self._load_prompt(concept)
+        message = self._client.messages.create(
+            model=self._model,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        first_block = message.content[0]
+        if not isinstance(first_block, TextBlock):
+            raise ValueError(
+                f"Expected TextBlock from model, got {type(first_block).__name__}"
+            )
+        raw: str = first_block.text
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Model returned non-JSON output. Parse error: {exc}\n\nRaw output:\n{raw}"
+            ) from exc
+        return validate_storyboard(data)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a storyboard JSON from a concept string.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("concept", help="Concept text to storyboard")
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Write storyboard JSON to this file (default: stdout)",
+    )
+    parser.add_argument(
+        "--model",
+        metavar="MODEL",
+        default=DEFAULT_MODEL,
+        help=f"Anthropic model ID (default: {DEFAULT_MODEL})",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    client = anthropic.Anthropic()
+    planner = StoryboardPlanner(client=client, model=args.model)
+    storyboard = planner.plan(args.concept)
+    serialized = json.dumps(storyboard, indent=2, ensure_ascii=False)
+
+    if args.output:
+        Path(args.output).write_text(serialized + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(serialized + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/concept-to-video/scripts/render_video.py
+++ b/skills/concept-to-video/scripts/render_video.py
@@ -8,12 +8,19 @@ management (Manim's default output nesting is deep and unintuitive).
 Usage:
     python3 render_video.py scene.py SceneName --quality high --format mp4
     python3 render_video.py scene.py SceneName --quality low --format gif --output /path/to/output.gif
+    python3 render_video.py scene.py SceneName --max-fix-attempts 3
 """
 
+from __future__ import annotations
+
 import argparse
+import difflib
+import json
+import re
+import shutil
 import subprocess
 import sys
-import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 QUALITY_MAP = {
@@ -29,6 +36,19 @@ FORMAT_MAP = {
     "webm": "--format=webm",
     "png":  "--format=png",   # renders each frame as PNG sequence
 }
+
+_MAX_FIX_ATTEMPTS_HARD_CAP = 3
+
+# Match lines like:  File "/path/to/file.py", line 42, in ...
+_TRACEBACK_LINE_RE = re.compile(
+    r'File "([^"]+)", line (\d+)'
+)
+
+# Match the exception class on the last non-blank line of stderr
+_EXCEPTION_CLASS_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Warning|Interrupt|KeyboardInterrupt|GeneratorExit|StopIteration|SystemExit))\s*(?::.*)?$",
+    re.MULTILINE,
+)
 
 
 def find_rendered_file(media_dir: Path, scene_name: str, quality_dir: str, fmt: str) -> Path | None:
@@ -71,7 +91,140 @@ def ensure_manim_installed() -> bool:
     return False
 
 
-def main():
+def parse_offending_lines(
+    scene_path: Path,
+    stderr: str,
+) -> tuple[int, int] | None:
+    """
+    Extract an offending line range from a Manim traceback.
+
+    Scans all ``File "...", line N`` entries that reference scene_path and
+    returns a (start, end) tuple covering all of them with ±5 lines of
+    context.  Returns None when no matching entry is found.
+    """
+    scene_str = str(scene_path)
+    line_numbers: list[int] = []
+    for m in _TRACEBACK_LINE_RE.finditer(stderr):
+        if scene_str in m.group(1):
+            line_numbers.append(int(m.group(2)))
+
+    if not line_numbers:
+        return None
+
+    source_lines = len(scene_path.read_text(encoding="utf-8").splitlines())
+    start = max(1, min(line_numbers) - 5)
+    end = min(source_lines, max(line_numbers) + 5)
+    return (start, end)
+
+
+def extract_error_class(stderr: str) -> str:
+    """
+    Return the exception class name from stderr, or 'UnknownError'.
+    """
+    # Walk lines in reverse; the exception line is usually near the bottom
+    for line in reversed(stderr.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        m = _EXCEPTION_CLASS_RE.match(line)
+        if m:
+            return m.group(1)
+    return "UnknownError"
+
+
+def _diff_summary(original: str, patched: str) -> str:
+    """Return a compact unified-diff summary (first 20 lines)."""
+    diff_lines = list(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            patched.splitlines(keepends=True),
+            fromfile="original",
+            tofile="patched",
+            n=1,
+        )
+    )
+    summary = "".join(diff_lines[:20])
+    if len(diff_lines) > 20:
+        summary += f"\n... ({len(diff_lines) - 20} more diff lines)"
+    return summary or "(no changes)"
+
+
+def run_with_autofix(
+    cmd: list[str],
+    scene_path: Path,
+    max_fix_attempts: int,
+) -> subprocess.CompletedProcess[str]:
+    """
+    Run *cmd* and, on failure, invoke the LLM fixup loop up to
+    *max_fix_attempts* times.
+
+    When max_fix_attempts == 0 the function degrades exactly to a single
+    ``subprocess.run`` call with ``capture_output=False`` — identical to the
+    pre-autofix behaviour.
+
+    On exhausting attempts without success the original subprocess result
+    (first failure) is returned so that callers can inspect the exit code and
+    raise accordingly.
+    """
+    if max_fix_attempts == 0:
+        return subprocess.run(cmd, capture_output=False, text=True)
+
+    # First attempt — capture stderr so we can feed it to the fixup client
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        # Print captured output now that we know it succeeded
+        if result.stdout:
+            print(result.stdout, end="")
+        return result
+
+    original_result = result
+    log_path = scene_path.with_suffix("").with_name(scene_path.stem + ".render-log.jsonl")
+
+    # Deferred import — only needed when autofix is active
+    from _fixup_client import request_patch  # noqa: PLC0415
+
+    for attempt in range(1, max_fix_attempts + 1):
+        stderr_text: str = result.stderr or ""
+        error_class = extract_error_class(stderr_text)
+        offending = parse_offending_lines(scene_path, stderr_text)
+
+        print(
+            f"\n[autofix] attempt {attempt}/{max_fix_attempts} — {error_class}",
+            file=sys.stderr,
+        )
+
+        original_source = scene_path.read_text(encoding="utf-8")
+
+        # Backup before patching
+        backup_path = scene_path.with_suffix(f".bak.{attempt}")
+        backup_path.write_text(original_source, encoding="utf-8")
+
+        patched_source = request_patch(scene_path, stderr_text, offending)
+        scene_path.write_text(patched_source, encoding="utf-8")
+
+        # Log the attempt
+        log_entry = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "attempt": attempt,
+            "error_class": error_class,
+            "stderr_tail": stderr_text[-500:],
+            "diff_summary": _diff_summary(original_source, patched_source),
+        }
+        with log_path.open("a", encoding="utf-8") as lf:
+            lf.write(json.dumps(log_entry) + "\n")
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            print(f"[autofix] render succeeded on attempt {attempt}", file=sys.stderr)
+            if result.stdout:
+                print(result.stdout, end="")
+            return result
+
+    # All attempts exhausted — return first failure for the caller to handle
+    return original_result
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description="Render Manim scene to video")
     parser.add_argument("scene_file", help="Path to the .py file containing the Scene class")
     parser.add_argument("scene_name", help="Name of the Scene class to render")
@@ -83,8 +236,23 @@ def main():
                         help="Output file path. If not specified, outputs next to scene file.")
     parser.add_argument("--media-dir", type=str, default=None,
                         help="Custom media directory for Manim output")
+    parser.add_argument(
+        "--max-fix-attempts",
+        type=int,
+        default=0,
+        metavar="N",
+        help=(
+            "Number of LLM-assisted auto-fix attempts on render failure "
+            f"(0 = disabled, max {_MAX_FIX_ATTEMPTS_HARD_CAP}; default: 0)"
+        ),
+    )
 
     args = parser.parse_args()
+
+    if args.max_fix_attempts < 0 or args.max_fix_attempts > _MAX_FIX_ATTEMPTS_HARD_CAP:
+        parser.error(
+            f"--max-fix-attempts must be between 0 and {_MAX_FIX_ATTEMPTS_HARD_CAP}"
+        )
 
     scene_path = Path(args.scene_file).resolve()
     if not scene_path.exists():
@@ -114,7 +282,7 @@ def main():
     print(f"Command: {' '.join(cmd)}")
     print()
 
-    result = subprocess.run(cmd, capture_output=False, text=True)
+    result = run_with_autofix(cmd, scene_path, args.max_fix_attempts)
 
     if result.returncode != 0:
         print(f"\nERROR: Manim render failed with exit code {result.returncode}", file=sys.stderr)
@@ -146,8 +314,6 @@ def main():
     print(f"  Quality:   {args.quality} ({quality_dir})")
     print(f"  Format:    {args.fmt}")
     print(f"  File size: {size:,} bytes ({size / 1024:.1f} KB)")
-
-    return str(final_path)
 
 
 if __name__ == "__main__":

--- a/skills/concept-to-video/tests/conftest.py
+++ b/skills/concept-to-video/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))

--- a/skills/concept-to-video/tests/test_critic_pass.py
+++ b/skills/concept-to-video/tests/test_critic_pass.py
@@ -1,0 +1,590 @@
+"""Unit tests for critic_pass.py — VLM critic pass for concept-to-video."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from anthropic.types import TextBlock
+
+import pytest
+
+# Make the scripts directory importable without installing a package
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from critic_pass import (  # noqa: E402
+    BudgetExceededError,
+    MAX_FRAMES,
+    _compute_timestamps,
+    _extract_python_block,
+    _load_critic_prompt,
+    _parse_patch_list,
+    _probe_duration,
+    _sample_frames,
+    main,
+    run_critic_pass,
+)
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+SCENE_SOURCE = """\
+from manim import *
+
+class DemoScene(Scene):
+    def construct(self):
+        circle = Circle()
+        self.play(Create(circle))
+        self.wait()
+"""
+
+CRITIC_PROMPT_CONTENT = """\
+# Critic Prompt
+Review the scene frames and return layout patches as a JSON array followed by
+a ```python ... ``` block with the full corrected scene.
+"""
+
+PATCH_LIST: list[dict[str, Any]] = [
+    {
+        "target_mobject": "circle",
+        "anchor_constraint": "center",
+        "reason": "circle drifts off-canvas",
+        "patch_code": "circle.move_to(ORIGIN)",
+    }
+]
+
+PATCHED_SCENE = """\
+from manim import *
+
+class DemoScene(Scene):
+    def construct(self):
+        circle = Circle()
+        circle.move_to(ORIGIN)
+        self.play(Create(circle))
+        self.wait()
+"""
+
+VALID_RESPONSE = json.dumps(PATCH_LIST) + "\n\n```python\n" + PATCHED_SCENE + "```\n"
+
+
+# ---------------------------------------------------------------------------
+# Fake Anthropic client
+# ---------------------------------------------------------------------------
+
+
+class FakeAnthropicClient:
+    """Minimal dependency-injection fake; records calls and returns canned responses."""
+
+    def __init__(self, response_text: str = VALID_RESPONSE) -> None:
+        self._response_text = response_text
+        self.call_count = 0
+        self.messages = self  # mirrors anthropic.Anthropic().messages.create(...)
+
+    def create(self, **kwargs: Any) -> MagicMock:
+        self.call_count += 1
+        msg = MagicMock()
+        msg.content = [TextBlock(type="text", text=self._response_text)]
+        msg.usage = MagicMock()
+        msg.usage.input_tokens = 1000
+        msg.usage.output_tokens = 500
+        return msg
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+
+def _ffprobe_ok(duration: float = 10.0) -> MagicMock:
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = f"{duration}\n"
+    r.stderr = ""
+    return r
+
+
+def _ffprobe_fail() -> MagicMock:
+    r = MagicMock()
+    r.returncode = 1
+    r.stdout = ""
+    r.stderr = "ffprobe: No such file"
+    return r
+
+
+def _ffmpeg_ok_factory(write_png: bool = True) -> Any:
+    """Returns a side_effect function for subprocess.run that handles ffprobe + ffmpeg."""
+
+    def _run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if "ffprobe" in cmd[0]:
+            return _ffprobe_ok(10.0)
+        # ffmpeg — write a minimal PNG so stat() works
+        out = Path(cmd[-1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        if write_png:
+            out.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 200)
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = ""
+        r.stderr = ""
+        return r
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def scene_file(tmp_path: Path) -> Path:
+    p = tmp_path / "demo_scene.py"
+    p.write_text(SCENE_SOURCE, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def video_file(tmp_path: Path) -> Path:
+    p = tmp_path / "demo.mp4"
+    p.write_bytes(b"\x00" * 16)
+    return p
+
+
+@pytest.fixture()
+def prompt_file(tmp_path: Path) -> Path:
+    p = tmp_path / "critic.md"
+    p.write_text(CRITIC_PROMPT_CONTENT, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def output_file(tmp_path: Path) -> Path:
+    return tmp_path / "patched_scene.py"
+
+
+# ---------------------------------------------------------------------------
+# _compute_timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTimestamps:
+    def test_compute_timestamps_single_frame_returns_midpoint(self) -> None:
+        # Arrange
+        duration = 10.0
+        # Act
+        result = _compute_timestamps(duration, 1)
+        # Assert
+        assert result == [5.0]
+
+    def test_compute_timestamps_five_frames_evenly_spaced(self) -> None:
+        # Arrange / Act
+        result = _compute_timestamps(10.0, 5)
+        # Assert
+        assert len(result) == 5
+        assert result[0] == pytest.approx(1.0)
+        assert result[-1] == pytest.approx(9.0)
+
+    def test_compute_timestamps_all_within_duration(self) -> None:
+        # Arrange / Act
+        result = _compute_timestamps(7.5, 4)
+        # Assert
+        assert all(0 <= ts < 7.5 for ts in result)
+
+
+# ---------------------------------------------------------------------------
+# _probe_duration
+# ---------------------------------------------------------------------------
+
+
+class TestProbeDuration:
+    def test_probe_duration_success_returns_float(self, video_file: Path) -> None:
+        # Arrange
+        fake = _ffprobe_ok(15.5)
+        # Act
+        with patch("subprocess.run", return_value=fake):
+            result = _probe_duration(video_file)
+        # Assert
+        assert result == pytest.approx(15.5)
+
+    def test_probe_duration_nonzero_exit_raises_runtime_error(
+        self, video_file: Path
+    ) -> None:
+        # Arrange / Act / Assert
+        with patch("subprocess.run", return_value=_ffprobe_fail()):
+            with pytest.raises(RuntimeError, match="ffprobe failed"):
+                _probe_duration(video_file)
+
+    def test_probe_duration_non_numeric_output_raises_runtime_error(
+        self, video_file: Path
+    ) -> None:
+        # Arrange
+        bad = MagicMock()
+        bad.returncode = 0
+        bad.stdout = "N/A\n"
+        bad.stderr = ""
+        # Act / Assert
+        with patch("subprocess.run", return_value=bad):
+            with pytest.raises(RuntimeError, match="non-numeric duration"):
+                _probe_duration(video_file)
+
+
+# ---------------------------------------------------------------------------
+# _sample_frames
+# ---------------------------------------------------------------------------
+
+
+class TestSampleFrames:
+    def test_sample_frames_creates_expected_paths(
+        self, tmp_path: Path, video_file: Path
+    ) -> None:
+        # Arrange
+        frame_dir = tmp_path / "frames"
+        frame_dir.mkdir()
+        timestamps = [1.0, 5.0, 9.0]
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            out = Path(cmd[-1])
+            out.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        # Act
+        with patch("subprocess.run", side_effect=fake_run):
+            paths = _sample_frames(video_file, timestamps, frame_dir)
+
+        # Assert
+        assert len(paths) == 3
+        assert all(p.exists() for p in paths)
+
+    def test_sample_frames_ffmpeg_failure_raises_runtime_error(
+        self, tmp_path: Path, video_file: Path
+    ) -> None:
+        # Arrange
+        frame_dir = tmp_path / "frames"
+        frame_dir.mkdir()
+        bad = MagicMock()
+        bad.returncode = 1
+        bad.stderr = "Error: codec not found"
+        # Act / Assert
+        with patch("subprocess.run", return_value=bad):
+            with pytest.raises(RuntimeError, match="ffmpeg failed"):
+                _sample_frames(video_file, [1.0], frame_dir)
+
+
+# ---------------------------------------------------------------------------
+# _load_critic_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCriticPrompt:
+    def test_load_critic_prompt_returns_content(self, prompt_file: Path) -> None:
+        # Arrange / Act
+        result = _load_critic_prompt(prompt_file)
+        # Assert
+        assert "Critic Prompt" in result
+
+    def test_load_critic_prompt_missing_file_raises_file_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange / Act / Assert
+        with pytest.raises(FileNotFoundError, match="Critic prompt not found"):
+            _load_critic_prompt(tmp_path / "nonexistent.md")
+
+
+# ---------------------------------------------------------------------------
+# _parse_patch_list
+# ---------------------------------------------------------------------------
+
+
+class TestParsePatchList:
+    def test_parse_patch_list_valid_json_returns_patches(self) -> None:
+        # Arrange
+        text = json.dumps(PATCH_LIST) + "\nExtra text"
+        # Act
+        result = _parse_patch_list(text)
+        # Assert
+        assert len(result) == 1
+        assert result[0]["target_mobject"] == "circle"
+        assert result[0]["anchor_constraint"] == "center"
+
+    def test_parse_patch_list_missing_required_field_raises_value_error(self) -> None:
+        # Arrange — patch missing 'reason'
+        bad = [{"target_mobject": "x", "anchor_constraint": "c", "patch_code": "pass"}]
+        # Act / Assert
+        with pytest.raises(ValueError, match="missing required field"):
+            _parse_patch_list(json.dumps(bad))
+
+    def test_parse_patch_list_malformed_json_raises_value_error(self) -> None:
+        # Arrange
+        text = "[{bad json here}]"
+        # Act / Assert
+        with pytest.raises(ValueError, match="Malformed JSON"):
+            _parse_patch_list(text)
+
+    def test_parse_patch_list_no_array_in_response_raises_value_error(self) -> None:
+        # Arrange
+        text = "No JSON array here whatsoever."
+        # Act / Assert
+        with pytest.raises(ValueError, match="does not contain a JSON array"):
+            _parse_patch_list(text)
+
+
+# ---------------------------------------------------------------------------
+# _extract_python_block
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPythonBlock:
+    def test_extract_python_block_returns_code_content(self) -> None:
+        # Arrange
+        text = "Some text\n```python\nprint('hi')\n```\nMore text"
+        # Act
+        result = _extract_python_block(text)
+        # Assert
+        assert result.strip() == "print('hi')"
+
+    def test_extract_python_block_missing_block_raises_value_error(self) -> None:
+        # Arrange
+        text = "No fenced block here."
+        # Act / Assert
+        with pytest.raises(ValueError, match="fenced block"):
+            _extract_python_block(text)
+
+
+# ---------------------------------------------------------------------------
+# run_critic_pass — integration-style tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCriticPass:
+    def _full_run(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+        fake_client: FakeAnthropicClient,
+        n_frames: int = 3,
+        critic_budget: int = 50_000,
+    ) -> tuple[list[Any], int]:
+        with patch("subprocess.run", side_effect=_ffmpeg_ok_factory()):
+            return run_critic_pass(
+                scene_file=scene_file,
+                video_file=video_file,
+                output_path=output_file,
+                n_frames=n_frames,
+                critic_budget=critic_budget,
+                model="claude-sonnet-4-6",
+                prompt_path=prompt_file,
+                client=fake_client,  # type: ignore[arg-type]
+            )
+
+    def test_run_critic_pass_happy_path_writes_patched_output(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient(response_text=VALID_RESPONSE)
+        # Act
+        patches, tokens = self._full_run(
+            scene_file, video_file, output_file, prompt_file, fake_client
+        )
+        # Assert
+        assert len(patches) == 1
+        assert patches[0]["target_mobject"] == "circle"
+        assert tokens == 1500
+        assert output_file.exists()
+        assert "move_to(ORIGIN)" in output_file.read_text(encoding="utf-8")
+        assert fake_client.call_count == 1
+
+    def test_run_critic_pass_scene_file_missing_raises_file_not_found(
+        self,
+        tmp_path: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient()
+        # Act / Assert
+        with pytest.raises(FileNotFoundError, match="Scene file not found"):
+            self._full_run(
+                tmp_path / "ghost.py", video_file, output_file, prompt_file, fake_client
+            )
+
+    def test_run_critic_pass_video_file_missing_raises_file_not_found(
+        self,
+        scene_file: Path,
+        tmp_path: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient()
+        # Act / Assert
+        with pytest.raises(FileNotFoundError, match="Video file not found"):
+            self._full_run(
+                scene_file, tmp_path / "ghost.mp4", output_file, prompt_file, fake_client
+            )
+
+    def test_run_critic_pass_prompt_missing_raises_file_not_found(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient()
+        # Act / Assert
+        with patch("subprocess.run", side_effect=_ffmpeg_ok_factory()):
+            with pytest.raises(FileNotFoundError, match="Critic prompt not found"):
+                run_critic_pass(
+                    scene_file=scene_file,
+                    video_file=video_file,
+                    output_path=output_file,
+                    n_frames=3,
+                    prompt_path=tmp_path / "no_critic.md",
+                    client=fake_client,  # type: ignore[arg-type]
+                )
+
+    def test_run_critic_pass_budget_exceeded_raises_budget_exceeded_error(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange — budget of 1 ensures estimation always exceeds it
+        fake_client = FakeAnthropicClient()
+        # Act / Assert
+        with patch("subprocess.run", side_effect=_ffmpeg_ok_factory()):
+            with pytest.raises(BudgetExceededError, match="Estimated token count"):
+                run_critic_pass(
+                    scene_file=scene_file,
+                    video_file=video_file,
+                    output_path=output_file,
+                    n_frames=3,
+                    critic_budget=1,
+                    prompt_path=prompt_file,
+                    client=fake_client,  # type: ignore[arg-type]
+                )
+        # No API call should be made when budget is exceeded
+        assert fake_client.call_count == 0
+
+    def test_run_critic_pass_malformed_json_response_raises_value_error(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        bad_response = "[{bad json}]\n\n```python\npass\n```"
+        fake_client = FakeAnthropicClient(response_text=bad_response)
+        # Act / Assert
+        with pytest.raises(ValueError, match="Malformed JSON"):
+            self._full_run(
+                scene_file, video_file, output_file, prompt_file, fake_client
+            )
+
+    def test_run_critic_pass_frame_count_clamped_to_max_frames(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient(response_text=VALID_RESPONSE)
+        ffmpeg_calls: list[list[str]] = []
+
+        def counting_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            if "ffprobe" in cmd[0]:
+                return _ffprobe_ok(10.0)
+            ffmpeg_calls.append(cmd)
+            out = Path(cmd[-1])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 200)
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        # Act — request 20 frames (above MAX_FRAMES=10)
+        with patch("subprocess.run", side_effect=counting_run):
+            run_critic_pass(
+                scene_file=scene_file,
+                video_file=video_file,
+                output_path=output_file,
+                n_frames=20,
+                prompt_path=prompt_file,
+                client=fake_client,  # type: ignore[arg-type]
+            )
+
+        # Assert — exactly MAX_FRAMES ffmpeg invocations
+        assert len(ffmpeg_calls) == MAX_FRAMES
+
+    def test_run_critic_pass_ffprobe_failure_raises_runtime_error_no_client_call(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        output_file: Path,
+        prompt_file: Path,
+    ) -> None:
+        # Arrange
+        fake_client = FakeAnthropicClient()
+        # Act / Assert
+        with patch("subprocess.run", return_value=_ffprobe_fail()):
+            with pytest.raises(RuntimeError, match="ffprobe failed"):
+                run_critic_pass(
+                    scene_file=scene_file,
+                    video_file=video_file,
+                    output_path=output_file,
+                    n_frames=3,
+                    prompt_path=prompt_file,
+                    client=fake_client,  # type: ignore[arg-type]
+                )
+        assert fake_client.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_cli_without_critic_flag_exits_zero_with_no_client_call(
+        self,
+        scene_file: Path,
+        video_file: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Arrange — no --critic flag; no client passed
+        # Act
+        with pytest.raises(SystemExit) as exc_info:
+            main([str(scene_file), str(video_file)])
+        # Assert
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "critic pass disabled" in captured.err
+
+    def test_cli_without_critic_flag_exits_zero_even_with_nonexistent_files(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Arrange — files don't exist; without --critic the script never reads them
+        # Act
+        with pytest.raises(SystemExit) as exc_info:
+            main([str(tmp_path / "ghost.py"), str(tmp_path / "ghost.mp4")])
+        # Assert
+        assert exc_info.value.code == 0
+        assert "critic pass disabled" in capsys.readouterr().err

--- a/skills/concept-to-video/tests/test_fetch_assets.py
+++ b/skills/concept-to-video/tests/test_fetch_assets.py
@@ -1,0 +1,545 @@
+"""Tests for fetch_assets.py — Phase 4 asset resolution."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the scripts directory importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from fetch_assets import (  # noqa: E402
+    AssetResolutionError,
+    IconFinderAdapter,
+    LocalAssetAdapter,
+    NoneAdapter,
+    _normalise_query,
+    _validate_storyboard,
+    main,
+    resolve_storyboard,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def asset_dir(tmp_path: Path) -> Path:
+    """Fixture directory with three SVG files."""
+    (tmp_path / "database.svg").write_text("<svg/>")
+    (tmp_path / "network-arrow.svg").write_text("<svg/>")
+    (tmp_path / "Computer_Server.svg").write_text("<svg/>")
+    return tmp_path
+
+
+@pytest.fixture()
+def simple_storyboard() -> dict[str, Any]:
+    return {
+        "concept": "TCP/IP",
+        "duration_estimate_seconds": 60,
+        "scenes": [
+            {
+                "index": 0,
+                "title": "Intro",
+                "duration_seconds": 15,
+                "beats": ["show computers"],
+                "assets": [
+                    {"kind": "icon", "query": "database", "required": True},
+                    {"kind": "text", "query": "TCP/IP", "required": True},
+                ],
+            },
+            {
+                "index": 1,
+                "title": "SYN",
+                "duration_seconds": 20,
+                "beats": ["animate arrow"],
+                "assets": [
+                    {"kind": "icon", "query": "network arrow", "required": False},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture()
+def storyboard_file(tmp_path: Path, simple_storyboard: dict[str, Any]) -> Path:
+    p = tmp_path / "storyboard.json"
+    p.write_text(json.dumps(simple_storyboard))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _normalise_query
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_query_lowercases_and_hyphenates() -> None:
+    # Arrange
+    query = "Computer Server"
+    # Act
+    result = _normalise_query(query)
+    # Assert
+    assert result == "computer-server"
+
+
+def test_normalise_query_collapses_underscores() -> None:
+    assert _normalise_query("network_arrow") == "network-arrow"
+
+
+def test_normalise_query_strips_whitespace() -> None:
+    assert _normalise_query("  database  ") == "database"
+
+
+# ---------------------------------------------------------------------------
+# LocalAssetAdapter
+# ---------------------------------------------------------------------------
+
+
+def test_localassetadapter_exact_match_returns_path(asset_dir: Path) -> None:
+    # Arrange
+    adapter = LocalAssetAdapter(asset_dir)
+    # Act
+    result = adapter.resolve("database", "icon")
+    # Assert
+    assert result is not None
+    assert result.name == "database.svg"
+
+
+def test_localassetadapter_case_insensitive_match_returns_path(
+    asset_dir: Path,
+) -> None:
+    # Arrange
+    adapter = LocalAssetAdapter(asset_dir)
+    # Act — file is "Computer_Server.svg"; stem normalises to "computer-server"
+    result = adapter.resolve("Computer Server", "icon")
+    # Assert
+    assert result is not None
+    assert result.name == "Computer_Server.svg"
+
+
+def test_localassetadapter_hyphen_normalised_match_returns_path(
+    asset_dir: Path,
+) -> None:
+    # Arrange
+    adapter = LocalAssetAdapter(asset_dir)
+    # Act — "network arrow" → "network-arrow" matches "network-arrow.svg"
+    result = adapter.resolve("network arrow", "icon")
+    # Assert
+    assert result is not None
+    assert result.name == "network-arrow.svg"
+
+
+def test_localassetadapter_no_match_returns_none(asset_dir: Path) -> None:
+    # Arrange
+    adapter = LocalAssetAdapter(asset_dir)
+    # Act
+    result = adapter.resolve("missing-icon", "icon")
+    # Assert
+    assert result is None
+
+
+def test_localassetadapter_invalid_directory_raises_valueerror(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    missing = tmp_path / "no_such_dir"
+    # Act / Assert
+    with pytest.raises(ValueError, match="asset-dir does not exist"):
+        LocalAssetAdapter(missing)
+
+
+# ---------------------------------------------------------------------------
+# NoneAdapter
+# ---------------------------------------------------------------------------
+
+
+def test_noneadapter_always_returns_none() -> None:
+    # Arrange
+    adapter = NoneAdapter()
+    # Act / Assert
+    assert adapter.resolve("anything", "icon") is None
+    assert adapter.resolve("", "text") is None
+
+
+def test_noneadapter_name_is_none() -> None:
+    assert NoneAdapter().name == "none"
+
+
+# ---------------------------------------------------------------------------
+# IconFinderAdapter
+# ---------------------------------------------------------------------------
+
+
+def test_iconfinderadapter_missing_api_key_raises_valueerror_at_construction() -> None:
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="ICONFINDER_API_KEY is not set"):
+        IconFinderAdapter("")
+
+
+def test_iconfinderadapter_from_env_missing_key_raises_valueerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    monkeypatch.delenv("ICONFINDER_API_KEY", raising=False)
+    # Act / Assert
+    with pytest.raises(ValueError, match="ICONFINDER_API_KEY is not set"):
+        IconFinderAdapter.from_env()
+
+
+def _make_urlopen_mock(
+    search_payload: dict[str, Any],
+    download_bytes: bytes = b"<svg/>",
+) -> Any:
+    """Return a patch target that returns search then download responses."""
+    call_count = 0
+
+    def fake_urlopen(req: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read.return_value = json.dumps(search_payload).encode()
+            return resp
+        else:
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read.return_value = download_bytes
+            return resp
+
+    return fake_urlopen
+
+
+def test_iconfinderadapter_resolve_successful_fetch_returns_path(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    payload = {
+        "icons": [
+            {
+                "vector_sizes": [
+                    {
+                        "formats": [
+                            {"download_url": "https://cdn.iconfinder.com/data/icons/db.svg"}
+                        ]
+                    }
+                ],
+                "raster_sizes": [],
+            }
+        ]
+    }
+    adapter = IconFinderAdapter("test-key")
+    fake_open = _make_urlopen_mock(payload)
+
+    with patch("urllib.request.urlopen", side_effect=fake_open):
+        with patch.dict("os.environ", {"TMPDIR": str(tmp_path)}):
+            # Act
+            result = adapter.resolve("database", "icon")
+
+    # Assert
+    assert result is not None
+    assert result.suffix == ".svg"
+    assert result.parent == tmp_path
+
+
+def test_iconfinderadapter_resolve_http_404_raises_runtimeerror() -> None:
+    # Arrange
+    import urllib.error
+
+    adapter = IconFinderAdapter("test-key")
+
+    def fake_urlopen(req: Any) -> Any:
+        raise urllib.error.HTTPError(
+            url="https://api.iconfinder.com/v4/icons/search",
+            code=404,
+            msg="Not Found",
+            hdrs=MagicMock(),
+            fp=None,
+        )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="HTTP 404"):
+            adapter.resolve("missing", "icon")
+
+
+def test_iconfinderadapter_resolve_http_500_raises_runtimeerror() -> None:
+    # Arrange
+    import urllib.error
+
+    adapter = IconFinderAdapter("test-key")
+
+    def fake_urlopen(req: Any) -> Any:
+        raise urllib.error.HTTPError(
+            url="https://api.iconfinder.com/v4/icons/search",
+            code=500,
+            msg="Server Error",
+            hdrs=MagicMock(),
+            fp=None,
+        )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            adapter.resolve("database", "icon")
+
+
+def test_iconfinderadapter_resolve_url_contains_encoded_query(
+    tmp_path: Path,
+) -> None:
+    """urlencode must come from urllib.parse — this test catches the wrong-module bug."""
+    # Arrange
+    captured_urls: list[str] = []
+    payload = {
+        "icons": [
+            {
+                "vector_sizes": [
+                    {
+                        "formats": [
+                            {"download_url": "https://cdn.iconfinder.com/data/icons/db.svg"}
+                        ]
+                    }
+                ],
+                "raster_sizes": [],
+            }
+        ]
+    }
+    adapter = IconFinderAdapter("test-key")
+    fake_open = _make_urlopen_mock(payload)
+
+    original_side_effect = fake_open
+
+    def capturing_urlopen(req: Any) -> Any:
+        if hasattr(req, "full_url"):
+            captured_urls.append(req.full_url)
+        return original_side_effect(req)
+
+    with patch("urllib.request.urlopen", side_effect=capturing_urlopen):
+        with patch.dict("os.environ", {"TMPDIR": str(tmp_path)}):
+            # Act
+            adapter.resolve("my query", "icon")
+
+    # Assert — the search URL must contain the percent-encoded query param
+    assert captured_urls, "urlopen was never called"
+    search_url = captured_urls[0]
+    assert "query=my+query" in search_url or "query=my%20query" in search_url
+
+
+def test_iconfinderadapter_resolve_no_results_returns_none() -> None:
+    # Arrange
+    adapter = IconFinderAdapter("test-key")
+    payload: dict[str, Any] = {"icons": []}
+
+    def fake_urlopen(req: Any) -> Any:
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.read.return_value = json.dumps(payload).encode()
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        # Act
+        result = adapter.resolve("obscure-query", "icon")
+
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _validate_storyboard
+# ---------------------------------------------------------------------------
+
+
+def test_validate_storyboard_missing_scenes_raises_valueerror() -> None:
+    with pytest.raises(ValueError, match="scenes"):
+        _validate_storyboard({"concept": "x"})
+
+
+def test_validate_storyboard_empty_scenes_raises_valueerror() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        _validate_storyboard({"scenes": []})
+
+
+def test_validate_storyboard_invalid_kind_raises_valueerror() -> None:
+    bad: dict[str, Any] = {
+        "scenes": [
+            {
+                "index": 0,
+                "assets": [{"kind": "video", "query": "x", "required": True}],
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="kind"):
+        _validate_storyboard(bad)
+
+
+def test_validate_storyboard_required_not_bool_raises_valueerror() -> None:
+    bad: dict[str, Any] = {
+        "scenes": [
+            {
+                "index": 0,
+                "assets": [{"kind": "icon", "query": "x", "required": "true"}],
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="required.*boolean"):
+        _validate_storyboard(bad)
+
+
+# ---------------------------------------------------------------------------
+# resolve_storyboard — integration
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_storyboard_with_none_adapter_returns_null_mapping(
+    simple_storyboard: dict[str, Any],
+) -> None:
+    # Arrange — mark all assets optional so NoneAdapter doesn't raise
+    for scene in simple_storyboard["scenes"]:
+        for asset in scene["assets"]:
+            asset["required"] = False
+    adapter = NoneAdapter()
+    # Act
+    result = resolve_storyboard(simple_storyboard, adapter)
+    # Assert
+    assert set(result.keys()) == {0, 1}
+    assert result[0]["database"] is None
+    assert result[0]["TCP/IP"] is None
+    assert result[1]["network arrow"] is None
+
+
+def test_resolve_storyboard_with_local_adapter_resolves_database(
+    simple_storyboard: dict[str, Any],
+    asset_dir: Path,
+) -> None:
+    # Arrange
+    adapter = LocalAssetAdapter(asset_dir)
+    # "TCP/IP" asset is required but won't resolve — patch it to optional
+    simple_storyboard["scenes"][0]["assets"][1]["required"] = False
+    # Act
+    result = resolve_storyboard(simple_storyboard, adapter)
+    # Assert
+    assert result[0]["database"] is not None
+    assert result[0]["database"].endswith("database.svg")
+    assert result[1]["network arrow"] is not None
+
+
+def test_resolve_storyboard_required_missing_raises_assetresolutionerror(
+    simple_storyboard: dict[str, Any],
+) -> None:
+    # Arrange
+    adapter = NoneAdapter()
+    # Both assets in scene 0 are required=True, NoneAdapter returns None
+    # Act / Assert
+    with pytest.raises(AssetResolutionError) as exc_info:
+        resolve_storyboard(simple_storyboard, adapter)
+    err = exc_info.value
+    assert isinstance(err.missing, list)
+    assert "database" in err.missing
+    assert "TCP/IP" in err.missing
+
+
+def test_resolve_storyboard_optional_missing_does_not_raise(
+    simple_storyboard: dict[str, Any],
+    asset_dir: Path,
+) -> None:
+    # Arrange — mark all assets optional
+    for scene in simple_storyboard["scenes"]:
+        for asset in scene["assets"]:
+            asset["required"] = False
+    adapter = NoneAdapter()
+    # Act — should not raise
+    result = resolve_storyboard(simple_storyboard, adapter)
+    # Assert
+    assert result[0]["database"] is None
+
+
+def test_assetresolutionerror_has_missing_attribute() -> None:
+    # Arrange / Act
+    err = AssetResolutionError(["icon-a", "icon-b"])
+    # Assert
+    assert err.missing == ["icon-a", "icon-b"]
+    assert "icon-a" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_main_cli_happy_path_local_adapter_prints_json(
+    storyboard_file: Path,
+    asset_dir: Path,
+    simple_storyboard: dict[str, Any],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Arrange — make all required assets optional so NoneAdapter won't raise
+    # Rewrite storyboard with all optional
+    for scene in simple_storyboard["scenes"]:
+        for asset in scene["assets"]:
+            asset["required"] = False
+    storyboard_file.write_text(json.dumps(simple_storyboard))
+
+    # Act
+    main(
+        [
+            str(storyboard_file),
+            "--adapter",
+            "local",
+            "--asset-dir",
+            str(asset_dir),
+        ]
+    )
+
+    # Assert
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "0" in output
+    assert "database" in output["0"]
+
+
+def test_main_cli_output_file_written(
+    storyboard_file: Path,
+    tmp_path: Path,
+    simple_storyboard: dict[str, Any],
+) -> None:
+    # Arrange — all optional to avoid resolution error
+    for scene in simple_storyboard["scenes"]:
+        for asset in scene["assets"]:
+            asset["required"] = False
+    storyboard_file.write_text(json.dumps(simple_storyboard))
+    out_file = tmp_path / "resolved.json"
+
+    # Act
+    main(["--adapter", "none", "--output", str(out_file), str(storyboard_file)])
+
+    # Assert
+    assert out_file.exists()
+    data = json.loads(out_file.read_text())
+    assert "0" in data
+
+
+def test_main_cli_malformed_storyboard_raises_valueerror(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{not valid json")
+    # Act / Assert
+    with pytest.raises(ValueError, match="malformed storyboard JSON"):
+        main(["--adapter", "none", str(bad_file)])
+
+
+def test_main_cli_missing_asset_dir_raises_valueerror(
+    storyboard_file: Path,
+) -> None:
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="--asset-dir is required"):
+        main(["--adapter", "local", str(storyboard_file)])

--- a/skills/concept-to-video/tests/test_plan_storyboard.py
+++ b/skills/concept-to-video/tests/test_plan_storyboard.py
@@ -1,0 +1,304 @@
+"""Unit tests for plan_storyboard.py — Planner stage."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic.types import TextBlock
+
+# Make the scripts directory importable without installing
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from plan_storyboard import StoryboardPlanner, validate_storyboard  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_valid_storyboard(concept: str = "Test concept") -> dict[str, Any]:
+    return {
+        "concept": concept,
+        "duration_estimate_seconds": 60,
+        "scenes": [
+            {
+                "index": 0,
+                "title": "Intro",
+                "duration_seconds": 15,
+                "beats": ["Show title", "Introduce concept"],
+                "assets": [
+                    {"kind": "icon", "query": "lightbulb", "required": True},
+                    {"kind": "text", "query": "Hello World", "required": False},
+                ],
+            }
+        ],
+    }
+
+
+def _fake_client(response_text: str) -> MagicMock:
+    """Return a minimal fake Anthropic client that returns response_text from messages.create."""
+    content_block = TextBlock(type="text", text=response_text)
+    message = MagicMock()
+    message.content = [content_block]
+    client = MagicMock()
+    client.messages.create.return_value = message
+    return client
+
+
+@pytest.fixture()
+def prompt_file(tmp_path: Path) -> Path:
+    """Write a minimal planner prompt template and return its path."""
+    p = tmp_path / "planner.md"
+    p.write_text("Plan this concept: {concept}", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# validate_storyboard — happy path
+# ---------------------------------------------------------------------------
+
+def test_validate_storyboard_valid_input_returns_dict() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+
+    # Act
+    result = validate_storyboard(data)
+
+    # Assert
+    assert result["concept"] == "Test concept"
+    assert len(result["scenes"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# validate_storyboard — schema violations
+# ---------------------------------------------------------------------------
+
+def test_validate_storyboard_missing_concept_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    del data["concept"]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="root.concept"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_missing_duration_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    del data["duration_estimate_seconds"]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="root.duration_estimate_seconds"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_empty_scenes_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["scenes"] = []
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="root.scenes"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_scenes_not_list_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["scenes"] = "not a list"
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="root.scenes"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_scene_missing_title_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    del data["scenes"][0]["title"]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.title"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_scene_missing_beats_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    del data["scenes"][0]["beats"]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.beats"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_scene_empty_beats_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["scenes"][0]["beats"] = []
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.beats"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_asset_invalid_kind_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["scenes"][0]["assets"][0]["kind"] = "video"
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.assets\[0\]\.kind"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_asset_missing_query_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    del data["scenes"][0]["assets"][0]["query"]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.assets\[0\]\.query"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_asset_required_not_bool_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["scenes"][0]["assets"][0]["required"] = "yes"
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"root\.scenes\[0\]\.assets\[0\]\.required"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_negative_duration_raises_value_error() -> None:
+    # Arrange
+    data = _make_valid_storyboard()
+    data["duration_estimate_seconds"] = -5
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="root.duration_estimate_seconds"):
+        validate_storyboard(data)
+
+
+def test_validate_storyboard_root_not_dict_raises_value_error() -> None:
+    # Act / Assert
+    with pytest.raises(ValueError, match="root"):
+        validate_storyboard("not a dict")
+
+
+# ---------------------------------------------------------------------------
+# StoryboardPlanner.plan — happy path
+# ---------------------------------------------------------------------------
+
+def test_plan_valid_concept_returns_storyboard(prompt_file: Path) -> None:
+    # Arrange
+    storyboard = _make_valid_storyboard("Binary search algorithm")
+    storyboard["concept"] = "Binary search algorithm"
+    client = _fake_client(json.dumps(storyboard))
+    planner = StoryboardPlanner(client=client, prompt_path=prompt_file)
+
+    # Act
+    result = planner.plan("Binary search algorithm")
+
+    # Assert
+    assert result["concept"] == "Binary search algorithm"
+    assert result["scenes"][0]["index"] == 0
+    client.messages.create.assert_called_once()
+
+
+def test_plan_substitutes_concept_into_prompt(prompt_file: Path) -> None:
+    # Arrange
+    storyboard = _make_valid_storyboard("Fourier transform")
+    storyboard["concept"] = "Fourier transform"
+    client = _fake_client(json.dumps(storyboard))
+    planner = StoryboardPlanner(client=client, prompt_path=prompt_file)
+
+    # Act
+    planner.plan("Fourier transform")
+
+    # Assert — the prompt sent to the API contains the concept text
+    call_kwargs = client.messages.create.call_args
+    messages = call_kwargs.kwargs["messages"]
+    assert "Fourier transform" in messages[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# StoryboardPlanner.plan — JSON parse failure
+# ---------------------------------------------------------------------------
+
+def test_plan_non_json_response_raises_value_error_with_raw_output(
+    prompt_file: Path,
+) -> None:
+    # Arrange
+    raw = "Sorry, I cannot generate a storyboard right now."
+    client = _fake_client(raw)
+    planner = StoryboardPlanner(client=client, prompt_path=prompt_file)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="non-JSON") as exc_info:
+        planner.plan("some concept")
+    assert raw in str(exc_info.value)
+
+
+def test_plan_partial_json_raises_value_error(prompt_file: Path) -> None:
+    # Arrange
+    client = _fake_client('{"concept": "x"')  # truncated JSON
+    planner = StoryboardPlanner(client=client, prompt_path=prompt_file)
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="non-JSON"):
+        planner.plan("some concept")
+
+
+# ---------------------------------------------------------------------------
+# StoryboardPlanner — prompt file loading
+# ---------------------------------------------------------------------------
+
+def test_plan_missing_prompt_file_raises_file_not_found_error() -> None:
+    # Arrange
+    client = _fake_client("{}")
+    missing = Path("/tmp/does_not_exist_planner_prompt.md")
+    planner = StoryboardPlanner(client=client, prompt_path=missing)
+
+    # Act / Assert
+    with pytest.raises(FileNotFoundError, match="Planner prompt not found"):
+        planner.plan("any concept")
+
+
+def test_plan_prompt_file_path_included_in_error_message() -> None:
+    # Arrange
+    client = _fake_client("{}")
+    missing = Path("/tmp/no_such_prompt_xyz.md")
+    planner = StoryboardPlanner(client=client, prompt_path=missing)
+
+    # Act / Assert
+    with pytest.raises(FileNotFoundError, match=str(missing)):
+        planner.plan("any concept")
+
+
+# ---------------------------------------------------------------------------
+# StoryboardPlanner — model override
+# ---------------------------------------------------------------------------
+
+def test_plan_uses_custom_model_when_provided(prompt_file: Path) -> None:
+    # Arrange
+    storyboard = _make_valid_storyboard()
+    client = _fake_client(json.dumps(storyboard))
+    planner = StoryboardPlanner(
+        client=client, model="claude-opus-4-5", prompt_path=prompt_file
+    )
+
+    # Act
+    planner.plan("test concept")
+
+    # Assert
+    call_kwargs = client.messages.create.call_args
+    assert call_kwargs.kwargs["model"] == "claude-opus-4-5"

--- a/skills/concept-to-video/tests/test_render_video_autofix.py
+++ b/skills/concept-to-video/tests/test_render_video_autofix.py
@@ -1,0 +1,453 @@
+"""
+Tests for the auto-fix loop in render_video.py and _fixup_client.py.
+
+All tests mock subprocess.run — no actual Manim invocations.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the scripts directory importable without installing
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from render_video import (  # noqa: E402
+    extract_error_class,
+    parse_offending_lines,
+    run_with_autofix,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MANIM_CMD = ["python3", "-m", "manim", "render", "-qh", "--format=mp4", "--media_dir=/tmp", "scene.py", "MyScene"]
+
+SAMPLE_TRACEBACK = textwrap.dedent("""\
+    Traceback (most recent call last):
+      File "/usr/lib/python3.12/subprocess.py", line 1009, in run
+        retcode = process.wait(timeout=timeout)
+      File "/path/to/scene.py", line 5, in construct
+        self.play(undefined_var.animate.shift(UP))
+      File "/path/to/manim/animation.py", line 100, in play
+        ...
+    NameError: name 'undefined_var' is not defined
+""")
+
+
+@pytest.fixture()
+def scene_file(tmp_path: Path) -> Path:
+    """A minimal Manim scene file in a temp directory."""
+    f = tmp_path / "scene.py"
+    f.write_text(
+        textwrap.dedent("""\
+            from manim import *
+
+            class MyScene(Scene):
+                def construct(self):
+                    circle = Circle()
+                    self.play(Create(circle))
+        """),
+        encoding="utf-8",
+    )
+    return f
+
+
+@pytest.fixture()
+def coder_prompt_file(tmp_path: Path) -> Path:
+    """A minimal stand-in coder.md prompt file."""
+    refs = tmp_path / "references" / "code2video"
+    refs.mkdir(parents=True)
+    prompt = refs / "coder.md"
+    prompt.write_text("# Fixup\nFix the Manim scene.", encoding="utf-8")
+    return prompt
+
+
+PATCHED_SCENE = textwrap.dedent("""\
+    from manim import *
+
+    class MyScene(Scene):
+        def construct(self):
+            square = Square()
+            self.play(Create(square))
+""")
+
+FENCED_RESPONSE = f"Here is the fix:\n\n```python\n{PATCHED_SCENE}```\n"
+
+
+# ---------------------------------------------------------------------------
+# FakeAnthropicClient
+# ---------------------------------------------------------------------------
+
+class FakeMessage:
+    def __init__(self, text: str) -> None:
+        self.content = [SimpleNamespace(text=text)]
+
+
+class FakeAnthropicClient:
+    """Dependency-injected fake — returns canned response, no network."""
+
+    def __init__(self, response_text: str = FENCED_RESPONSE) -> None:
+        self.response_text = response_text
+        self.messages = self  # mimic client.messages.create(...)
+        self.call_count = 0
+
+    def create(self, **kwargs: object) -> FakeMessage:  # noqa: ARG002
+        self.call_count += 1
+        return FakeMessage(self.response_text)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: extract_error_class
+# ---------------------------------------------------------------------------
+
+def test_extract_error_class_name_error_returns_correct_class() -> None:
+    # Arrange
+    stderr = SAMPLE_TRACEBACK
+
+    # Act
+    result = extract_error_class(stderr)
+
+    # Assert
+    assert result == "NameError"
+
+
+def test_extract_error_class_unknown_stderr_returns_unknown_error() -> None:
+    # Arrange
+    stderr = "manim exited with some weird output"
+
+    # Act
+    result = extract_error_class(stderr)
+
+    # Assert
+    assert result == "UnknownError"
+
+
+def test_extract_error_class_attribute_error_detected() -> None:
+    # Arrange
+    stderr = "AttributeError: 'NoneType' object has no attribute 'shift'"
+
+    # Act
+    result = extract_error_class(stderr)
+
+    # Assert
+    assert result == "AttributeError"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: parse_offending_lines
+# ---------------------------------------------------------------------------
+
+def test_parse_offending_lines_extracts_range_from_traceback(scene_file: Path) -> None:
+    # Arrange — patch traceback to reference our scene_file
+    stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+
+    # Act
+    result = parse_offending_lines(scene_file, stderr)
+
+    # Assert
+    assert result is not None
+    start, end = result
+    assert start <= 5 <= end  # line 5 must be within the extracted range
+
+
+def test_parse_offending_lines_returns_none_when_no_match(scene_file: Path) -> None:
+    # Arrange — traceback references a different file
+    stderr = SAMPLE_TRACEBACK  # uses /path/to/scene.py, not scene_file
+
+    # Act
+    result = parse_offending_lines(scene_file, stderr)
+
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _fixup_client.request_patch
+# ---------------------------------------------------------------------------
+
+def test_request_patch_returns_patched_scene_content(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient()
+
+    # Act
+    result = fc.request_patch(scene_file, SAMPLE_TRACEBACK, None, client=fake_client)
+
+    # Assert
+    assert "Square" in result  # patched version swaps Circle → Square
+    assert fake_client.call_count == 1
+
+
+def test_request_patch_missing_prompt_file_raises_file_not_found(
+    scene_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", Path("/nonexistent/coder.md"))
+    fake_client = FakeAnthropicClient()
+
+    # Act / Assert
+    with pytest.raises(FileNotFoundError):
+        fc.request_patch(scene_file, "some error", None, client=fake_client)
+
+
+def test_request_patch_no_fenced_block_raises_value_error(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange — response has no ```python block
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient(response_text="I cannot fix this scene.")
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="no fenced"):
+        fc.request_patch(scene_file, "some error", None, client=fake_client)
+
+
+def test_request_patch_includes_offending_lines_in_prompt(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+
+    captured_messages: list[dict[str, object]] = []
+
+    class CapturingClient:
+        def __init__(self) -> None:
+            self.messages: CapturingClient = self
+
+        def create(self, **kwargs: object) -> FakeMessage:
+            captured_messages.append(dict(kwargs))
+            return FakeMessage(FENCED_RESPONSE)
+
+    # Act
+    fc.request_patch(scene_file, "err", (3, 5), client=CapturingClient())
+
+    # Assert
+    assert captured_messages, "No API call made"
+    content = str(captured_messages[0].get("messages", ""))
+    assert "3" in content  # offending line range present
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: run_with_autofix
+# ---------------------------------------------------------------------------
+
+def test_run_with_autofix_n0_does_not_call_fixup_on_failure(
+    scene_file: Path,
+) -> None:
+    """N=0 must preserve exact current behavior — no fixup, no capture."""
+    # Arrange
+    failing_result = MagicMock()
+    failing_result.returncode = 1
+
+    with patch("render_video.subprocess.run", return_value=failing_result) as mock_run:
+        # Act
+        result = run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=0)
+
+    # Assert
+    mock_run.assert_called_once_with(MANIM_CMD, capture_output=False, text=True)
+    assert result.returncode == 1
+
+
+def test_run_with_autofix_n0_success_returns_result(scene_file: Path) -> None:
+    """N=0 on success passes through the result unchanged."""
+    # Arrange
+    ok_result = MagicMock()
+    ok_result.returncode = 0
+    ok_result.stdout = ""
+
+    with patch("render_video.subprocess.run", return_value=ok_result) as mock_run:
+        # Act
+        result = run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=0)
+
+    # Assert
+    mock_run.assert_called_once_with(MANIM_CMD, capture_output=False, text=True)
+    assert result.returncode == 0
+
+
+def test_run_with_autofix_n1_fixup_called_then_succeeds(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N=1: first render fails → fixup called → retry succeeds."""
+    # Arrange
+    fail_result = MagicMock()
+    fail_result.returncode = 1
+    fail_result.stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+    fail_result.stdout = ""
+
+    ok_result = MagicMock()
+    ok_result.returncode = 0
+    ok_result.stdout = ""
+
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient()
+    monkeypatch.setattr(fc, "AnthropicClient", lambda: fake_client)
+
+    subprocess_results = iter([fail_result, ok_result])
+
+    with patch("render_video.subprocess.run", side_effect=lambda *a, **kw: next(subprocess_results)):
+        # Act
+        result = run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=1)
+
+    # Assert
+    assert result.returncode == 0
+    assert fake_client.call_count == 1  # fixup was called exactly once
+
+
+def test_run_with_autofix_n1_backup_created_on_attempt(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backup file <scene>.bak.1 must exist after one fixup attempt."""
+    # Arrange
+    fail_result = MagicMock()
+    fail_result.returncode = 1
+    fail_result.stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+    fail_result.stdout = ""
+
+    ok_result = MagicMock()
+    ok_result.returncode = 0
+    ok_result.stdout = ""
+
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient()
+    monkeypatch.setattr(fc, "AnthropicClient", lambda: fake_client)
+
+    subprocess_results = iter([fail_result, ok_result])
+
+    with patch("render_video.subprocess.run", side_effect=lambda *a, **kw: next(subprocess_results)):
+        run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=1)
+
+    # Assert
+    backup = scene_file.with_suffix(".bak.1")
+    assert backup.exists(), f"Expected backup at {backup}"
+
+
+def test_run_with_autofix_n3_persistent_failure_raises_original_error(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N=3 with all attempts failing returns original result (exit code != 0)."""
+    # Arrange
+    fail_result = MagicMock()
+    fail_result.returncode = 1
+    fail_result.stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+    fail_result.stdout = ""
+
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient()
+    monkeypatch.setattr(fc, "AnthropicClient", lambda: fake_client)
+
+    # 4 calls total: initial + 3 retries, all fail
+    with patch("render_video.subprocess.run", return_value=fail_result):
+        result = run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=3)
+
+    # Assert — original error returned, not swallowed
+    assert result.returncode == 1
+    assert fake_client.call_count == 3  # tried all 3 patches
+
+
+def test_run_with_autofix_n3_log_file_has_three_entries(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Log file must contain exactly 3 JSONL entries after 3 failed attempts."""
+    # Arrange
+    fail_result = MagicMock()
+    fail_result.returncode = 1
+    fail_result.stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+    fail_result.stdout = ""
+
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    fake_client = FakeAnthropicClient()
+    monkeypatch.setattr(fc, "AnthropicClient", lambda: fake_client)
+
+    with patch("render_video.subprocess.run", return_value=fail_result):
+        run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=3)
+
+    # Assert
+    log_path = scene_file.with_name(scene_file.stem + ".render-log.jsonl")
+    assert log_path.exists(), f"Log file not found at {log_path}"
+
+    entries = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(entries) == 3
+
+    for i, entry in enumerate(entries, start=1):
+        assert entry["attempt"] == i
+        assert "error_class" in entry
+        assert "stderr_tail" in entry
+        assert "diff_summary" in entry
+        assert "timestamp" in entry
+
+
+def test_run_with_autofix_n3_backups_created_for_each_attempt(
+    scene_file: Path,
+    coder_prompt_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backup files .bak.1, .bak.2, .bak.3 must all exist after 3 attempts."""
+    # Arrange
+    fail_result = MagicMock()
+    fail_result.returncode = 1
+    fail_result.stderr = SAMPLE_TRACEBACK.replace("/path/to/scene.py", str(scene_file))
+    fail_result.stdout = ""
+
+    import _fixup_client as fc
+    monkeypatch.setattr(fc, "_CODER_PROMPT_PATH", coder_prompt_file)
+    monkeypatch.setattr(fc, "AnthropicClient", lambda: FakeAnthropicClient())
+
+    with patch("render_video.subprocess.run", return_value=fail_result):
+        run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=3)
+
+    # Assert
+    for n in (1, 2, 3):
+        backup = scene_file.with_suffix(f".bak.{n}")
+        assert backup.exists(), f"Missing backup: {backup}"
+
+
+def test_run_with_autofix_first_success_skips_fixup(
+    scene_file: Path,
+) -> None:
+    """When initial render succeeds, no fixup is invoked regardless of N."""
+    # Arrange
+    ok_result = MagicMock()
+    ok_result.returncode = 0
+    ok_result.stdout = ""
+
+    with patch("render_video.subprocess.run", return_value=ok_result) as mock_run:
+        result = run_with_autofix(MANIM_CMD, scene_file, max_fix_attempts=3)
+
+    # Assert
+    assert result.returncode == 0
+    mock_run.assert_called_once()  # no retry subprocess calls


### PR DESCRIPTION
## Summary

Adds an opt-in agentic pipeline to `concept-to-video` that layers three Code2Video-derived patterns over the existing single-shot Manim workflow: a storyboard planner, a render-failure auto-fix loop, and a VLM layout critic. All new behavior is gated behind flags, so the default code path is byte-identical to v1.1.1 and existing invocations are unaffected. Skill version bumped to **1.2.0**.

## Motivation

The current single-shot flow (`concept → one Manim scene → render`) works but has a well-known failure mode: text overlapping mobjects, elements drifting off canvas, and silent layout bugs that only surface on playback. Code2Video (arXiv 2510.01174, NeurIPS 2025 DL4C) reports ~40% quality improvement over direct code generation on the MMMC benchmark by introducing three portable patterns:

1. **Plan first** — expand the concept into a storyboard before writing any Manim code
2. **Auto-fix on render failure** — capture stderr, feed it back to the coder, retry
3. **Visual critic** — sample frames from the rendered video and ask a VLM to patch the layout

Code2Video ships as a research codebase rather than a library, so this PR reimplements the methodology inside the existing skill under MIT attribution rather than wrapping it.

## What changes (7 commits)

| # | Commit | Scope |
|---|--------|-------|
| 1 | `chore(concept-to-video): add pyright config and tests conftest` | Adds `pyrightconfig.json` and `tests/conftest.py` so the tests directory can resolve sibling imports from `scripts/`. Prerequisite for the phased commits that follow. |
| 2 | `feat(concept-to-video): vendor Code2Video prompt templates` | New `references/code2video/` directory with `LICENSE`, `ATTRIBUTION.md` (pins upstream commit SHA), and three prompt templates (`planner.md`, `coder.md`, `critic.md`) adapted to the storyboard schema. |
| 3 | `feat(concept-to-video): add storyboard planner stage` | New `plan_storyboard.py` CLI + `storyboard-schema.md`. Emits validated storyboard JSON from a concept string via the Anthropic Messages API with the vendored planner prompt. |
| 4 | `feat(concept-to-video): add render auto-fix loop` | Extends `render_video.py` with `--max-fix-attempts N` (default 0, hard cap 3). On non-zero exit, parses the traceback, asks the coder prompt to patch the scene file, logs the attempt as JSONL, backs up the prior version, and retries. New `_fixup_client.py` keeps the LLM call isolated from the subprocess wrapper. |
| 5 | `feat(concept-to-video): add VLM critic pass` | New `critic_pass.py` CLI. Samples N frames from the rendered video via ffmpeg, sends them with the scene source to a VLM using the critic prompt, and applies the returned layout patches. Gated behind `--critic`, bounded by `--critic-budget`, aborts via `BudgetExceededError` before any API call if the estimate exceeds the ceiling. |
| 6 | `feat(concept-to-video): add pluggable asset sourcing` | New `fetch_assets.py` with three adapters behind a common Protocol: `LocalAssetAdapter`, `IconFinderAdapter`, `NoneAdapter`. Required assets that fail to resolve raise `AssetResolutionError` rather than silently skipping. Replaces Code2Video's hardcoded IconFinder dependency, which broke in 2025.10. |
| 7 | `feat(concept-to-video): document agentic mode and bump to 1.2.0` | Adds an "Agentic Mode (Opt-In)" section to `SKILL.md` with pipeline diagram, flag reference table, cost tradeoffs, invocation example, and attribution pointer. Adds 5 eval cases (auto-fix NameError recovery, off-canvas recovery, exhaustion, critic layout fix, budget abort). Regenerates the top-level `manifest.yaml`. |

## Pipeline

```
concept
  └─► plan_storyboard.py ──► storyboard.json
            │
            ▼
      fetch_assets.py (optional)
            │
            ▼
      coder writes scene.py
            │
            ▼
      render_video.py --max-fix-attempts N
            │  ▲
            │  └─ LLM fixup loop (on failure, up to N retries)
            ▼
      critic_pass.py --critic
            │  ▲
            │  └─ VLM layout patch (1 call with M image blocks)
            ▼
       final MP4
```

## New CLI surface

| Script | Flag | Default | Hard cap | Effect |
|--------|------|---------|----------|--------|
| `render_video.py` | `--max-fix-attempts` | `0` | `3` | LLM-assisted auto-fix on render failure; 0 disables the loop entirely |
| `critic_pass.py` | `--critic` | disabled | — | Enable the VLM critic pass; no-op without this flag |
| `critic_pass.py` | `--critic-budget` | `50000` | — | Token ceiling for the critic call; aborts loudly if exceeded |
| `critic_pass.py` | `--frames` | `5` | `10` | Frames sampled from the rendered video for the critic |
| `fetch_assets.py` | `--adapter` | `none` | — | Asset backend: `local`, `iconfinder`, `none` |
| `fetch_assets.py` | `--asset-dir` | — | — | Root directory for `--adapter=local` |

## Design principles

- **Opt-in everywhere.** Every new feature is disabled by default. `--max-fix-attempts 0`, `--critic` absent, `--adapter none` — no existing invocation changes behavior.
- **Fail fast, fail loud.** `BudgetExceededError`, `AssetResolutionError`, `FileNotFoundError` for missing prompts, `ValueError` with raw output on malformed LLM responses. No silent fallbacks, no swallowed exceptions, no `try/except ImportError`. Per the repo's No Bullshit Code rules.
- **Dependency injection for testability.** Every LLM-calling function accepts a client parameter so tests run against fakes with no network access. Production CLIs build real clients at the entry point.
- **Self-contained package.** All vendored content lives under `skills/concept-to-video/references/code2video/`. No cross-package references. No new top-level repo dependencies.

## Test coverage

**93 tests, all passing.** `ruff check`, `mypy --strict`, `pytest` all green.

| Test file | Tests | Covers |
|-----------|-------|--------|
| `test_plan_storyboard.py` | 20 | Schema validation happy path and failure modes, JSON parse errors, prompt file loading, text-block narrowing |
| `test_render_video_autofix.py` | 17 | N=0 passthrough (byte-identical to pre-change), N=1 recovery, N=3 exhaustion raising original error, backup creation per attempt, log file structure, traceback line extraction, missing-prompt error |
| `test_critic_pass.py` | 26 | `--critic` disabled → zero client calls, happy path, budget-exceeded abort before API call, malformed JSON response, frame count clamping to MAX_FRAMES, ffprobe failure propagation, missing scene/prompt files |
| `test_fetch_assets.py` | 30 | Three adapters (Local, IconFinder, None), storyboard validation, URL encoding assertion, HTTP error propagation, `AssetResolutionError` on required-missing, CLI end-to-end |

### Eval cases added

5 new cases in `evals/cases.yaml`:

- `autofix_recovery_name_error` — planted NameError patched within 2 attempts; log has 1 entry
- `autofix_recovery_off_canvas` — off-canvas mobject repositioned; diff_summary logged
- `autofix_exhaustion` — permanently broken scene; 3-attempt loop exhausted; non-zero exit
- `critic_driven_layout_fix` — text-overlaps-rectangle; critic returns non-empty patches
- `critic_budget_abort` — `--critic-budget 100` triggers `BudgetExceededError` before any API call

## Attribution and licensing

Code2Video is vendored under MIT attribution at `skills/concept-to-video/references/code2video/`. `ATTRIBUTION.md` pins upstream commit `f579f1e527f9d6684eb581853f8739b6b39f2914`, documents what was vendored verbatim (prompts), what was reimplemented (auto-fix loop, critic pass), and what was deliberately skipped (MMMC benchmark, TeachQuiz metric, IconFinder hardcoded integration). Upstream `LICENSE` is included.

## Backward compatibility

- Skill version bumped `1.1.1 → 1.2.0` (minor — strictly additive).
- `render_video.py` default behavior is byte-identical to v1.1.1 — verified by the N=0 passthrough test.
- No changes to the single-shot workflow documented in Steps 0–5.5 of `SKILL.md`.
- No new top-level repo dependencies; all new scripts use `anthropic` (already available) and stdlib only.
- Existing `add_audio.py` untouched.

## Quality gates

| Gate | Status |
|------|--------|
| `uv run pytest skills/concept-to-video/tests/` | 93/93 passed |
| `uv run ruff check skills/concept-to-video/scripts/ skills/concept-to-video/tests/` | clean |
| `uv run mypy --strict skills/concept-to-video/scripts/` | clean (6 source files) |
| `package-evaluator skills/concept-to-video` | 97.6% — Exemplary |
| `uv run python scripts/generate_manifest.py` | manifest regenerated |

Package-evaluator flagged one LOW-severity finding: the top-level Reference Files table in `SKILL.md` does not yet enumerate the new agentic-mode scripts. Deferred to a follow-up — the Agentic Mode section documents them inline.

## Deliberately out of scope

- **MMMC benchmark and TeachQuiz metric** — research artifacts, would belong in a separate evals harness rather than this skill.
- **3D ThreeDScene support** — OpenGL is unreliable in headless containers and already excluded from the skill's Limitations section.
- **Changes to `concept-to-image`** — different renderer, different failure modes; out of scope per the architecture plan.
- **Remotion-video parity** — the critic pattern may generalize, but is not applied here.

## Test plan

- [ ] Local CI runs `pytest`, `ruff`, `mypy` green on the branch
- [ ] Regenerated `manifest.yaml` matches expected counts (63 skills, 17 agents, 7 hooks, 4 rules, 5 commands, 3 utilities, 11 presets)
- [ ] `concept-to-video` shows `version: 1.2.0` in manifest
- [ ] Smoke: `python3 scripts/render_video.py` with no `--max-fix-attempts` behaves exactly as before
- [ ] Smoke: `python3 scripts/critic_pass.py scene.py video.mp4` without `--critic` exits 0 immediately with "critic pass disabled"
- [ ] Follow-up: update the top-level Reference Files table to enumerate new agentic-mode files (low-severity package-evaluator finding)