### PR TITLE
chore(opus-4-7): adapt packages to Opus 4.7 launch (adaptive thinking, xhigh default, dispatch discipline)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,7 @@ body:
       label: Environment
       description: Claude version, OS, and any other relevant context.
       placeholder: |
-        Claude version: claude-sonnet-4-6
+        Claude version: claude-opus-4-7
         OS: macOS 15.3
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [secret-scanner](agents/secret-scanner/)       | haiku  | Pre-commit detection of hardcoded credentials         |
 | [test-engineer](agents/test-engineer/)         | sonnet | Co-evolutionary skill evolution with generate-verify-refine loops |
 
+> **Model routing:** Agents marked `opus` run on Claude Opus 4.7 with `xhigh` effort by default in Claude Code. Use `max` effort only for genuinely hard novel problems (diminishing returns, overthinking risk); `high` when running concurrent sessions or for cost-sensitive work. Opus 4.7 uses adaptive thinking — there is no fixed thinking budget to tune.
+
 ### Skills — Development & Tooling
 
 | Skill                                            | Description                                                                                                                                                 |

--- a/agents/codebase-auditor/AGENT.md
+++ b/agents/codebase-auditor/AGENT.md
@@ -93,7 +93,7 @@ If no scope is specified, determine scope from context: if recent changes exist 
 
 ### Phase 2: Parallel Agent Spawning
 
-Spawn three specialized review agents in parallel using the Agent tool. Each agent receives the determined scope from Phase 1.
+Spawn three specialized review agents in parallel using the Agent tool, **all in a single assistant message** so Opus 4.7 fans them out rather than serializing. Each agent receives the determined scope from Phase 1.
 
 **Agent 1 — Code Quality Review:**
 

--- a/agents/idea-scout/AGENT.md
+++ b/agents/idea-scout/AGENT.md
@@ -114,7 +114,7 @@ If the idea description is missing critical elements (problem, solution, target 
 
 ### Phase 3: Parallel Research
 
-Spawn three research agents in parallel using the Agent tool. Each receives the structured idea and Lean Canvas from Phases 1-2.
+Spawn three research agents in parallel using the Agent tool, **all in a single assistant message** — Opus 4.7's judicious-delegation default will serialize them otherwise. Each receives the structured idea and Lean Canvas from Phases 1-2.
 
 **Agent A — Market Research:**
 

--- a/agents/research-analyst/AGENT.md
+++ b/agents/research-analyst/AGENT.md
@@ -109,7 +109,7 @@ If the research question is vague, ask up to 3 clarifying questions to narrow sc
 
 ### Phase 2: Parallel Source Investigation
 
-Spawn parallel research agents using the Agent tool. Each agent targets a different source type based on the plan from Phase 1.
+Spawn parallel research agents using the Agent tool. Issue all relevant Agent calls in a **single assistant message** so Opus 4.7 actually fans them out — its default judicious delegation otherwise tends to serialize. Each agent targets a different source type based on the plan from Phase 1.
 
 **Agent A — Web Research:**
 

--- a/agents/team-lead/AGENT.md
+++ b/agents/team-lead/AGENT.md
@@ -161,7 +161,7 @@ research-analyst → content-strategist → media-producer
 Execute the delegation plan:
 
 1. **Sequential steps:** Spawn each agent via the Agent tool, wait for completion, pass output to the next agent
-2. **Parallel steps:** Spawn multiple agents simultaneously using parallel Agent tool calls, wait for all to complete
+2. **Parallel steps:** Spawn multiple agents simultaneously by issuing all Agent tool calls in a **single assistant message**, wait for all to complete. Opus 4.7 defaults toward judicious delegation and will serialize or skip spawns if the independence is not stated — name the topology explicitly.
 3. **Conditional steps:** After each agent completes, evaluate whether the next step should proceed:
    - If `codebase-auditor` returns FAIL → do not proceed to `release-captain`, report issues
    - If `idea-scout` returns NO-GO → do not proceed to `project-architect`, report findings

--- a/agents/test-engineer/AGENT.md
+++ b/agents/test-engineer/AGENT.md
@@ -104,7 +104,7 @@ convergence.
 
 ### Phase 2: Initial Generation (Generator Role)
 
-The generator produces the first version of the skill package.
+The generator produces the first version of the skill package. Emit complete files in one pass: Opus 4.7's terser default can truncate SKILL.md bodies or omit phases when the spec is ambiguous — state length and completeness requirements up front.
 
 1. Invoke the `immune` skill in `cheatsheet-only` mode for the target domain:
    - Extract positive patterns that improve skill quality

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -747,8 +747,9 @@ packages:
     - literature-review
   - name: sequential-thinking
     version: 1.1.1
-    description: 'DEPRECATED: Use the model''s native extended thinking instead. Structured, reflective problem-solving through
-      sequential chain-of-thought reasoning that replaced the Sequential Thinking MCP server.'
+    description: 'DEPRECATED: Opus 4.7''s adaptive thinking covers most cases natively. Structured, reflective problem-solving
+      through sequential chain-of-thought reasoning that replaced the Sequential Thinking MCP server. Retained as a reference
+      pattern when deterministic, reviewable reasoning traces are required regardless of the model''s adaptive-thinking choice.'
     path: skills/sequential-thinking
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/sequential-thinking/SKILL.md
     tags:

--- a/skills/agent-builder/references/api-vs-sdk.md
+++ b/skills/agent-builder/references/api-vs-sdk.md
@@ -10,7 +10,7 @@ from anthropic import Anthropic
 
 client = Anthropic(api_key="sk-...")  # Requires separate API key
 response = client.messages.create(   # Bypasses agent loop
-    model="claude-sonnet-4-5",
+    model="claude-sonnet-4-6",
     messages=[{"role": "user", "content": "Hello"}]
 )
 ```

--- a/skills/sequential-thinking/SKILL.md
+++ b/skills/sequential-thinking/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: sequential-thinking
 description:
-  "DEPRECATED: Use the model's native extended thinking instead. Structured,
+  "DEPRECATED: Opus 4.7's adaptive thinking covers most cases natively. Structured,
   reflective problem-solving through sequential chain-of-thought reasoning that replaced
-  the Sequential Thinking MCP server.
+  the Sequential Thinking MCP server. Retained as a reference pattern when deterministic,
+  reviewable reasoning traces are required regardless of the model's adaptive-thinking
+  choice.
 
   "
 metadata:
@@ -14,9 +16,12 @@ metadata:
   difficulty: intermediate
 ---
 
-> **DEPRECATED** — Sonnet 4 and Opus 4 handle structured chain-of-thought natively,
-> including revision, branching, and scope adjustment. This skill no longer provides
-> meaningful uplift over the base model. Retained for reference only.
+> **DEPRECATED** — Opus 4.7 uses adaptive thinking (optional at each step) and Sonnet 4.6
+> handles structured chain-of-thought natively. For most tasks, prompting "Think carefully
+> and step-by-step; this is harder than it looks" elicits the required depth. This
+> methodology is retained as a reference pattern when deterministic, reviewable reasoning
+> traces are required (audits, proofs, post-hoc analysis) regardless of the model's
+> adaptive-thinking choice.
 
 # Sequential Thinking
 

--- a/skills/skill-distiller/SKILL.md
+++ b/skills/skill-distiller/SKILL.md
@@ -150,7 +150,7 @@ Produce the final comparison:
 
 ## Limitations
 
-- Cannot distill skills that rely on extended thinking or multi-turn reasoning
+- Cannot distill skills that rely on open-ended adaptive reasoning at many decision points or multi-turn reasoning
 - Visual/interactive skills (HTML generation, browser automation) may not distill well
 - Distillation optimizes for determinism, not creativity — skills requiring open-ended generation
   (writing, brainstorming) are poor candidates

--- a/skills/skill-distiller/evals/cases.yaml
+++ b/skills/skill-distiller/evals/cases.yaml
@@ -51,10 +51,10 @@ cases:
         weight: 0.3
 
   - id: reduce_skill_cost
-    prompt: "Optimize this skill for cost by making it Haiku-compatible. It currently uses too much reasoning and extended thinking."
+    prompt: "Optimize this skill for cost by making it Haiku-compatible. It currently uses too much open-ended reasoning at each decision point."
     fixtures: []
     rubric:
-      - "Identifies sections requiring extended thinking and replaces with explicit steps"
+      - "Identifies sections requiring open-ended adaptive reasoning and replaces with explicit steps"
       - "Produces cross-model performance comparison table"
       - "Outputs a recommendation (SHIP, ITERATE, or MANUAL_REVIEW_NEEDED)"
     trigger_expected: true

--- a/skills/to-markdown/SKILL.md
+++ b/skills/to-markdown/SKILL.md
@@ -113,7 +113,7 @@ import anthropic
 from markitdown import MarkItDown
 
 client = anthropic.Anthropic()
-md = MarkItDown(llm_client=client, llm_model="claude-sonnet-4-20250514")
+md = MarkItDown(llm_client=client, llm_model="claude-sonnet-4-6")
 result = md.convert("presentation.pptx")
 ```
 


### PR DESCRIPTION
## Summary

Adapts the armory to Anthropic's Claude Opus 4.7 launch (2026-04). Four small, independently revertable commits refresh skill/agent prompts and docs where Opus-4.6-era assumptions no longer hold, without changing any package's public contract. No breaking changes; manifest regenerated.

Source announcements driving this PR:
- https://www.anthropic.com/news/claude-opus-4-7
- https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code

## Why this is needed

Opus 4.7 changes three behaviors that affect armory packages:

1. **Adaptive thinking replaces fixed-budget Extended Thinking.** Thinking is optional per-step; numeric `budget_tokens` is no longer supported. Every doc that said "extended thinking" as a feature name is now imprecise.
2. **`xhigh` is the new default effort tier** (between `high` and `max`). Readers reaching the README with an Opus-4.6 mental model need to know the current default and when to deviate.
3. **More judicious delegation and terser default output.** Orchestrator agents that relied on Opus 4.6's eager parallel sub-agent spawning will silently serialize under 4.7 unless the independence of sub-tasks is stated explicitly, in a single assistant message. Generator agents can emit truncated output if completeness isn't demanded up front.

Audit confirmed **no breaking hits**: no package sends numeric `budget_tokens` to the Anthropic SDK; all agent `model:` frontmatter uses logical aliases (`opus`/`sonnet`/`haiku`) that the platform maps to the current Opus 4.7 / Sonnet 4.6 / Haiku 4.5. Only content updates were needed.

## What changed (per commit)

### `3971a9b` — chore(skills): refresh sequential-thinking and skill-distiller for Opus 4.7
- **`skills/sequential-thinking/SKILL.md`**: rewrite the deprecation rationale. The old text said "Sonnet 4 and Opus 4 handle structured chain-of-thought natively" — under 4.7's *adaptive* (optional per-step) thinking, this skill's deterministic protocol has a clearer niche: reviewable reasoning traces for audits, proofs, and post-hoc analysis where you can't rely on the model choosing to think. Frontmatter description updated; body deprecation block rewritten. Status stays `deprecated` pending maintainer call on un-shelving.
- **`skills/skill-distiller/SKILL.md:153`**: replace "Cannot distill skills that rely on extended thinking or multi-turn reasoning" with "open-ended adaptive reasoning at many decision points" — the old wording referenced the removed fixed-budget feature.
- **`skills/skill-distiller/evals/cases.yaml`**: same terminology update in the `reduce_skill_cost` prompt and its rubric line, so the eval still matches what the skill actually does.
- **`manifest.yaml`**: regenerated to pick up the `sequential-thinking` frontmatter description change (project convention — CI fails otherwise).

### `6ffaf59` — chore(docs): refresh stale model-ID examples
- **`skills/to-markdown/SKILL.md:116`**: MarkItDown example switches from the dated `claude-sonnet-4-20250514` alias to `claude-sonnet-4-6`.
- **`skills/agent-builder/references/api-vs-sdk.md:13`**: the "do not use the raw Anthropic API" example updates from `claude-sonnet-4-5` to `claude-sonnet-4-6`. The example is intentionally kept in the *avoid* block — only the model string is current.
- **`.github/ISSUE_TEMPLATE/bug_report.yml:48`**: placeholder `Claude version` updates from `claude-sonnet-4-6` to `claude-opus-4-7` (matches Claude Code's new default).

### `8b16007` — chore(agents): reinforce parallel-dispatch discipline for Opus 4.7
Five orchestrators get a short, targeted sentence at each fan-out phase telling the model to issue all Agent calls in a **single assistant message** and stating *why* (Opus 4.7's judicious-delegation default will otherwise serialize). Minimal footprint — one-line edits at the relevant parallel-spawn phase in each file.

- `agents/team-lead/AGENT.md` — Phase 3 "Parallel steps" bullet.
- `agents/research-analyst/AGENT.md` — Phase 2 "Parallel Source Investigation" intro.
- `agents/idea-scout/AGENT.md` — Phase 3 "Parallel Research" intro.
- `agents/codebase-auditor/AGENT.md` — Phase 2 "Parallel Agent Spawning" intro.
- `agents/test-engineer/AGENT.md` — Phase 2 "Initial Generation" gets a terseness-guard note (Opus 4.7's shorter default output can truncate SKILL.md bodies when the spec is ambiguous; Generator must emit complete files in one pass).

### `0113ad3` — docs(readme): note Opus 4.7 default and effort-level routing
- **`README.md`**: one-line blockquote under the agents table — agents marked `opus` run on Claude Opus 4.7 with `xhigh` effort by default in Claude Code. Spells out when to deviate: `max` only for genuinely hard novel problems (diminishing returns, overthinking risk); `high` for concurrent sessions or cost-sensitive work. Flags that Opus 4.7 uses adaptive thinking — there is no fixed thinking budget to tune.

## Audit scope and non-findings

Scanned the full repo for Opus-4.7-sensitive patterns. The following checks came back **clean** and required no edits — documenting here so reviewers don't redo the audit:

- No `budget_tokens` / `thinking_budget` literals in any agent, skill, hook, rule, command, utility, or preset.
- No direct Anthropic SDK `thinking={...}` calls that would hit the removed feature.
- All agent `model:` frontmatter fields use the logical aliases `opus` / `sonnet` / `haiku` — platform maps these to the current model automatically, so no mass rename.
- No orchestrator config embeds a specific effort level that would pin the user below `xhigh`.
- `manifest.yaml` only mirrored skill descriptions; regeneration captures the single description change.

## Known follow-ups (deliberately out of scope for this PR)

Left for subsequent PRs so this one stays reviewable:

- **P2 — concept-to-video model config extraction.** `skills/concept-to-video/scripts/{plan_storyboard.py, critic_pass.py, _fixup_client.py}` hardcode `DEFAULT_MODEL = "claude-sonnet-4-6"`, and `tests/test_plan_storyboard.py` references `"claude-opus-4-5"`. Per the global "model refs in config files only" rule these belong in a `config.toml`. Not Opus-4.7-caused, pre-existing hygiene.
- **P2 — tokenizer-drift footnote.** Opus 4.7 input tokens run 1.0–1.35× Opus 4.6 for the same text due to a tokenizer update. Token-savings claims in `skills/usage-audit`, `skills/mcp-to-skill`, and `skills/immune` warrant a "pre-4.7 baselines are a lower bound" caveat.
- **P2 — new `adaptive-thinking-control` rule.** A two-paragraph rules package documenting the prompt phrases that replace the old fixed thinking budget ("Think carefully and step-by-step; this is harder than it looks" / "Prioritize responding quickly…"). Parent CLAUDE.md already documents these user-side; a package would make them portable.
- **P3 — `/ultrareview` cross-references** from `pre-landing-review` / `pr-review` / `pr-review-toolkit` to Claude Code's new native review command.
- **P3 — vision ceiling update** in `skills/to-markdown` and `skills/concept-to-image` (Opus 4.7 accepts ~3.75 MP vs prior ~1 MP).
- **P3 — stale marketing copy** in `skills/linkedin-post-style/SKILL.md` example posts citing "Opus 4.6" (example-tier content, low urgency).
- **P3 — `opus-4-7-migration` skill** that scans downstream repos for `budget_tokens`, old model IDs, and Opus-4.6-verbosity-assuming prompts.

## Test plan

- [x] `uv run python scripts/generate_manifest.py` succeeds — regenerated manifest is the one committed.
- [x] `yaml.safe_load` parses `manifest.yaml`, `skills/skill-distiller/evals/cases.yaml`, and `.github/ISSUE_TEMPLATE/bug_report.yml` without errors.
- [x] `git diff` reviewed per commit; no unintended changes.
- [ ] CI green on PR.
- [ ] Maintainer review of the orchestrator prompt nudges (subjective — wording choices in the five agent files are the highest-risk edits).
- [ ] Optional spot-check: invoke `team-lead` or `codebase-auditor` on a fan-out task under Opus 4.7 and confirm the agent issues Agent calls in a single message.