### PR TITLE
feat(opus-4-7): P2 follow-ups — config extraction, tokenizer drift, adaptive-thinking rule

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1437,6 +1437,27 @@ packages:
     category: operations
     difficulty: intermediate
   rules:
+  - name: adaptive-thinking-control
+    version: 1.0.0
+    description: 'Controls reasoning depth on Claude Opus 4.7 via prompt-level directives, replacing the removed fixed-budget
+      Extended Thinking feature. Opus 4.7 uses adaptive thinking — the model chooses whether to think at each step — so the
+      lever moved from a numeric budget_tokens parameter to specific prompt phrases that nudge depth up or down. Covers the
+      deeper-reasoning cue, the lower-latency cue, anti-patterns (setting budget_tokens on 4.7, assuming the model will always
+      think by default), and effort-level interactions. Use this rule when prompting Opus 4.7 for tasks where reasoning depth
+      or latency materially affects the outcome. Triggers on: "adaptive thinking", "thinking budget", "extended thinking",
+      "budget_tokens", "Opus 4.7 thinking", "make Claude think harder", "make Claude faster", "reasoning depth", "latency
+      vs reasoning", "xhigh effort", "max effort".'
+    path: rules/adaptive-thinking-control
+    source: https://github.com/Mathews-Tom/armory/blob/main/rules/adaptive-thinking-control/RULE.md
+    scope: global
+    tags:
+    - opus-4-7
+    - adaptive-thinking
+    - prompting
+    - effort
+    - extended-thinking
+    category: development
+    difficulty: beginner
   - name: commit-standards
     version: 1.0.0
     description: Enforces conventional commit format, branch naming conventions, and commit message structure for consistent

--- a/rules/adaptive-thinking-control/RULE.md
+++ b/rules/adaptive-thinking-control/RULE.md
@@ -1,0 +1,110 @@
+---
+name: adaptive-thinking-control
+type: rule
+description: >
+  Controls reasoning depth on Claude Opus 4.7 via prompt-level directives,
+  replacing the removed fixed-budget Extended Thinking feature. Opus 4.7 uses
+  adaptive thinking — the model chooses whether to think at each step — so
+  the lever moved from a numeric budget_tokens parameter to specific prompt
+  phrases that nudge depth up or down. Covers the deeper-reasoning cue,
+  the lower-latency cue, anti-patterns (setting budget_tokens on 4.7,
+  assuming the model will always think by default), and effort-level
+  interactions. Use this rule when prompting Opus 4.7 for tasks where
+  reasoning depth or latency materially affects the outcome. Triggers on:
+  "adaptive thinking", "thinking budget", "extended thinking", "budget_tokens",
+  "Opus 4.7 thinking", "make Claude think harder", "make Claude faster",
+  "reasoning depth", "latency vs reasoning", "xhigh effort", "max effort".
+metadata:
+  version: 1.0.0
+  scope: global
+  applies_to:
+    languages: ["*"]
+  category: development
+  tags: [opus-4-7, adaptive-thinking, prompting, effort, extended-thinking]
+  difficulty: beginner
+---
+
+# Adaptive Thinking Control
+
+Rules for controlling reasoning depth on Claude Opus 4.7, which replaced fixed-budget Extended Thinking with adaptive thinking. The model now decides whether to think at each step — so the lever moved from a numeric `budget_tokens` parameter to prompt-level directives. This rule documents the directives that actually work and the anti-patterns that silently fail.
+
+## What Changed in Opus 4.7
+
+Opus 4.7 does not support Extended Thinking with a fixed `budget_tokens` value. The adaptive-thinking mechanism makes thinking optional per step: the model may reason deeply on a hard sub-task and respond immediately on a trivial one in the same conversation. There is no dial to set a global depth; there are prompt phrases that bias the choice.
+
+This applies to both direct Anthropic API usage and to Claude Code, where effort levels (`low`/`medium`/`high`/`xhigh`/`max`) set the ceiling for reasoning budget but do not force the model to think when it judges thinking unnecessary.
+
+## Deeper-Reasoning Cue
+
+When the task is harder than it looks or a shallow pass will miss edge cases, prompt with:
+
+> "Think carefully and step-by-step before responding; this problem is harder than it looks."
+
+Place this phrase **early** in the first-turn prompt, alongside intent and constraints. Opus 4.7 follows instructions literally, so late cues compete with the momentum of a direct-response default.
+
+**When to apply:**
+
+- Architecture design where trade-offs span multiple dimensions
+- Debugging across distributed systems, race conditions, or subtle state bugs
+- Refactors that touch many call sites and need AST-level reasoning
+- Formal reasoning: proofs, security analysis, invariant derivation
+- Any task where the correct answer is non-obvious from surface reading
+
+## Lower-Latency Cue
+
+When the task is mechanical or time-sensitive, prompt with:
+
+> "Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly."
+
+**When to apply:**
+
+- Rote edits (renames, imports, boilerplate)
+- Lookups and retrievals where the answer is in the context already
+- Bulk or parallel sub-agent tasks where latency compounds
+- Status checks and polling loops
+- Conversational or confirmatory turns
+
+## Anti-Patterns
+
+**Do not set `budget_tokens` on Opus 4.7.** Code that still sends `thinking={"type": "enabled", "budget_tokens": N}` against Opus 4.7 will fail or be ignored depending on SDK version. Remove the parameter; rely on prompt-level control instead.
+
+**Do not assume Opus 4.7 will always think.** Under 4.6, Extended Thinking was often on by default for agentic tasks. Under 4.7, an ambiguous prompt can produce a terse direct answer. If depth matters, state it explicitly.
+
+**Do not stack cues.** Prompting "Think carefully and step-by-step, but also respond quickly" confuses the adaptive-thinking choice. Pick one direction per prompt.
+
+**Do not rely on emoji, bold, or repetition to "force" thinking.** 4.7's literal instruction following means it takes the phrasing at face value. The deeper-reasoning cue above is calibrated; paraphrases that sound equivalent may not elicit the same behavior.
+
+## Effort-Level Interactions
+
+Claude Code's `/effort` command sets the reasoning ceiling, not a floor. Adaptive thinking operates within that ceiling.
+
+| Effort   | Use when                                                                              |
+| -------- | ------------------------------------------------------------------------------------- |
+| `low`    | Trivial edits, latency-critical loops                                                 |
+| `medium` | Single-file changes, low-stakes refactors                                             |
+| `high`   | Cost-sensitive or concurrent sessions where you accept slightly shallower reasoning   |
+| `xhigh`  | **Default.** Best for most coding and agentic work                                    |
+| `max`    | Genuinely hard novel problems only — diminishing returns, overthinking risk           |
+
+The deeper-reasoning cue has the largest effect at `xhigh` and `max`. Below `high`, the effort ceiling dominates and the cue is advisory.
+
+## First-Turn Discipline
+
+Opus 4.7 reasons more when the task is specified completely up front: intent, constraints, acceptance criteria, and file paths in one message. Every additional user turn that adds context adds reasoning overhead and fragments the adaptive-thinking choice across turns.
+
+Batch context into the first message. Reserve subsequent turns for corrections and scope changes, not initial specification.
+
+## Migration from Opus 4.6
+
+If a prompt, agent, or skill previously depended on verbose Opus 4.6 reasoning by default:
+
+1. Add the deeper-reasoning cue to the first-turn prompt where depth is load-bearing.
+2. Remove any `budget_tokens` values from Anthropic SDK calls targeting Opus 4.7.
+3. For agent orchestrators, state sub-task independence explicitly when parallel dispatch is required — 4.7's judicious delegation default can serialize otherwise.
+4. Review length expectations: 4.7 is less default-verbose, so requests for structured long-form output may need an explicit length directive.
+
+## Related
+
+- `~/.claude/CLAUDE.md` — global Opus 4.7 prompt patterns and effort-level defaults
+- `rules/token-efficiency/RULE.md` — general tool-usage token discipline (complements but does not replace this rule)
+- `skills/prompt-lab/` — prompt-pattern catalog including CoT variants

--- a/rules/adaptive-thinking-control/evals/cases.yaml
+++ b/rules/adaptive-thinking-control/evals/cases.yaml
@@ -1,0 +1,66 @@
+cases:
+  - id: deeper_reasoning_request
+    prompt: "How do I make Claude Opus 4.7 think more carefully on a hard architecture decision?"
+    fixtures: []
+    rubric:
+      - "recommends the deeper-reasoning cue phrase"
+      - "explains that Opus 4.7 uses adaptive thinking, not fixed budget"
+      - "notes the cue should be placed early in the first-turn prompt"
+    trigger_expected: true
+
+  - id: budget_tokens_migration
+    prompt: "My code sets budget_tokens=8000 on the Anthropic API. Does this still work on Opus 4.7?"
+    fixtures: []
+    rubric:
+      - "states that fixed-budget Extended Thinking is not supported on Opus 4.7"
+      - "recommends removing the budget_tokens parameter"
+      - "points to prompt-level directives as the replacement control"
+    trigger_expected: true
+
+  - id: latency_priority
+    prompt: "This prompt is in a bulk loop and I need Opus 4.7 to respond faster without thinking deeply"
+    fixtures: []
+    rubric:
+      - "recommends the lower-latency cue phrase"
+      - "explains that adaptive thinking can be biased toward direct response"
+      - "mentions effort-level interaction (high or lower for bulk work)"
+    trigger_expected: true
+
+  - id: effort_vs_thinking_confusion
+    prompt: "What's the difference between xhigh effort and the deeper-reasoning prompt cue in Opus 4.7?"
+    fixtures: []
+    rubric:
+      - "explains effort sets the ceiling, adaptive thinking operates within it"
+      - "states the deeper-reasoning cue biases the per-step choice"
+      - "notes the cue has largest effect at xhigh and max"
+    trigger_expected: true
+
+  - id: migration_from_opus_4_6
+    prompt: "My skill worked great on Opus 4.6 with extended thinking enabled. How do I port it to 4.7?"
+    fixtures: []
+    rubric:
+      - "removes budget_tokens from any SDK calls"
+      - "adds the deeper-reasoning cue where depth was load-bearing"
+      - "reviews assumptions about default verbose output"
+    trigger_expected: true
+
+  - id: negative_commit_format
+    prompt: "How should I format my commit message for a bug fix?"
+    fixtures: []
+    rubric:
+      - "commit formatting is covered by commit-standards, not adaptive thinking control"
+    trigger_expected: false
+
+  - id: negative_general_prompt_engineering
+    prompt: "What are good few-shot prompting patterns for classification tasks?"
+    fixtures: []
+    rubric:
+      - "general prompt engineering patterns are in prompt-lab, not this rule"
+    trigger_expected: false
+
+  - id: negative_api_pricing
+    prompt: "How much does Opus 4.7 cost per million tokens?"
+    fixtures: []
+    rubric:
+      - "pricing is a billing question, not an adaptive thinking control concern"
+    trigger_expected: false

--- a/skills/concept-to-video/config.toml
+++ b/skills/concept-to-video/config.toml
@@ -1,0 +1,14 @@
+# Model configuration for the concept-to-video pipeline.
+#
+# Per armory convention, model identifiers live in config files rather than
+# source code so a single edit here retargets every pipeline stage.
+
+[models]
+# Storyboard planner: concept text -> structured scene JSON.
+planner = "claude-sonnet-4-6"
+
+# Visual critic: rendered frames -> layout patches.
+critic = "claude-sonnet-4-6"
+
+# Scene fixup: failing Manim scene + stderr -> corrected scene.
+fixup = "claude-sonnet-4-6"

--- a/skills/concept-to-video/scripts/_config.py
+++ b/skills/concept-to-video/scripts/_config.py
@@ -1,0 +1,35 @@
+"""Load model identifiers for the concept-to-video pipeline from config.toml."""
+
+from __future__ import annotations
+
+import tomllib
+from functools import cache
+from pathlib import Path
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config.toml"
+
+
+@cache
+def _load() -> dict[str, str]:
+    if not _CONFIG_PATH.exists():
+        raise FileNotFoundError(
+            f"config.toml not found at {_CONFIG_PATH}. "
+            "The skill directory is missing its model configuration."
+        )
+    with _CONFIG_PATH.open("rb") as fh:
+        data = tomllib.load(fh)
+    models = data.get("models")
+    if not isinstance(models, dict):
+        raise ValueError(f"{_CONFIG_PATH}: [models] section is required")
+    return {str(k): str(v) for k, v in models.items()}
+
+
+def model_for(stage: str) -> str:
+    """Return the configured model identifier for a pipeline stage."""
+    models = _load()
+    if stage not in models:
+        raise KeyError(
+            f"config.toml: no model configured for stage {stage!r}. "
+            f"Configured stages: {sorted(models)}"
+        )
+    return models[stage]

--- a/skills/concept-to-video/scripts/_fixup_client.py
+++ b/skills/concept-to-video/scripts/_fixup_client.py
@@ -13,10 +13,14 @@ from typing import Any, Protocol, cast, runtime_checkable
 
 import anthropic
 
+from _config import model_for
+
 _FENCED_PYTHON_RE = re.compile(
     r"```python\s*\n(.*?)```",
     re.DOTALL,
 )
+
+_DEFAULT_FIXUP_MODEL = model_for("fixup")
 
 _CODER_PROMPT_PATH = (
     Path(__file__).parent.parent / "references" / "code2video" / "coder.md"
@@ -63,7 +67,7 @@ def request_patch(
     offending_lines: tuple[int, int] | None,
     *,
     client: ClientProtocol | None = None,
-    model: str = "claude-sonnet-4-6",
+    model: str = _DEFAULT_FIXUP_MODEL,
 ) -> str:
     """
     Send scene source + stderr to the LLM and return the patched scene content.

--- a/skills/concept-to-video/scripts/critic_pass.py
+++ b/skills/concept-to-video/scripts/critic_pass.py
@@ -21,11 +21,13 @@ from anthropic.types import (
     TextBlockParam,
 )
 
+from _config import model_for
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = model_for("critic")
 DEFAULT_FRAMES = 5
 MAX_FRAMES = 10
 DEFAULT_CRITIC_BUDGET = 50_000

--- a/skills/concept-to-video/scripts/plan_storyboard.py
+++ b/skills/concept-to-video/scripts/plan_storyboard.py
@@ -11,6 +11,8 @@ from typing import Any
 import anthropic
 from anthropic.types import TextBlock
 
+from _config import model_for
+
 # ---------------------------------------------------------------------------
 # Types
 # ---------------------------------------------------------------------------
@@ -92,7 +94,7 @@ def validate_storyboard(data: Any) -> Storyboard:
 # Core planner
 # ---------------------------------------------------------------------------
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = model_for("planner")
 _PROMPT_PATH = Path(__file__).parent.parent / "references" / "code2video" / "planner.md"
 
 

--- a/skills/concept-to-video/tests/test_critic_pass.py
+++ b/skills/concept-to-video/tests/test_critic_pass.py
@@ -379,7 +379,7 @@ class TestRunCriticPass:
                 output_path=output_file,
                 n_frames=n_frames,
                 critic_budget=critic_budget,
-                model="claude-sonnet-4-6",
+                model="test-model-override",
                 prompt_path=prompt_file,
                 client=fake_client,  # type: ignore[arg-type]
             )

--- a/skills/concept-to-video/tests/test_plan_storyboard.py
+++ b/skills/concept-to-video/tests/test_plan_storyboard.py
@@ -293,7 +293,7 @@ def test_plan_uses_custom_model_when_provided(prompt_file: Path) -> None:
     storyboard = _make_valid_storyboard()
     client = _fake_client(json.dumps(storyboard))
     planner = StoryboardPlanner(
-        client=client, model="claude-opus-4-5", prompt_path=prompt_file
+        client=client, model="test-model-override", prompt_path=prompt_file
     )
 
     # Act
@@ -301,4 +301,4 @@ def test_plan_uses_custom_model_when_provided(prompt_file: Path) -> None:
 
     # Assert
     call_kwargs = client.messages.create.call_args
-    assert call_kwargs.kwargs["model"] == "claude-opus-4-5"
+    assert call_kwargs.kwargs["model"] == "test-model-override"

--- a/skills/mcp-to-skill/SKILL.md
+++ b/skills/mcp-to-skill/SKILL.md
@@ -184,6 +184,8 @@ python3 scripts/estimate_tokens.py --mcp-tools TOOL_COUNT --avg-schema-chars AVG
 
 This shows before/after token savings per turn and across a typical conversation.
 
+> **Opus 4.7 note:** Input tokens run 1.0–1.35× Opus 4.6 for the same text due to a tokenizer update. Treat pre-4.7 baselines as a lower bound — actual savings on Opus 4.7 may be larger than the estimator reports.
+
 **Generate 2-3 test scenarios** — realistic prompts that would trigger the new skill
 and show the replacement commands in action. Present them to the user.
 

--- a/skills/usage-audit/SKILL.md
+++ b/skills/usage-audit/SKILL.md
@@ -39,7 +39,9 @@ independent checks in parallel.
 ### MCP Servers
 
 Each connected server loads full tool definitions into context every turn
-(~15,000-20,000 tokens each), whether you invoke a tool or not.
+(~15,000-20,000 tokens each), whether you invoke a tool or not. Under Opus 4.7 this
+figure can run 1.0–1.35× higher for the same schemas due to a tokenizer update —
+prefer measured values from `/context` over these static estimates.
 
 - Count configured servers in `settings.json` and `~/.claude/settings.json`.
 - Report total MCP overhead from `/context`.


### PR DESCRIPTION
## Summary

Second-wave adaptations to Anthropic's Claude Opus 4.7 launch, following #63. Three logical commits: `concept-to-video` model configuration extracted to a config file, two token-accounting skills gain a tokenizer-drift caveat, and a new `adaptive-thinking-control` rule package documents the prompt-level replacement for fixed-budget Extended Thinking. No breaking changes; all validators green.

Source announcements driving this PR (same as #63):
- https://www.anthropic.com/news/claude-opus-4-7
- https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code

## Why this is needed

Three loose ends remained after #63 merged:

1. **`concept-to-video` hardcoded model IDs in three scripts and two tests**, with one test still pinned to the retired `claude-opus-4-5` alias. Violated the global "model refs in config files only" rule and tightly coupled source to a specific model version.
2. **Opus 4.7's tokenizer change (1.0–1.35× input-token bump for the same text)** made the static token-savings numbers in `mcp-to-skill` and `usage-audit` silently misleading — readers comparing against pre-4.7 baselines would under- or over-count without a footnote.
3. **No portable documentation of the adaptive-thinking prompt phrases** that replaced fixed `budget_tokens`. The parent CLAUDE.md documents them user-side, but downstream repos consuming armory rules had no way to inherit them.

## What changed (per commit)

### `0dd37e2` — chore(concept-to-video): extract model defaults to config.toml

Move hardcoded model IDs out of script source per the armory convention that model references live in config files. A single edit to `config.toml` now retargets every pipeline stage.

- **New `skills/concept-to-video/config.toml`**: `[models]` section with `planner`, `critic`, `fixup` keys. All three default to `claude-sonnet-4-6` today; edit-one-place to change.
- **New `skills/concept-to-video/scripts/_config.py`**: `tomllib`-based loader with `@cache` and explicit failure modes — missing file, missing `[models]` section, or missing stage key each raise with a concrete message. Fails fast, does not silently fall back.
- **`scripts/plan_storyboard.py`** and **`scripts/critic_pass.py`**: `DEFAULT_MODEL` now resolves via `model_for("planner")` / `model_for("critic")` at module import time. Public CLI and class signatures unchanged.
- **`scripts/_fixup_client.py`**: `request_patch` default arg resolves to `_DEFAULT_FIXUP_MODEL`, a module-level constant loaded via `model_for("fixup")`. API signature unchanged for callers.
- **`tests/test_plan_storyboard.py`**: model-override test now uses `"test-model-override"` sentinel instead of the retired `"claude-opus-4-5"` alias. The test asserts on override-param passthrough, not on a specific model, so the sentinel expresses intent more clearly and never goes stale.
- **`tests/test_critic_pass.py`**: same synthetic sentinel replaces `"claude-sonnet-4-6"` in the fixture's model arg.

Pre-existing ruff-format drift in unrelated regions of these files deliberately left untouched per "don't introduce abstractions beyond what the task requires."

### `c38a8c7` — docs(skills): flag Opus 4.7 tokenizer drift in token-accounting skills

Two skills quote fixed token counts that readers compare against their own measurements. Opus 4.7's tokenizer update shifts input tokens 1.0–1.35× for the same text vs Opus 4.6. Without a caveat, readers either double-count savings or misdiagnose legitimately higher context usage as a regression.

- **`skills/mcp-to-skill/SKILL.md:185`**: append a blockquote note after the before/after token-savings line pointing out that pre-4.7 baselines are a lower bound and actual 4.7 savings may exceed the estimator.
- **`skills/usage-audit/SKILL.md:42`**: inline caveat appended to the "~15,000-20,000 tokens per MCP server" figure directing readers to trust measured `/context` values over static estimates on 4.7.

`immune/SKILL.md` had no token-count claims, so no footnote was needed there despite being on the audit list. `scripts/estimate_tokens.py` output reflects actual input strings and needs no change — only the written numeric claims needed qualifying.

### `74b120c` — feat(rules): add adaptive-thinking-control rule for Opus 4.7

New rules package filling the largest content gap from the launch. Opus 4.7 removed fixed-budget Extended Thinking and replaced it with adaptive thinking — the control lever moved from `budget_tokens={N}` to specific prompt phrases, and the phrasing is calibrated (paraphrases that sound equivalent do not always elicit the same behavior).

- **`rules/adaptive-thinking-control/RULE.md`**: covers the deeper-reasoning cue (\"Think carefully and step-by-step before responding; this problem is harder than it looks\"), the lower-latency cue (\"Prioritize responding quickly rather than thinking deeply. When in doubt, respond directly.\"), effort-level interaction table (low/medium/high/xhigh/max with when-to-use guidance), first-turn specification discipline, and a migration checklist from Opus 4.6. Explicit anti-patterns section flags: setting `budget_tokens` on 4.7, assuming the model will always think by default, stacking contradictory cues, relying on emoji/bold/repetition to force depth.
- **`rules/adaptive-thinking-control/evals/cases.yaml`**: 5 positive cases (deeper reasoning request, budget_tokens migration, latency priority, effort-vs-cue confusion, 4.6→4.7 port) and 3 negative cases (commit format, general prompt engineering, API pricing) to keep trigger scope tight.
- **`manifest.yaml`**: regenerated via `scripts/generate_manifest.py` — rules count 4 → 5.

Frontmatter follows the existing rule conventions (`name`, `type: rule`, `description`, `metadata.version`, `scope: global`, `applies_to.languages: [\"*\"]`, `category`, `tags`, `difficulty`), matching `token-efficiency` and `commit-standards`.

## Validation

- `uv run ruff check skills/concept-to-video/` — clean.
- `uv run ruff format --check skills/concept-to-video/scripts/_config.py` — clean (1 file already formatted).
- `uv run mypy --strict` on the 4 touched concept-to-video scripts — no issues.
- `uv run pytest skills/concept-to-video/tests/` — **93 passed in 0.34s**.
- `uv run python scripts/validate_frontmatter.py rules/adaptive-thinking-control/RULE.md` — 113 packages passed.
- `uv run python scripts/validate_evals.py rules/adaptive-thinking-control/` — 5 rules validated.
- `uv run python scripts/validate_references.py rules/adaptive-thinking-control/RULE.md` — references intact.

## Known follow-ups (out of scope)

Matches the P3 list from #63; reproduced here for traceability:

- **`/ultrareview` cross-references** from `pre-landing-review` / `pr-review` / `pr-review-toolkit` to Claude Code's new native review command.
- **Vision ceiling update** in `skills/to-markdown` and `skills/concept-to-image` (Opus 4.7 accepts ~3.75 MP vs prior ~1 MP).
- **Stale marketing copy** in `skills/linkedin-post-style/SKILL.md` example posts citing "Opus 4.6" (example-tier content, low urgency).
- **New `opus-4-7-migration` skill** that scans downstream repos for `budget_tokens` calls, old model IDs, and Opus-4.6-verbosity-assuming prompts.
- **Ruff format pass on `skills/concept-to-video/`** to clear the 10 pre-existing drift files. Intentionally deferred from this PR so the diff stays scoped to model-config extraction.

## Test plan

- [x] Local `ruff check` + `ruff format --check` on new file — clean.
- [x] Local `mypy --strict` on all 4 touched concept-to-video scripts — 0 issues.
- [x] Local `pytest skills/concept-to-video/tests/` — 93/93 pass.
- [x] Repo validators (`validate_frontmatter`, `validate_evals`, `validate_references`) — 113 packages green.
- [x] Manifest regenerated and committed.
- [ ] CI green on PR.
- [ ] Maintainer review of the adaptive-thinking-control rule — subjective content; wording of the deeper/lower-latency cues is reproduced verbatim from Anthropic guidance but the migration checklist and anti-patterns are interpretations.
- [ ] Optional: try the new rule on a downstream repo by installing via `skill-library` and checking that it triggers on the expected prompts.