### PR TITLE
chore(gitignore): ignore local agent workspaces and .docs planning dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,12 @@ Thumbs.db
 # ── Exceptions ────────────────────────────────
 !.env.example
 !*.tfvars.example
+
+# Agentic Systems
+.agent
+.claude/
+.gemini
+.opencode/
+
+# Developer workspace
+.docs/


### PR DESCRIPTION
## Summary

Exclude directories that tooling creates alongside the repo but should not ship with it.

- **Agent caches and configs**: `.agent`, `.claude/`, `.gemini`, `.opencode/` — created by various agent runtimes when operating inside the repo. Personal to each contributor, never intended for version control.
- **Developer workspace**: `.docs/` — holds temporary planning notes (implementation plans, execution logs) that should be deleted after implementation completes per the convention already used by `MEMENTO_SKILLS_PLAN.md` and `SKILLSBENCH_EXECUTION_NOTES.md`.

Also adds a trailing newline to the file (it was missing one).

## Test plan

- [ ] `git check-ignore .claude/` returns 0
- [ ] `git check-ignore .docs/foo.md` returns 0
- [ ] No currently-tracked files match the new patterns (verified: `git ls-files` has no entries under `.claude/`, `.docs/`, `.agent`, `.gemini`, `.opencode/`)