### PR TITLE
fix(hooks): deduplicate hook entries by command to remove legacy orphans

### DIFF
--- a/scripts/hooks_installer.py
+++ b/scripts/hooks_installer.py
@@ -140,9 +140,13 @@ def merge_hook_config(
             matcher_group = {"matcher": matcher, "hooks": []}
             event_list.append(matcher_group)
 
-        # Remove any existing entry from this hook package, then append
+        # Remove existing entries by hook name OR by command to prevent duplicates.
+        # Command deduplication cleans up legacy entries that predate _hook_name tracking.
+        new_command = hook_entry.get("command", "")
         matcher_group["hooks"] = [
-            h for h in matcher_group["hooks"] if h.get("_hook_name") != hook_name
+            h for h in matcher_group["hooks"]
+            if h.get("_hook_name") != hook_name
+            and (not new_command or h.get("command") != new_command)
         ]
         matcher_group["hooks"].append(hook_entry)
 

--- a/tests/test_hooks_installer.py
+++ b/tests/test_hooks_installer.py
@@ -128,6 +128,32 @@ class TestMergeHookConfig:
         assert len(groups) == 1
         assert len(groups[0]["hooks"]) == 1
 
+    def test_merge_removes_legacy_entries_without_hook_name(
+        self, empty_settings: dict, git_protection_meta: dict
+    ) -> None:
+        """Reinstalling a hook removes legacy entries that lack _hook_name tracking."""
+        claude_dir = Path("/home/user/.claude")
+        resolved_cmd = "bash /home/user/.claude/hooks/git-protection/handler.sh"
+        # Simulate two legacy entries installed before _hook_name tracking existed
+        empty_settings["hooks"] = {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": resolved_cmd},
+                        {"type": "command", "command": resolved_cmd},
+                    ],
+                }
+            ]
+        }
+        result = merge_hook_config(
+            empty_settings, "git-protection", git_protection_meta, claude_dir
+        )
+        groups = result["hooks"]["PreToolUse"]
+        assert len(groups) == 1
+        assert len(groups[0]["hooks"]) == 1
+        assert groups[0]["hooks"][0].get("_hook_name") == "git-protection"
+
     def test_merge_preserves_existing_settings(
         self, git_protection_meta: dict
     ) -> None:


### PR DESCRIPTION
## Problem

`merge_hook_config` deduplicates hook entries in `settings.json` using the `_hook_name` field introduced to track package ownership. Entries installed before that field existed — or installed via an older version of the installer — carry no `_hook_name` and are invisible to the filter.

The result: every reinstall appends a new tracked entry while leaving the old untracked ones in place. The same hook command accumulates and fires multiple times per prompt.

Confirmed in a real `settings.json`:

```json
{
  "matcher": "",
  "hooks": [
    {"type": "command", "command": "bash /Users/druk/.claude/hooks/prompt-context/handler.sh"},
    {"type": "command", "command": "bash /Users/druk/.claude/hooks/prompt-context/handler.sh"},
    {"type": "command", "command": "bash /Users/druk/.claude/hooks/prompt-context/handler.sh", "timeout_ms": 5000, "_hook_name": "prompt-context"}
  ]
}
```

Three entries, all running the same script on every prompt.

## Fix

Add a secondary deduplication guard in `merge_hook_config`: when adding a new entry, also remove any existing entry in the same matcher group whose resolved `command` matches the incoming command — regardless of whether `_hook_name` is present.

```python
# Before
matcher_group["hooks"] = [
    h for h in matcher_group["hooks"] if h.get("_hook_name") != hook_name
]

# After
new_command = hook_entry.get("command", "")
matcher_group["hooks"] = [
    h for h in matcher_group["hooks"]
    if h.get("_hook_name") != hook_name
    and (not new_command or h.get("command") != new_command)
]
```

The resolved absolute path (e.g. `bash /home/user/.claude/hooks/git-protection/handler.sh`) serves as a content-addressed key. Two different hooks resolve to different absolute paths, so the command guard cannot accidentally remove a sibling hook's entry.

Self-healing: reinstalling any hook with this fix removes all legacy duplicates and leaves exactly one tracked entry.

## Test Coverage

New case in `TestMergeHookConfig`: seeds a matcher group with two legacy entries (no `_hook_name`, same resolved command), reinstalls the hook, and asserts the group collapses to a single entry carrying `_hook_name`.

```python
def test_merge_removes_legacy_entries_without_hook_name(self, ...):
    # Two legacy entries without _hook_name
    empty_settings["hooks"] = {
        "PreToolUse": [{
            "matcher": "Bash",
            "hooks": [
                {"type": "command", "command": resolved_cmd},
                {"type": "command", "command": resolved_cmd},
            ],
        }]
    }
    result = merge_hook_config(empty_settings, "git-protection", meta, claude_dir)
    assert len(result["hooks"]["PreToolUse"][0]["hooks"]) == 1
    assert result["hooks"]["PreToolUse"][0]["hooks"][0]["_hook_name"] == "git-protection"
```

All 24 tests pass.

## Checklist

- [x] Root cause identified (missing command-based deduplication)
- [x] Fix is backward-compatible (existing `_hook_name` deduplication unchanged)
- [x] Regression test added
- [x] All tests pass (`uv run pytest tests/test_hooks_installer.py`)