### PR TITLE
docs(readme): add GitHub stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # armory
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![packages: 106](https://img.shields.io/badge/packages-106-informational)](manifest.yaml) [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/) [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![packages: 106](https://img.shields.io/badge/packages-106-informational)](manifest.yaml)
+[![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
 
 Curated, production-grade skills, agents, hooks, rules, commands, utilities, and presets for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![packages: 106](https://img.shields.io/badge/packages-106-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
+[![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
 
 Curated, production-grade skills, agents, hooks, rules, commands, utilities, and presets for AI coding agents. No magic, no demos — battle-tested workflows built for developers who use AI seriously.


### PR DESCRIPTION
## Summary
- wrap the README header badges onto separate lines for cleaner maintenance and narrower Markdown diffs
- add a GitHub stars badge to the README header
- link the new badge directly to the repository stargazers page

## Scope
This branch only changes the README header badge block. It does not alter package metadata, site generation, install flows, or any runtime code.

## Implementation Details
- split the existing single-line badge row in `README.md` into one badge per line
- keep the existing license, package-count, eval-coverage, and catalog badges intact
- add a Shields.io GitHub stars social badge for `Mathews-Tom/armory`
- point the new stars badge to `https://github.com/Mathews-Tom/armory/stargazers`

## Validation
- inspected the branch diff against `main`
- verified the final README header block after each commit

## Commit Structure
- `docs(readme): wrap header badges`
- `docs(readme): add GitHub stars badge`
