### PR TITLE
feat(handoff): add session continuity packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 106](https://img.shields.io/badge/packages-106-informational)](manifest.yaml)
+[![packages: 125](https://img.shields.io/badge/packages-125-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -68,6 +68,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |
 | [skill-library](skills/skill-library/)           | Agent-native catalog for browsing, installing, updating, syncing, and removing armory skills from within a Claude Code session                              |
 | [env-validator](skills/env-validator/)           | Validate `.env` files against project requirements — missing vars, type mismatches, insecure defaults, `.env.example` drift                                 |
+| [handoff](skills/handoff/)                       | Maintain `.docs/handoff.md` as a 200-line session-continuity runbook for in-flight work, blockers, decisions, validation state, and resume steps           |
 
 ### Skills — Research & Analysis
 
@@ -190,6 +191,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [security-scan](commands/security-scan/) | Security vulnerability audit     |
 | [refactor](commands/refactor/)           | Code simplification workflow     |
 | [evolve](commands/evolve/)               | Co-evolutionary skill generation |
+| [handoff](commands/handoff/)             | Refresh or scaffold `.docs/handoff.md` |
 
 ## Hooks
 
@@ -201,6 +203,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [anatomy-index](hooks/anatomy-index/)     | Maintain project file index with token estimates     |
 | [read-dedup](hooks/read-dedup/)           | Warn on duplicate file reads within a session        |
 | [prompt-context](hooks/prompt-context/)   | Inject text file as additionalContext on every prompt |
+| [handoff-on-stop](hooks/handoff-on-stop/) | Refresh `.docs/handoff.md` on Stop when present      |
 
 ## Utilities
 
@@ -222,6 +225,7 @@ Presets install curated bundles of passive packages (rules, hooks, commands) in 
 | [ai-builder](presets/ai-builder/)       | 6 skills                                         | AI/ML development toolkit — agent building, prompt engineering, GPU optimization, RAG auditing. |
 | [skill-evolution](presets/skill-evolution/) | 6 skills, 1 agent, 1 command               | EvoSkills pipeline — co-evolutionary skill factory with paper-to-skill, distillation, and verification. |
 | [terse-mode](presets/terse-mode/)       | 1 hook                                           | Terse output enforcement via prompt-context hook with compaction-immune rule injection.          |
+| [session-continuity](presets/session-continuity/) | 1 skill, 1 command, 1 hook          | Atomic handoff install: `/handoff`, greenfield scaffold, and opt-in Stop refresh gated by `.docs/handoff.md`. |
 
 ### Deprecated Presets
 

--- a/commands/handoff/COMMAND.md
+++ b/commands/handoff/COMMAND.md
@@ -1,0 +1,53 @@
+---
+name: handoff
+type: command
+description: 'Slash-command wrapper for the handoff skill. `/handoff` refreshes `.docs/handoff.md`; `/handoff init` scaffolds the schema in greenfield projects; both preserve the 200-line cap and authority boundary. Triggers on: "/handoff", "/handoff init", "update handoff", "refresh handoff", "session handoff", "create handoff", "resume checklist". Use this command when pausing, ending, transferring, or resuming in-flight coding work across agent sessions.'
+metadata:
+  version: 0.1.0
+  category: development
+  tags: [handoff, slash-command, session-continuity, runbook]
+  difficulty: intermediate
+  phase: ship
+command:
+  syntax: /handoff [init]
+  handler: inline
+  dependencies:
+    - skills/handoff
+---
+
+# Handoff Command
+
+Thin slash-command entry point for the `handoff` skill.
+
+## Workflow
+
+1. `/handoff` invokes the handoff skill in refresh mode.
+2. `/handoff init` invokes the handoff skill in scaffold mode.
+3. The command writes only `.docs/handoff.md`.
+4. The command preserves the schema, authority boundary, and 200-line hard cap.
+
+## Operations
+
+| Command | Output | Use |
+| --- | --- | --- |
+| `/handoff` | Full rewrite of `.docs/handoff.md` | End or pause a session |
+| `/handoff init` | Empty schema scaffold if absent | Project initialization |
+
+## Output
+
+The command delegates to:
+
+```bash
+uv run skills/handoff/scripts/handoff.py --project-root "$PWD"
+uv run skills/handoff/scripts/handoff.py --project-root "$PWD" --init
+```
+
+## Error Handling
+
+| Problem | Resolution |
+| --- | --- |
+| Not in a git repository | Report the git error unless running `init` |
+| `.docs/` missing | Create it |
+| Existing handoff absent during refresh | Create a populated file rather than failing |
+| Existing handoff present during init | Leave it untouched |
+

--- a/commands/handoff/evals/cases.yaml
+++ b/commands/handoff/evals/cases.yaml
@@ -1,0 +1,41 @@
+cases:
+  - id: handoff_refresh
+    prompt: "/handoff"
+    fixtures: []
+    rubric:
+      - "Invokes the handoff skill in refresh mode"
+      - "Writes .docs/handoff.md"
+      - "Preserves the authority-boundary line"
+    trigger_expected: true
+
+  - id: handoff_init
+    prompt: "/handoff init"
+    fixtures: []
+    rubric:
+      - "Invokes the handoff skill in scaffold mode"
+      - "Creates a schema stub when absent"
+      - "Does not overwrite an existing handoff during init"
+    trigger_expected: true
+
+  - id: implicit_refresh
+    prompt: "Refresh handoff before we stop"
+    fixtures: []
+    rubric:
+      - "Recognizes refresh intent"
+      - "Delegates to handoff skill"
+    trigger_expected: true
+
+  - id: negative_changelog
+    prompt: "Write release notes for the last ten commits"
+    fixtures: []
+    rubric:
+      - "Does not activate; release notes belong to changelog-composer"
+    trigger_expected: false
+
+  - id: negative_adr
+    prompt: "Write an ADR for choosing PostgreSQL over SQLite"
+    fixtures: []
+    rubric:
+      - "Does not activate; durable decisions belong to adr-writer"
+    trigger_expected: false
+

--- a/hooks/handoff-on-stop/HOOK.md
+++ b/hooks/handoff-on-stop/HOOK.md
@@ -1,0 +1,45 @@
+---
+name: handoff-on-stop
+type: hook
+trigger: stop
+description: 'Refreshes `.docs/handoff.md` on session Stop when a project has opted in by already having that file. Invokes the handoff skill silently, logs failures, and continues without blocking shutdown. Triggers on: "handoff on stop", "session end handoff", "auto refresh handoff", "Stop hook", "session continuity hook", "save context on stop". Use this hook when projects need automatic session-continuity updates at the end of coding-agent sessions without creating handoff files everywhere.'
+metadata:
+  version: 0.1.0
+  category: operations
+  tags: [handoff, session-continuity, stop-hook, runbook]
+  difficulty: intermediate
+  phase: ship
+hook:
+  events: [Stop]
+  matcher: ""
+  handler: { type: command, command: bash handler.sh, timeout_ms: 10000 }
+---
+
+# Handoff On Stop
+
+Refreshes `.docs/handoff.md` at the end of a session for projects that have explicitly opted in.
+
+## Workflow
+
+1. On `Stop`, check the current working directory for `.docs/handoff.md`.
+2. If the file is absent, exit 0 with no output.
+3. If present, invoke the `handoff` skill behavior silently.
+4. If refresh fails, append a diagnostic to `.docs/handoff.log` and exit 0.
+
+## Output
+
+No user-visible output on success or no-op. Failures are logged and do not block the Stop event.
+
+## Error Handling
+
+| Failure | Behavior |
+| --- | --- |
+| `.docs/handoff.md` absent | No-op, exit 0 |
+| Generator script missing | Log and exit 0 |
+| Git command failure | Log and exit 0 |
+| Write failure | Log and exit 0 |
+
+## Idempotency
+
+The hook performs a full rewrite through the handoff generator. Repeated Stop events update timestamp and state without appending duplicate sections.
+

--- a/hooks/handoff-on-stop/evals/cases.yaml
+++ b/hooks/handoff-on-stop/evals/cases.yaml
@@ -1,0 +1,40 @@
+cases:
+  - id: refreshes_when_present
+    prompt: "A Stop event fires in a project with .docs/handoff.md"
+    fixtures: []
+    rubric:
+      - "Hook checks for .docs/handoff.md"
+      - "Hook invokes the handoff refresh path silently"
+      - "Hook exits 0"
+    trigger_expected: true
+
+  - id: noops_when_absent
+    prompt: "A Stop event fires in a project without .docs/handoff.md"
+    fixtures: []
+    rubric:
+      - "Hook exits 0 without creating a handoff"
+      - "Hook produces no user-visible output"
+    trigger_expected: true
+
+  - id: logs_and_continues_on_failure
+    prompt: "The handoff generator fails during a Stop event"
+    fixtures: []
+    rubric:
+      - "Hook records the failure"
+      - "Hook does not block the Stop event"
+    trigger_expected: true
+
+  - id: negative_user_prompt
+    prompt: "The user sends a normal coding prompt"
+    fixtures: []
+    rubric:
+      - "Hook should not fire because the event is not Stop"
+    trigger_expected: false
+
+  - id: negative_pre_tool
+    prompt: "A PreToolUse event fires before editing a file"
+    fixtures: []
+    rubric:
+      - "Hook should not fire on PreToolUse"
+    trigger_expected: false
+

--- a/hooks/handoff-on-stop/handler.sh
+++ b/hooks/handoff-on-stop/handler.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -u
+
+if [ ! -f ".docs/handoff.md" ]; then
+  exit 0
+fi
+
+log_file=".docs/handoff.log"
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH= cd -- "$script_dir/../.." && pwd)"
+script="$repo_root/skills/handoff/scripts/handoff.py"
+
+if [ -x "$script" ]; then
+  "$script" --project-root "$PWD" >/dev/null 2>>"$log_file" || true
+elif command -v uv >/dev/null 2>&1 && [ -f "$script" ]; then
+  uv run "$script" --project-root "$PWD" >/dev/null 2>>"$log_file" || true
+else
+  printf '%s handoff-on-stop: generator unavailable\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$log_file" 2>/dev/null || true
+fi
+
+exit 0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -466,6 +466,22 @@ packages:
     category: data
     difficulty: advanced
     phase: build
+  - name: handoff
+    version: 0.1.0
+    description: 'Produces and refreshes `.docs/handoff.md`, a 200-line session-continuity runbook for coding agents. Captures
+      git state, working-tree changes, last validation commands, session decisions, blockers, resume checklist, references,
+      and greenfield scaffolds. Triggers on: "update handoff", "session handoff", "refresh handoff", "/handoff", "/handoff
+      init", "resume checklist", "cold-start primer". Use this skill when ending, pausing, resuming, or transferring in-flight
+      project work across agent sessions.'
+    path: skills/handoff
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/handoff/SKILL.md
+    tags:
+    - session-continuity
+    - runbook
+    - context
+    category: development
+    difficulty: intermediate
+    phase: ship
   - name: html-presentation
     version: 1.1.1
     description: 'Converts documents, outlines, or notes into self-contained HTML slide decks with horizontal (Reveal.js)
@@ -1551,6 +1567,25 @@ packages:
     - hooks
     category: operations
     difficulty: beginner
+  - name: handoff-on-stop
+    version: 0.1.0
+    description: 'Refreshes `.docs/handoff.md` on session Stop when a project has opted in by already having that file. Invokes
+      the handoff skill silently, logs failures, and continues without blocking shutdown. Triggers on: "handoff on stop",
+      "session end handoff", "auto refresh handoff", "Stop hook", "session continuity hook", "save context on stop". Use this
+      hook when projects need automatic session-continuity updates at the end of coding-agent sessions without creating handoff
+      files everywhere.'
+    path: hooks/handoff-on-stop
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/handoff-on-stop/HOOK.md
+    events:
+    - Stop
+    tags:
+    - handoff
+    - session-continuity
+    - stop-hook
+    - runbook
+    category: operations
+    difficulty: intermediate
+    phase: ship
   - name: pre-edit-backup
     version: 1.0.0
     description: Creates a backup copy of any file before Claude Code edits it. Fires on PreToolUse for the Edit tool, reads
@@ -1739,6 +1774,22 @@ packages:
     - command
     category: meta
     difficulty: intermediate
+  - name: handoff
+    version: 0.1.0
+    description: 'Slash-command wrapper for the handoff skill. `/handoff` refreshes `.docs/handoff.md`; `/handoff init` scaffolds
+      the schema in greenfield projects; both preserve the 200-line cap and authority boundary. Triggers on: "/handoff", "/handoff
+      init", "update handoff", "refresh handoff", "session handoff", "create handoff", "resume checklist". Use this command
+      when pausing, ending, transferring, or resuming in-flight coding work across agent sessions.'
+    path: commands/handoff
+    source: https://github.com/Mathews-Tom/armory/blob/main/commands/handoff/COMMAND.md
+    tags:
+    - handoff
+    - slash-command
+    - session-continuity
+    - runbook
+    category: development
+    difficulty: intermediate
+    phase: ship
   - name: refactor
     version: 1.0.0
     description: 'Code simplification workflow that identifies and cleans recently modified files. Uses git diff to find changed
@@ -1995,6 +2046,23 @@ packages:
     - strict
     category: review
     difficulty: intermediate
+  - name: session-continuity
+    version: 0.1.0
+    description: 'Bundles the handoff skill, `/handoff` command, and opt-in Stop hook for maintaining `.docs/handoff.md` as
+      a project-local session-continuity runbook. Covers refresh, greenfield scaffold, automatic Stop-event rewrite, authority-boundary
+      enforcement, and 200-line cap. Triggers on: "session continuity", "handoff preset", "install handoff", "preserve session
+      state", "cold-start primer", "resume checklist". Use this preset when teams want atomic install/uninstall of handoff
+      capture across coding agents.'
+    path: presets/session-continuity
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/session-continuity/PRESET.md
+    tags:
+    - session-continuity
+    - handoff
+    - preset
+    - runbook
+    category: operations
+    difficulty: intermediate
+    phase: ship
   - name: skill-evolution
     version: 1.0.0
     description: 'Skill generation and co-evolutionary refinement tools. Bundles the test-engineer agent (co-evolutionary

--- a/presets/session-continuity/PRESET.md
+++ b/presets/session-continuity/PRESET.md
@@ -1,0 +1,64 @@
+---
+name: session-continuity
+type: preset
+description: 'Bundles the handoff skill, `/handoff` command, and opt-in Stop hook for maintaining `.docs/handoff.md` as a project-local session-continuity runbook. Covers refresh, greenfield scaffold, automatic Stop-event rewrite, authority-boundary enforcement, and 200-line cap. Triggers on: "session continuity", "handoff preset", "install handoff", "preserve session state", "cold-start primer", "resume checklist". Use this preset when teams want atomic install/uninstall of handoff capture across coding agents.'
+packages:
+  - skills/handoff
+  - commands/handoff
+  - hooks/handoff-on-stop
+metadata:
+  version: 0.1.0
+  category: operations
+  tags: [session-continuity, handoff, preset, runbook]
+  difficulty: intermediate
+  phase: ship
+preset:
+  packages:
+    skills:
+      - { name: handoff }
+    commands:
+      - { name: handoff }
+    hooks:
+      - { name: handoff-on-stop }
+---
+
+# Session Continuity
+
+Installs the handoff workflow as one unit: manual refresh, greenfield scaffold, and opt-in Stop refresh.
+
+## Included Packages
+
+| Type | Package | Role |
+| --- | --- | --- |
+| Skill | handoff | Generates and maintains `.docs/handoff.md` |
+| Command | handoff | Provides `/handoff` and `/handoff init` |
+| Hook | handoff-on-stop | Refreshes on Stop when `.docs/handoff.md` already exists |
+
+## Workflow
+
+1. Install the preset.
+2. In an opted-in project, run `/handoff init` once or create `.docs/handoff.md`.
+3. Use `/handoff` any time session state should be refreshed.
+4. On Stop, the hook refreshes only projects that already contain `.docs/handoff.md`.
+
+## Opt-In Gate
+
+The hook is project-gated by file presence. If `.docs/handoff.md` is absent, `handoff-on-stop` exits 0 and creates nothing. This prevents global installs from adding handoff files to unrelated repositories.
+
+## Output
+
+One project-local file:
+
+```text
+.docs/handoff.md
+```
+
+## Error Handling
+
+| Problem | Resolution |
+| --- | --- |
+| Hook installed globally | File-presence gate prevents unwanted writes |
+| Stop refresh fails | Hook logs and continues |
+| Existing project lacks `.docs/` | `/handoff init` creates it |
+| Handoff grows too large | Skill enforces 200-line cap |
+

--- a/presets/session-continuity/evals/cases.yaml
+++ b/presets/session-continuity/evals/cases.yaml
@@ -1,0 +1,32 @@
+cases:
+  - id: install_session_continuity
+    prompt: "Install the handoff preset for session continuity"
+    fixtures: []
+    rubric:
+      - "Includes the handoff skill"
+      - "Includes the /handoff command"
+      - "Includes the handoff-on-stop hook"
+    trigger_expected: true
+
+  - id: atomic_handoff_bundle
+    prompt: "I want atomic install and uninstall of the handoff command and stop hook"
+    fixtures: []
+    rubric:
+      - "Routes to session-continuity preset"
+      - "Explains that the Stop hook is opt-in by .docs/handoff.md presence"
+    trigger_expected: true
+
+  - id: negative_only_changelog
+    prompt: "Install tools for generating changelogs and release notes"
+    fixtures: []
+    rubric:
+      - "Does not activate; this preset is for session handoff, not release documentation"
+    trigger_expected: false
+
+  - id: negative_security_stack
+    prompt: "Install the strict security review preset"
+    fixtures: []
+    rubric:
+      - "Does not activate; security review belongs to sec-strict"
+    trigger_expected: false
+

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: handoff
+description: 'Produces and refreshes `.docs/handoff.md`, a 200-line session-continuity runbook for coding agents. Captures git state, working-tree changes, last validation commands, session decisions, blockers, resume checklist, references, and greenfield scaffolds. Triggers on: "update handoff", "session handoff", "refresh handoff", "/handoff", "/handoff init", "resume checklist", "cold-start primer". Use this skill when ending, pausing, resuming, or transferring in-flight project work across agent sessions.'
+metadata:
+  version: 0.1.0
+  category: development
+  tags: [session-continuity, runbook, context]
+  difficulty: intermediate
+  phase: ship
+---
+
+# Handoff
+
+Maintains `.docs/handoff.md` as the project-local cold-start primer for the next coding agent or human developer. The file captures transient session state only: what changed, what was decided, what is blocked, and exactly how to resume.
+
+## Reference Files
+
+| File | Contents | Load When |
+| --- | --- | --- |
+| `references/schema.md` | Verbatim handoff schema and line-budget rules | Always before writing |
+| `references/authority-boundaries.md` | Boundary between handoff, memory, CLAUDE.md, plans, and git | Always before writing |
+
+## When To Use
+
+| Use handoff | Use another surface |
+| --- | --- |
+| In-flight work, uncommitted edits, current branch, blockers, resume steps | `git log` for committed history |
+| Session-scoped decisions and failed approaches | Memory or ADRs for durable project facts |
+| Immediate validation state and exact next command | `CLAUDE.md` for stable setup instructions |
+| Current roadmap cursor | Plan files for strategic roadmap content |
+
+## Triggers
+
+- Direct commands: `/handoff`, `/handoff init`
+- Refresh phrases: "update handoff", "session handoff", "refresh handoff", "save handoff"
+- Resume phrases: "cold-start primer", "resume checklist", "handoff to next session"
+- Stop hook: refresh silently when `.docs/handoff.md` already exists
+
+## Prerequisites
+
+- `git` available in the project root.
+- Project write access for `.docs/handoff.md`.
+- Optional project-local marker files:
+  - `.docs/handoff.last-validation` containing the last verification command and result.
+  - `.docs/handoff.session` containing extra bullets for changes, decisions, blockers, or refs.
+
+## Workflow
+
+1. **Resolve mode.**
+   - `/handoff init` or invocation from an initialization workflow writes a greenfield stub when `.docs/handoff.md` is absent.
+   - `/handoff`, refresh phrases, and Stop-hook invocation rewrite the full file.
+2. **Read source of truth.**
+   - Load `references/schema.md` and preserve the schema headings exactly.
+   - Load `references/authority-boundaries.md` and include the authority boundary line in every generated handoff.
+3. **Detect repository state.**
+   - Run `git rev-parse --show-toplevel`, `git branch --show-current`, `git rev-parse --short HEAD`, and `git status --porcelain`.
+   - Count modified, untracked, and staged paths from porcelain status.
+   - Include the top 3-5 changed paths in the Status section.
+4. **Detect validation state.**
+   - Prefer recent session context: commands actually run in the current agent session and their result.
+   - If available, read `.docs/handoff.last-validation`.
+   - If neither exists, write explicit unknowns: "not recorded this session" rather than inventing pass/fail.
+5. **Gather session substance.**
+   - Summarize logical changes from current conversation, uncommitted paths, and commits since the branch base when relevant.
+   - Record decisions with rationale in two sentences or fewer.
+   - Record blockers and open questions as actionable unchecked items.
+   - Include failed approaches when they would prevent wasted work in the next session.
+6. **Write by full rewrite.**
+   - Replace `.docs/handoff.md` atomically; do not append.
+   - Create `.docs/` if absent.
+   - Keep the file lowercase at `.docs/handoff.md`.
+7. **Enforce 200 lines.**
+   - Count final lines after rendering.
+   - If over 200, truncate `## What changed this session` oldest-first.
+   - Insert `<!-- WARNING: handoff exceeded 200 lines; oldest session changes were truncated. -->`.
+   - If still over 200, compress decisions and blockers to the newest actionable items, preserving all required headings.
+
+## Supported Operations
+
+| Operation | Command | Behavior |
+| --- | --- | --- |
+| Refresh | `/handoff` | Rewrites `.docs/handoff.md` from current repo and session state |
+| Scaffold | `/handoff init` | Creates an empty schema stub when no handoff exists |
+| Stop refresh | Stop hook | Refreshes only when `.docs/handoff.md` already exists |
+| Dry run | `uv run skills/handoff/scripts/handoff.py --dry-run` | Prints generated content without writing |
+
+## Implementation Notes
+
+The bundled script is the deterministic baseline used by the command and hook:
+
+```bash
+uv run skills/handoff/scripts/handoff.py --project-root "$PWD"
+uv run skills/handoff/scripts/handoff.py --project-root "$PWD" --init
+```
+
+Agents may improve populated bullets from live session context before writing, but must preserve:
+
+- Schema headings and order.
+- Authority boundary line.
+- Full-file rewrite semantics.
+- Hard 200-line cap.
+- Explicit unknowns instead of silent fallbacks.
+
+## Greenfield Scaffold
+
+When invoked as `/handoff init` or under a project initialization flow and `.docs/handoff.md` does not exist, write the schema with empty placeholders and real git metadata. This documents the `/init` integration point without modifying any init script.
+
+## Output Format
+
+Write exactly one file: `.docs/handoff.md`.
+
+Required first lines:
+
+```markdown
+# Handoff — <project name>
+
+**Last touched:** <ISO 8601 timestamp with timezone> · **branch:** `<branch>` · **HEAD:** `<short-sha>` · **session:** <model id>
+```
+
+## Troubleshooting
+
+| Problem | Resolution |
+| --- | --- |
+| Not in a git repository | Fail clearly for refresh; scaffold may use branch `—` and HEAD `—` only during `/handoff init` |
+| `.docs/` missing | Create it before writing |
+| Validation state unavailable | Write "not recorded this session"; do not claim tests passed |
+| Generated file exceeds 200 lines | Truncate oldest `What changed` bullets and add the warning comment |
+| Existing handoff uses old casing or root path | Do not migrate automatically; future refreshes converge only when invoked in that project |
+
+## Verification
+
+- `uv run python scripts/validate_evals.py`
+- `uv run scripts/evaluate_package.py skills/handoff`
+- `uv run skills/handoff/scripts/handoff.py --project-root <repo> --dry-run`
+- `uv run skills/handoff/scripts/handoff.py --project-root <repo> --init --output <tmp-file>`
+

--- a/skills/handoff/evals/cases.yaml
+++ b/skills/handoff/evals/cases.yaml
@@ -1,0 +1,57 @@
+cases:
+  - id: refresh_existing_handoff
+    prompt: "/handoff"
+    fixtures: ["fixtures/known-git-state"]
+    rubric:
+      - "Rewrites .docs/handoff.md using the locked schema"
+      - "Includes branch, short HEAD, working-tree counts, validation state, decisions, blockers, and refs"
+      - "Preserves the authority-boundary line"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "## Resume checklist"
+        weight: 1.0
+      - type: contains
+        target: "Authority: this file owns *transient session state*"
+        weight: 1.0
+
+  - id: greenfield_scaffold
+    prompt: "/handoff init"
+    fixtures: ["fixtures/greenfield"]
+    rubric:
+      - "Creates .docs/handoff.md if absent"
+      - "Uses empty placeholders without claiming tests passed"
+      - "Includes every schema heading"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "No session changes recorded yet."
+        weight: 0.8
+
+  - id: line_cap_truncation
+    prompt: "refresh handoff with a very long session change list"
+    fixtures: ["fixtures/line-cap"]
+    rubric:
+      - "Generated handoff is no more than 200 lines"
+      - "Oldest What changed bullets are truncated first"
+      - "Warning comment is emitted"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "handoff exceeded 200 lines"
+        weight: 1.0
+
+  - id: negative_durable_memory
+    prompt: "Store this project architecture fact in long-term memory"
+    fixtures: []
+    rubric:
+      - "Does not activate handoff because durable facts belong in memory or CLAUDE.md"
+    trigger_expected: false
+
+  - id: negative_changelog
+    prompt: "Generate release notes from the commits since v1.2.0"
+    fixtures: []
+    rubric:
+      - "Does not activate handoff because committed-history summaries belong to changelog-composer"
+    trigger_expected: false
+

--- a/skills/handoff/evals/fixtures/greenfield/expected-scaffold.md
+++ b/skills/handoff/evals/fixtures/greenfield/expected-scaffold.md
@@ -1,0 +1,34 @@
+# Handoff — greenfield
+
+**Last touched:** <timestamp> · **branch:** `<branch>` · **HEAD:** `<short-sha>` · **session:** <model id>
+
+> Authority: this file owns *transient session state*. Persistent facts live in `~/.claude/projects/<project>/memory/`. Static setup lives in `CLAUDE.md`. Strategic
+roadmap lives in `~/.claude/plans/<plan>.md`. Committed history lives in `git log`.
+
+## Status
+- Working tree: 0 modified, 0 untracked, 0 staged (`—`)
+- Tests: not recorded this session → not recorded this session
+- Lint/type: not recorded this session
+- Last verified: not recorded this session @ <timestamp>
+
+## What changed this session
+- No session changes recorded yet.
+
+## Decisions
+1. **Handoff scaffold established** (<date>) — Use `.docs/handoff.md` as the transient session-state runbook; promote durable facts to the proper authority surface.
+
+## Blockers / open questions
+- [ ] No blockers recorded.
+
+## Resume checklist
+1. Run `git status` and confirm the tree matches the Status section.
+2. Re-run the last recorded validation command or establish one if not recorded.
+3. Open the first changed path listed above and inspect where work stopped.
+4. Resolve the top blocker or make the next recorded decision.
+
+## Refs
+- Plan: `—`
+- Related PRs: —
+- Memory: `—`
+- Conversation: —
+

--- a/skills/handoff/evals/fixtures/known-git-state/expected-handoff.md
+++ b/skills/handoff/evals/fixtures/known-git-state/expected-handoff.md
@@ -1,0 +1,35 @@
+# Handoff — known-git-state
+
+**Last touched:** <timestamp> · **branch:** `<branch>` · **HEAD:** `<short-sha>` · **session:** <model id>
+
+> Authority: this file owns *transient session state*. Persistent facts live in `~/.claude/projects/<project>/memory/`. Static setup lives in `CLAUDE.md`. Strategic
+roadmap lives in `~/.claude/plans/<plan>.md`. Committed history lives in `git log`.
+
+## Status
+- Working tree: <counts> (`<top paths>`)
+- Tests: uv run pytest tests/test_session.py -q → 12 passed
+- Lint/type: uv run pytest tests/test_session.py -q → 12 passed
+- Last verified: uv run pytest tests/test_session.py -q → 12 passed @ <timestamp>
+
+## What changed this session
+- Updated `src/session.py` to preserve failed approach context for the next agent.
+- Added `.docs/handoff.last-validation` as a project-local validation marker.
+
+## Decisions
+1. **Use lowercase path** (2026-05-08) — `.docs/handoff.md` is the canonical per-project path across agents.
+
+## Blockers / open questions
+- [ ] Confirm the next validation command after rebasing the branch.
+
+## Resume checklist
+1. Run `git status` and confirm the tree matches the Status section.
+2. Re-run the last recorded validation command or establish one if not recorded.
+3. Open the first changed path listed above and inspect where work stopped.
+4. Resolve the top blocker or make the next recorded decision.
+
+## Refs
+- Plan: `—`
+- Related PRs: —
+- Memory: `—`
+- Conversation: searchat query: session handoff lowercase path
+

--- a/skills/handoff/references/authority-boundaries.md
+++ b/skills/handoff/references/authority-boundaries.md
@@ -1,0 +1,23 @@
+# Authority Boundaries
+
+`.docs/handoff.md` owns transient session state: the current branch, uncommitted or in-flight work, decisions made in the active session, immediate blockers, validation state, and resume steps.
+
+It does not own durable project knowledge.
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| `.docs/handoff.md` | Session cursor, local working state, blockers, next commands | Long-lived architecture facts, installation docs, committed history |
+| `~/.claude/projects/<project>/memory/` | Persistent cross-conversation facts and preferences | Current uncommitted working-tree details |
+| `CLAUDE.md` | Static project setup, repo conventions, stable commands | Temporary blockers or half-finished edits |
+| `~/.claude/plans/<plan>.md` | Strategic roadmap and multi-session plan | The current cursor inside the roadmap |
+| `git log` | Committed history and PR-ready narrative | Uncommitted work, failed attempts, session-local choices |
+
+Promote information out of handoff when it becomes durable:
+
+- Stable setup instruction → `CLAUDE.md`
+- Durable architectural decision → memory or ADR
+- Completed committed work → commit message, changelog, or PR description
+- Multi-session roadmap item → plan file
+
+Agent-agnostic rule: write for any coding agent or human who can read Markdown and run shell commands. Avoid tool-specific assumptions unless they are explicit refs.
+

--- a/skills/handoff/references/schema.md
+++ b/skills/handoff/references/schema.md
@@ -1,0 +1,52 @@
+# Handoff Schema
+
+Every generated handoff uses this schema exactly, at `.docs/handoff.md`.
+
+```markdown
+# Handoff — <project name>
+
+**Last touched:** <ISO 8601 timestamp with timezone> · **branch:** `<branch>` · **HEAD:** `<short-sha>` · **session:** <model id>
+
+> Authority: this file owns *transient session state*. Persistent facts live in `~/.claude/projects/<project>/memory/`. Static setup lives in `CLAUDE.md`. Strategic
+roadmap lives in `~/.claude/plans/<plan>.md`. Committed history lives in `git log`.
+
+## Status
+- Working tree: <N modified, M untracked, K staged> (`<top 3-5 paths>`)
+- Tests: <last command> → <pass/fail counts, named failures>
+- Lint/type: <ruff/mypy/eslint/tsc state>
+- Last verified: <command + timestamp>
+
+## What changed this session
+- <bullet per logical change; reference SHAs for commits, paths for uncommitted work>
+
+## Decisions
+1. **<decision title>** (<date>) — <rationale, ≤2 sentences>
+
+## Blockers / open questions
+- [ ] <unresolved item, with enough context to resume cold>
+
+## Resume checklist
+1. <first verification step — usually `git status` to confirm tree matches Status>
+2. <second step — usually re-run last test command to confirm same state>
+3. <third step — point at the specific file:line where work stopped>
+4. <fourth step — flag the next decision to make, if any>
+
+## Refs
+- Plan: `<path or "—">`
+- Related PRs: <numbers or "—">
+- Memory: `<files or "—">`
+- Conversation: <searchat query or "—">
+```
+
+## Line Budget
+
+The hard cap is 200 lines.
+
+Header and section overhead is approximately 25 lines. The remaining budget belongs to content. If generated content exceeds 200 lines, truncate `## What changed this session` oldest-first and insert:
+
+```markdown
+<!-- WARNING: handoff exceeded 200 lines; oldest session changes were truncated. -->
+```
+
+Preserve every schema heading even when content must be compressed.
+

--- a/skills/handoff/scripts/handoff.py
+++ b/skills/handoff/scripts/handoff.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+MAX_LINES = 200
+WARNING = "<!-- WARNING: handoff exceeded 200 lines; oldest session changes were truncated. -->"
+
+
+@dataclass(frozen=True)
+class GitState:
+    branch: str
+    head: str
+    modified: int
+    untracked: int
+    staged: int
+    paths: list[str]
+
+
+def run_git(root: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def git_state(root: Path, allow_missing: bool) -> GitState:
+    try:
+        branch = run_git(root, ["branch", "--show-current"]) or "detached"
+        head = run_git(root, ["rev-parse", "--short", "HEAD"])
+        status = run_git(root, ["status", "--porcelain"]).splitlines()
+    except RuntimeError:
+        if allow_missing:
+            return GitState("—", "—", 0, 0, 0, [])
+        raise
+
+    modified = 0
+    untracked = 0
+    staged = 0
+    paths: list[str] = []
+    for line in status:
+        if not line:
+            continue
+        index = line[0]
+        worktree = line[1]
+        path = line[3:] if len(line) > 3 else line[2:].strip()
+        if line.startswith("??"):
+            untracked += 1
+        if index not in (" ", "?"):
+            staged += 1
+        if worktree not in (" ", "?") or index == "M":
+            modified += 1
+        paths.append(path)
+    return GitState(branch, head, modified, untracked, staged, paths[:5])
+
+
+def read_marker(root: Path, name: str) -> str | None:
+    path = root / ".docs" / name
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def project_name(root: Path) -> str:
+    return root.resolve().name
+
+
+def timestamp() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def session_id() -> str:
+    return (
+        os.environ.get("HANDOFF_SESSION_ID")
+        or os.environ.get("AI_SESSION_MODEL")
+        or "agent session"
+    )
+
+
+def default_validation(root: Path) -> tuple[str, str, str]:
+    marker = read_marker(root, "handoff.last-validation")
+    if marker:
+        first = marker.splitlines()[0]
+        return first, marker, f"{first} @ {timestamp()}"
+    return (
+        "not recorded this session",
+        "not recorded this session",
+        f"not recorded this session @ {timestamp()}",
+    )
+
+
+def parse_session_marker(root: Path) -> dict[str, list[str]]:
+    marker = read_marker(root, "handoff.session")
+    sections: dict[str, list[str]] = {
+        "changed": [],
+        "decisions": [],
+        "blockers": [],
+        "refs": [],
+    }
+    if not marker:
+        return sections
+    current: str | None = None
+    for raw in marker.splitlines():
+        line = raw.strip()
+        key = line.lower().rstrip(":")
+        if key in sections:
+            current = key
+            continue
+        if current and line:
+            sections[current].append(line)
+    return sections
+
+
+def parse_existing_handoff(root: Path) -> dict[str, list[str]]:
+    path = root / ".docs" / "handoff.md"
+    if not path.exists():
+        return {
+            "changed": [],
+            "decisions": [],
+            "blockers": [],
+            "refs": [],
+            "validation": [],
+        }
+
+    sections: dict[str, list[str]] = {
+        "changed": [],
+        "decisions": [],
+        "blockers": [],
+        "refs": [],
+        "validation": [],
+    }
+    active: str | None = None
+    heading_map = {
+        "what changed this session": "changed",
+        "what was built": "changed",
+        "current state": "changed",
+        "immediate next actions": "blockers",
+        "recommended resume path": "blockers",
+        "open questions": "blockers",
+        "open questions for next session": "blockers",
+        "blockers / open questions": "blockers",
+        "test status": "validation",
+        "lint and type verification commands": "validation",
+        "reference": "refs",
+        "refs": "refs",
+    }
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if line.startswith("#"):
+            key = line.lstrip("# ").strip().lower()
+            active = heading_map.get(key)
+            continue
+        if not active or not line.strip():
+            continue
+        stripped = line.strip()
+        if stripped.startswith(
+            (
+                "- ",
+                "1. ",
+                "2. ",
+                "3. ",
+                "4. ",
+                "|",
+                "`",
+                "uv run",
+                "npm ",
+                "pnpm ",
+                "yarn ",
+                "bun ",
+                "go ",
+                "cargo ",
+            )
+        ):
+            sections[active].append(stripped)
+    validation = sections["validation"]
+    command_lines = [
+        item
+        for item in validation
+        if item.strip("`").startswith(
+            ("uv run", "npm ", "pnpm ", "yarn ", "bun ", "go ", "cargo ")
+        )
+    ]
+    sections["validation"] = command_lines[:6] or validation[:12]
+    return {key: values[:12] for key, values in sections.items()}
+
+
+def render(root: Path, init: bool) -> list[str]:
+    state = git_state(root, allow_missing=init)
+    tests, lint, verified = default_validation(root)
+    session = parse_session_marker(root)
+    existing = (
+        parse_existing_handoff(root) if not init else parse_existing_handoff(root)
+    )
+    if tests == "not recorded this session" and existing["validation"]:
+        validation_summary = next(
+            (
+                item.strip("`")
+                for item in existing["validation"]
+                if item.startswith("`uv run")
+            ),
+            next(
+                (
+                    item
+                    for item in existing["validation"]
+                    if item.startswith(
+                        ("uv run", "npm ", "pnpm ", "yarn ", "bun ", "go ", "cargo ")
+                    )
+                ),
+                existing["validation"][0],
+            ),
+        )
+        tests = validation_summary
+        lint = validation_summary
+        verified = f"{validation_summary} @ {timestamp()}"
+    paths = ", ".join(state.paths) if state.paths else "—"
+    today = datetime.now().date().isoformat()
+
+    changed = (
+        session["changed"]
+        or existing["changed"]
+        or [
+            "No session changes recorded yet."
+            if init
+            else f"Working tree snapshot captured for {paths}."
+        ]
+    )
+    decisions = (
+        session["decisions"]
+        or existing["decisions"]
+        or [
+            f"**Handoff scaffold established** ({today}) — Use `.docs/handoff.md` as the transient session-state runbook; promote durable facts to the proper authority surface."
+        ]
+    )
+    blockers = (
+        session["blockers"]
+        or existing["blockers"]
+        or [
+            "No blockers recorded."
+            if init
+            else "Review current working tree and session context before continuing."
+        ]
+    )
+    refs = session["refs"] or existing["refs"]
+
+    lines = [
+        f"# Handoff — {project_name(root)}",
+        "",
+        f"**Last touched:** {timestamp()} · **branch:** `{state.branch}` · **HEAD:** `{state.head}` · **session:** {session_id()}",
+        "",
+        "> Authority: this file owns *transient session state*. Persistent facts live in `~/.claude/projects/<project>/memory/`. Static setup lives in `CLAUDE.md`. Strategic",
+        "roadmap lives in `~/.claude/plans/<plan>.md`. Committed history lives in `git log`.",
+        "",
+        "## Status",
+        f"- Working tree: {state.modified} modified, {state.untracked} untracked, {state.staged} staged (`{paths}`)",
+        f"- Tests: {tests} → {tests}",
+        f"- Lint/type: {lint}",
+        f"- Last verified: {verified}",
+        "",
+        "## What changed this session",
+        *[f"- {item.lstrip('- ')}" for item in changed],
+        "",
+        "## Decisions",
+        *[
+            f"{idx}. {item.lstrip('0123456789. ')}"
+            for idx, item in enumerate(decisions, 1)
+        ],
+        "",
+        "## Blockers / open questions",
+        *[
+            item if item.startswith("- [ ]") else f"- [ ] {item.lstrip('- ')}"
+            for item in blockers
+        ],
+        "",
+        "## Resume checklist",
+        "1. Run `git status` and confirm the tree matches the Status section.",
+        "2. Re-run the last recorded validation command or establish one if not recorded.",
+        "3. Open the first changed path listed above and inspect where work stopped.",
+        "4. Resolve the top blocker or make the next recorded decision.",
+        "",
+        "## Refs",
+        "- Plan: `—`",
+        "- Related PRs: —",
+        "- Memory: `—`",
+        f"- Conversation: {refs[0] if refs else '—'}",
+    ]
+    return enforce_limit(lines)
+
+
+def enforce_limit(lines: list[str]) -> list[str]:
+    if len(lines) <= MAX_LINES:
+        return lines
+    changed_start = lines.index("## What changed this session") + 1
+    changed_end = lines.index("", changed_start)
+    while len(lines) > MAX_LINES and changed_end - changed_start > 1:
+        del lines[changed_start]
+        changed_end -= 1
+    if WARNING not in lines:
+        lines.insert(changed_start, WARNING)
+    while len(lines) > MAX_LINES and changed_end - changed_start > 1:
+        del lines[changed_start + 1]
+        changed_end -= 1
+    return lines[:MAX_LINES]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--output")
+    parser.add_argument("--init", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.project_root).resolve()
+    output = (
+        Path(args.output).resolve() if args.output else root / ".docs" / "handoff.md"
+    )
+    if args.init and output.exists():
+        return 0
+    lines = render(root, init=args.init)
+    text = "\n".join(lines) + "\n"
+    if args.dry_run:
+        print(text, end="")
+        return 0
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/humanize/references/detection-patterns.md
+++ b/skills/humanize/references/detection-patterns.md
@@ -15,11 +15,9 @@ Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:
 **Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
 
 Before:
-
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
 
 After:
-
 > The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
 ### Pattern 2: Notability and Media Emphasis
@@ -29,11 +27,9 @@ After:
 **Problem:** Hits readers over the head with claims of notability without context.
 
 Before:
-
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 After:
-
 > In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
 ### Pattern 3: Superficial -ing Analyses
@@ -43,11 +39,9 @@ After:
 **Problem:** Tacks present participle phrases onto sentences to add fake depth.
 
 Before:
-
 > The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
 
 After:
-
 > The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
 ### Pattern 4: Promotional Language
@@ -57,11 +51,9 @@ After:
 **Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
 
 Before:
-
 > Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 After:
-
 > Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
 ### Pattern 5: Vague Attributions
@@ -71,11 +63,9 @@ After:
 **Problem:** Attributes opinions to vague authorities without specific sources.
 
 Before:
-
 > Experts believe it plays a crucial role in the regional ecosystem.
 
 After:
-
 > The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
 ### Pattern 6: Formulaic Challenges Sections
@@ -85,11 +75,9 @@ After:
 **Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
 
 Before:
-
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
 
 After:
-
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
 
 ---
@@ -103,11 +91,9 @@ After:
 **Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
 
 Before:
-
 > Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
 
 After:
-
 > Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
 
 ### Pattern 8: Copula Avoidance
@@ -117,17 +103,14 @@ After:
 **Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
 
 Before:
-
 > Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 After:
-
 > Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
 
 ### Pattern 22: Filler Phrases
 
 Common substitutions:
-
 - "In order to achieve this goal" -> "To achieve this"
 - "Due to the fact that" -> "Because"
 - "At this point in time" -> "Now"
@@ -140,11 +123,9 @@ Common substitutions:
 **Problem:** Over-qualifying every statement.
 
 Before:
-
 > It could potentially possibly be argued that the policy might have some effect on outcomes.
 
 After:
-
 > The policy may affect outcomes.
 
 ---
@@ -156,11 +137,9 @@ After:
 **Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
 
 Before:
-
 > It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
 
 After:
-
 > The heavy beat adds to the aggressive tone.
 
 ### Pattern 10: Rule of Three
@@ -168,11 +147,9 @@ After:
 **Problem:** Forces ideas into groups of three to appear comprehensive.
 
 Before:
-
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 After:
-
 > The event includes talks and panels. There's also time for informal networking between sessions.
 
 ### Pattern 11: Elegant Variation (Synonym Cycling)
@@ -180,11 +157,9 @@ After:
 **Problem:** Excessive synonym substitution driven by repetition-penalty.
 
 Before:
-
 > The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
 
 After:
-
 > The protagonist faces many challenges but eventually triumphs and returns home.
 
 ### Pattern 12: False Ranges
@@ -192,11 +167,9 @@ After:
 **Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
 
 Before:
-
 > Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
 
 After:
-
 > The book covers the Big Bang, star formation, and current theories about dark matter.
 
 ### Pattern 15: Inline-Header Vertical Lists
@@ -204,13 +177,11 @@ After:
 **Problem:** Lists where items start with bolded headers followed by colons.
 
 Before:
-
 > - **User Experience:** The UX has been significantly improved.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 After:
-
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
 ---
@@ -222,11 +193,9 @@ After:
 **Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
 
 Before:
-
 > The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
 
 After:
-
 > The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
 
 **Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
@@ -236,11 +205,9 @@ After:
 **Problem:** Mechanical emphasis on phrases.
 
 Before:
-
 > It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
 
 After:
-
 > It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
 
 ### Pattern 16: Title Case in Headings
@@ -253,12 +220,10 @@ After: `## Strategic negotiations and global partnerships`
 **Problem:** Decorating headings or bullet points with emoji.
 
 Before:
-
 > - :rocket: **Launch Phase:** The product launches in Q3
 > - :bulb: **Key Insight:** Users prefer simplicity
 
 After:
-
 > The product launches in Q3. User research showed a preference for simplicity.
 
 ### Pattern 18: Curly Quotation Marks
@@ -278,11 +243,9 @@ Fix: Replace all curly quotes with straight quotes.
 **Problem:** Chatbot conversation artifacts left in published text.
 
 Before:
-
 > Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
 
 After:
-
 > The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
 ### Pattern 20: Knowledge-Cutoff Disclaimers
@@ -290,29 +253,23 @@ After:
 **Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
 
 Before:
-
 > While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 After:
-
 > The company was founded in 1994, according to its registration documents.
 
 ### Pattern 21: Sycophantic Tone
 
 Before:
-
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point.
 
 After:
-
 > The economic factors you mentioned are relevant here.
 
 ### Pattern 24: Generic Positive Conclusions
 
 Before:
-
 > The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 After:
-
 > The company plans to open two more locations next year.

--- a/skills/linkedin-post-style/references/detection-patterns.md
+++ b/skills/linkedin-post-style/references/detection-patterns.md
@@ -15,11 +15,9 @@ Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:
 **Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
 
 Before:
-
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
 
 After:
-
 > The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
 ### Pattern 2: Notability and Media Emphasis
@@ -29,11 +27,9 @@ After:
 **Problem:** Hits readers over the head with claims of notability without context.
 
 Before:
-
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 After:
-
 > In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
 ### Pattern 3: Superficial -ing Analyses
@@ -43,11 +39,9 @@ After:
 **Problem:** Tacks present participle phrases onto sentences to add fake depth.
 
 Before:
-
 > The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
 
 After:
-
 > The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
 ### Pattern 4: Promotional Language
@@ -57,11 +51,9 @@ After:
 **Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
 
 Before:
-
 > Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 After:
-
 > Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
 ### Pattern 5: Vague Attributions
@@ -71,11 +63,9 @@ After:
 **Problem:** Attributes opinions to vague authorities without specific sources.
 
 Before:
-
 > Experts believe it plays a crucial role in the regional ecosystem.
 
 After:
-
 > The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
 ### Pattern 6: Formulaic Challenges Sections
@@ -85,11 +75,9 @@ After:
 **Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
 
 Before:
-
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
 
 After:
-
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
 
 ---
@@ -103,11 +91,9 @@ After:
 **Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
 
 Before:
-
 > Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
 
 After:
-
 > Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
 
 ### Pattern 8: Copula Avoidance
@@ -117,17 +103,14 @@ After:
 **Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
 
 Before:
-
 > Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 After:
-
 > Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
 
 ### Pattern 22: Filler Phrases
 
 Common substitutions:
-
 - "In order to achieve this goal" -> "To achieve this"
 - "Due to the fact that" -> "Because"
 - "At this point in time" -> "Now"
@@ -140,11 +123,9 @@ Common substitutions:
 **Problem:** Over-qualifying every statement.
 
 Before:
-
 > It could potentially possibly be argued that the policy might have some effect on outcomes.
 
 After:
-
 > The policy may affect outcomes.
 
 ---
@@ -156,11 +137,9 @@ After:
 **Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
 
 Before:
-
 > It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
 
 After:
-
 > The heavy beat adds to the aggressive tone.
 
 ### Pattern 10: Rule of Three
@@ -168,11 +147,9 @@ After:
 **Problem:** Forces ideas into groups of three to appear comprehensive.
 
 Before:
-
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 After:
-
 > The event includes talks and panels. There's also time for informal networking between sessions.
 
 ### Pattern 11: Elegant Variation (Synonym Cycling)
@@ -180,11 +157,9 @@ After:
 **Problem:** Excessive synonym substitution driven by repetition-penalty.
 
 Before:
-
 > The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
 
 After:
-
 > The protagonist faces many challenges but eventually triumphs and returns home.
 
 ### Pattern 12: False Ranges
@@ -192,11 +167,9 @@ After:
 **Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
 
 Before:
-
 > Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
 
 After:
-
 > The book covers the Big Bang, star formation, and current theories about dark matter.
 
 ### Pattern 15: Inline-Header Vertical Lists
@@ -204,13 +177,11 @@ After:
 **Problem:** Lists where items start with bolded headers followed by colons.
 
 Before:
-
 > - **User Experience:** The UX has been significantly improved.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 After:
-
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
 ---
@@ -222,11 +193,9 @@ After:
 **Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
 
 Before:
-
 > The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
 
 After:
-
 > The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
 
 **Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
@@ -236,11 +205,9 @@ After:
 **Problem:** Mechanical emphasis on phrases.
 
 Before:
-
 > It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
 
 After:
-
 > It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
 
 ### Pattern 16: Title Case in Headings
@@ -253,12 +220,10 @@ After: `## Strategic negotiations and global partnerships`
 **Problem:** Decorating headings or bullet points with emoji.
 
 Before:
-
 > - :rocket: **Launch Phase:** The product launches in Q3
 > - :bulb: **Key Insight:** Users prefer simplicity
 
 After:
-
 > The product launches in Q3. User research showed a preference for simplicity.
 
 ### Pattern 18: Curly Quotation Marks
@@ -278,11 +243,9 @@ Fix: Replace all curly quotes with straight quotes.
 **Problem:** Chatbot conversation artifacts left in published text.
 
 Before:
-
 > Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
 
 After:
-
 > The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
 ### Pattern 20: Knowledge-Cutoff Disclaimers
@@ -290,29 +253,23 @@ After:
 **Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
 
 Before:
-
 > While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 After:
-
 > The company was founded in 1994, according to its registration documents.
 
 ### Pattern 21: Sycophantic Tone
 
 Before:
-
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point.
 
 After:
-
 > The economic factors you mentioned are relevant here.
 
 ### Pattern 24: Generic Positive Conclusions
 
 Before:
-
 > The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 After:
-
 > The company plans to open two more locations next year.

--- a/skills/manuscript-review/references/detection-patterns.md
+++ b/skills/manuscript-review/references/detection-patterns.md
@@ -15,11 +15,9 @@ Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:
 **Problem:** Puffs up importance by claiming arbitrary aspects represent or contribute to broader topics.
 
 Before:
-
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain.
 
 After:
-
 > The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
 ### Pattern 2: Notability and Media Emphasis
@@ -29,11 +27,9 @@ After:
 **Problem:** Hits readers over the head with claims of notability without context.
 
 Before:
-
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 After:
-
 > In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
 ### Pattern 3: Superficial -ing Analyses
@@ -43,11 +39,9 @@ After:
 **Problem:** Tacks present participle phrases onto sentences to add fake depth.
 
 Before:
-
 > The temple's color palette resonates with the region's natural beauty, symbolizing Texas bluebonnets, reflecting the community's deep connection to the land.
 
 After:
-
 > The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
 ### Pattern 4: Promotional Language
@@ -57,11 +51,9 @@ After:
 **Problem:** Cannot maintain neutral tone, especially for cultural heritage topics.
 
 Before:
-
 > Nestled within the breathtaking region of Gonder, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 After:
-
 > Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
 ### Pattern 5: Vague Attributions
@@ -71,11 +63,9 @@ After:
 **Problem:** Attributes opinions to vague authorities without specific sources.
 
 Before:
-
 > Experts believe it plays a crucial role in the regional ecosystem.
 
 After:
-
 > The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
 ### Pattern 6: Formulaic Challenges Sections
@@ -85,11 +75,9 @@ After:
 **Problem:** Formulaic "Challenges" sections that inflate and then dismiss problems.
 
 Before:
-
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas. Despite these challenges, Korattur continues to thrive.
 
 After:
-
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022.
 
 ---
@@ -103,11 +91,9 @@ After:
 **Problem:** These words appear at statistically anomalous frequency in post-2023 text and often co-occur.
 
 Before:
-
 > Additionally, a distinctive feature is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape.
 
 After:
-
 > Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common in the south.
 
 ### Pattern 8: Copula Avoidance
@@ -117,17 +103,14 @@ After:
 **Problem:** Substitutes elaborate constructions for simple "is", "are", "has".
 
 Before:
-
 > Gallery 825 serves as LAAA's exhibition space. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 After:
-
 > Gallery 825 is LAAA's exhibition space. The gallery has four rooms totaling 3,000 square feet.
 
 ### Pattern 22: Filler Phrases
 
 Common substitutions:
-
 - "In order to achieve this goal" -> "To achieve this"
 - "Due to the fact that" -> "Because"
 - "At this point in time" -> "Now"
@@ -140,11 +123,9 @@ Common substitutions:
 **Problem:** Over-qualifying every statement.
 
 Before:
-
 > It could potentially possibly be argued that the policy might have some effect on outcomes.
 
 After:
-
 > The policy may affect outcomes.
 
 ---
@@ -156,11 +137,9 @@ After:
 **Problem:** "Not only...but..." and "It's not just about..., it's..." constructions are overused.
 
 Before:
-
 > It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
 
 After:
-
 > The heavy beat adds to the aggressive tone.
 
 ### Pattern 10: Rule of Three
@@ -168,11 +147,9 @@ After:
 **Problem:** Forces ideas into groups of three to appear comprehensive.
 
 Before:
-
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 After:
-
 > The event includes talks and panels. There's also time for informal networking between sessions.
 
 ### Pattern 11: Elegant Variation (Synonym Cycling)
@@ -180,11 +157,9 @@ After:
 **Problem:** Excessive synonym substitution driven by repetition-penalty.
 
 Before:
-
 > The protagonist faces challenges. The main character must overcome obstacles. The central figure triumphs. The hero returns.
 
 After:
-
 > The protagonist faces many challenges but eventually triumphs and returns home.
 
 ### Pattern 12: False Ranges
@@ -192,11 +167,9 @@ After:
 **Problem:** "From X to Y" constructions where X and Y are not on a meaningful scale.
 
 Before:
-
 > Our journey has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth of stars to the enigmatic dance of dark matter.
 
 After:
-
 > The book covers the Big Bang, star formation, and current theories about dark matter.
 
 ### Pattern 15: Inline-Header Vertical Lists
@@ -204,13 +177,11 @@ After:
 **Problem:** Lists where items start with bolded headers followed by colons.
 
 Before:
-
 > - **User Experience:** The UX has been significantly improved.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 After:
-
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
 ---
@@ -222,11 +193,9 @@ After:
 **Problem:** Em dashes appear more frequently in AI text than human text, mimicking "punchy" sales writing.
 
 Before:
-
 > The term is promoted by Dutch institutions — not by the people themselves. You don't say "Netherlands, Europe" — yet this mislabeling continues — even in official documents.
 
 After:
-
 > The term is promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe," yet this mislabeling continues in official documents.
 
 **Fix:** Replace most em dashes with commas, periods, or parentheses. Keep only when the aside genuinely interrupts the sentence.
@@ -236,11 +205,9 @@ After:
 **Problem:** Mechanical emphasis on phrases.
 
 Before:
-
 > It blends **OKRs**, **KPIs**, and visual tools such as the **Business Model Canvas** and **Balanced Scorecard**.
 
 After:
-
 > It blends OKRs, KPIs, and visual tools like the Business Model Canvas and Balanced Scorecard.
 
 ### Pattern 16: Title Case in Headings
@@ -253,12 +220,10 @@ After: `## Strategic negotiations and global partnerships`
 **Problem:** Decorating headings or bullet points with emoji.
 
 Before:
-
 > - :rocket: **Launch Phase:** The product launches in Q3
 > - :bulb: **Key Insight:** Users prefer simplicity
 
 After:
-
 > The product launches in Q3. User research showed a preference for simplicity.
 
 ### Pattern 18: Curly Quotation Marks
@@ -278,11 +243,9 @@ Fix: Replace all curly quotes with straight quotes.
 **Problem:** Chatbot conversation artifacts left in published text.
 
 Before:
-
 > Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
 
 After:
-
 > The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
 ### Pattern 20: Knowledge-Cutoff Disclaimers
@@ -290,29 +253,23 @@ After:
 **Signal words:** as of [date], Up to my last training update, While specific details are limited/scarce, based on available information
 
 Before:
-
 > While specific details about the founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 After:
-
 > The company was founded in 1994, according to its registration documents.
 
 ### Pattern 21: Sycophantic Tone
 
 Before:
-
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point.
 
 After:
-
 > The economic factors you mentioned are relevant here.
 
 ### Pattern 24: Generic Positive Conclusions
 
 Before:
-
 > The future looks bright. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 After:
-
 > The company plans to open two more locations next year.

--- a/skills/plan-review/references/project-detection.md
+++ b/skills/plan-review/references/project-detection.md
@@ -8,17 +8,17 @@ Stack-agnostic project detection patterns for identifying test commands, package
 
 Detect the project's test command by checking these files in order:
 
-| Check | File                                | Condition                                  | Command                                                                          |
-| ----- | ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
-| 1     | `Makefile`                          | Has `test:` target                         | `make test`                                                                      |
-| 2     | `package.json`                      | Has `scripts.test`                         | `{pkg-manager} run test`                                                         |
-| 3     | `pyproject.toml`                    | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
-| 4     | `Cargo.toml`                        | Exists                                     | `cargo test`                                                                     |
-| 5     | `go.mod`                            | Exists                                     | `go test ./...`                                                                  |
-| 6     | `Gemfile` + `Rakefile`              | Has `test` task                            | `bundle exec rake test`                                                          |
-| 7     | `mix.exs`                           | Exists                                     | `mix test`                                                                       |
-| 8     | `build.gradle` / `build.gradle.kts` | Exists                                     | `./gradlew test`                                                                 |
-| 9     | `pom.xml`                           | Exists                                     | `mvn test`                                                                       |
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
 
 If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
 
@@ -28,19 +28,19 @@ If multiple match, prefer the first in order. If `Makefile` exists with a `test`
 
 Detect from lock files (most specific wins):
 
-| Lock File           | Package Manager | Run Command   |
-| ------------------- | --------------- | ------------- |
-| `pnpm-lock.yaml`    | pnpm            | `pnpm run`    |
-| `bun.lockb`         | bun             | `bun run`     |
-| `yarn.lock`         | yarn            | `yarn run`    |
-| `package-lock.json` | npm             | `npm run`     |
-| `uv.lock`           | uv              | `uv run`      |
-| `poetry.lock`       | poetry          | `poetry run`  |
-| `Pipfile.lock`      | pipenv          | `pipenv run`  |
-| `Cargo.lock`        | cargo           | `cargo`       |
-| `go.sum`            | go modules      | `go`          |
-| `Gemfile.lock`      | bundler         | `bundle exec` |
-| `mix.lock`          | mix             | `mix`         |
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
 
 If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
 
@@ -50,14 +50,14 @@ If no lock file: fall back to manifest file detection (`package.json` → npm, `
 
 Check in order:
 
-| Strategy         | Detection                                          | Read                             | Write                                  |
-| ---------------- | -------------------------------------------------- | -------------------------------- | -------------------------------------- |
-| `VERSION` file   | File named `VERSION` at repo root                  | Read contents                    | Write new version                      |
-| `package.json`   | Has `version` field                                | `jq -r .version package.json`    | `jq '.version = "X.Y.Z"' package.json` |
-| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML                       | Update TOML                            |
-| `Cargo.toml`     | Has `[package] version`                            | Parse TOML                       | Update TOML (+ `Cargo.lock`)           |
-| `mix.exs`        | Has `version:` in project config                   | Regex extract                    | Regex replace                          |
-| Git tags only    | No version file, but `v*` tags exist               | `git describe --tags --abbrev=0` | `git tag vX.Y.Z`                       |
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
 
 For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
 
@@ -68,81 +68,76 @@ For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit c
 Detect by analyzing dependencies and configuration files:
 
 ### Python
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Django    | `django` in dependencies, `manage.py` exists  |
-| FastAPI   | `fastapi` in dependencies                     |
-| Flask     | `flask` in dependencies                       |
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
 | Starlette | `starlette` in dependencies (without FastAPI) |
 
 ### JavaScript/TypeScript
-
-| Framework      | Detection                                          |
-| -------------- | -------------------------------------------------- |
-| Next.js        | `next` in dependencies, `next.config.*` exists     |
-| Remix          | `@remix-run/node` in dependencies                  |
-| SvelteKit      | `@sveltejs/kit` in dependencies                    |
-| Nuxt           | `nuxt` in dependencies                             |
-| Express        | `express` in dependencies (without meta-framework) |
-| Astro          | `astro` in dependencies                            |
-| Vite (library) | `vite` in dependencies (without meta-framework)    |
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
 
 ### Ruby
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Rails     | `rails` in Gemfile, `config/routes.rb` exists |
-| Sinatra   | `sinatra` in Gemfile                          |
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
 
 ### Go
-
-| Framework        | Detection                              |
-| ---------------- | -------------------------------------- |
-| Gin              | `github.com/gin-gonic/gin` in `go.mod` |
-| Echo             | `github.com/labstack/echo` in `go.mod` |
-| Chi              | `github.com/go-chi/chi` in `go.mod`    |
-| Standard library | No framework dependency                |
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
 
 ### Rust
-
-| Framework | Detection                   |
-| --------- | --------------------------- |
+| Framework | Detection |
+|-----------|-----------|
 | Actix-web | `actix-web` in `Cargo.toml` |
-| Axum      | `axum` in `Cargo.toml`      |
-| Rocket    | `rocket` in `Cargo.toml`    |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
 
 ### Default Ports by Framework
 
-| Framework     | Default Port |
-| ------------- | ------------ |
-| Next.js       | 3000         |
-| Remix         | 3000         |
-| SvelteKit     | 5173         |
-| Nuxt          | 3000         |
-| Vite          | 5173         |
-| Express       | 3000         |
-| Django        | 8000         |
-| FastAPI       | 8000         |
-| Flask         | 5000         |
-| Rails         | 3000         |
-| Phoenix       | 4000         |
-| Go (common)   | 8080         |
-| Rust (common) | 8080         |
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
 
 ---
 
 ## Monorepo Detection
 
-| Signal                                    | Tool                 | Configuration                             |
-| ----------------------------------------- | -------------------- | ----------------------------------------- |
-| `pnpm-workspace.yaml`                     | pnpm workspaces      | `packages:` array lists workspace globs   |
-| `turbo.json`                              | Turborepo            | `pipeline:` defines task dependencies     |
-| `nx.json`                                 | Nx                   | `targetDefaults:` defines build graph     |
-| `lerna.json`                              | Lerna                | `packages:` array lists package locations |
-| `[workspace]` in `Cargo.toml`             | Cargo workspaces     | `members:` array lists crate paths        |
-| `go.work`                                 | Go workspaces        | `use` directives list module paths        |
-| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects     |
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
 
 For monorepos, scope operations to the relevant workspace/package when a path is specified.
 
@@ -150,40 +145,35 @@ For monorepos, scope operations to the relevant workspace/package when a path is
 
 ## CI/CD Detection
 
-| Path                      | System                         |
-| ------------------------- | ------------------------------ |
-| `.github/workflows/*.yml` | GitHub Actions                 |
-| `.gitlab-ci.yml`          | GitLab CI                      |
-| `Jenkinsfile`             | Jenkins                        |
-| `.circleci/config.yml`    | CircleCI                       |
-| `bitbucket-pipelines.yml` | Bitbucket Pipelines            |
-| `.travis.yml`             | Travis CI                      |
-| `azure-pipelines.yml`     | Azure DevOps                   |
-| `.buildkite/pipeline.yml` | Buildkite                      |
-| `Taskfile.yml`            | Task (not CI, but task runner) |
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
 
 ---
 
 ## Changelog Detection
 
-| File           | Format                         |
-| -------------- | ------------------------------ |
+| File | Format |
+|------|--------|
 | `CHANGELOG.md` | Keep a Changelog (most common) |
-| `CHANGES.md`   | Variant naming                 |
-| `HISTORY.md`   | Variant naming                 |
-| `NEWS.md`      | GNU-style                      |
-| None           | Skip changelog updates         |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
 
 Keep a Changelog format:
-
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
-
 ### Added
-
 ### Changed
-
 ### Fixed
-
 ### Removed
 ```

--- a/skills/qa-systematic/references/project-detection.md
+++ b/skills/qa-systematic/references/project-detection.md
@@ -8,17 +8,17 @@ Stack-agnostic project detection patterns for identifying test commands, package
 
 Detect the project's test command by checking these files in order:
 
-| Check | File                                | Condition                                  | Command                                                                          |
-| ----- | ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
-| 1     | `Makefile`                          | Has `test:` target                         | `make test`                                                                      |
-| 2     | `package.json`                      | Has `scripts.test`                         | `{pkg-manager} run test`                                                         |
-| 3     | `pyproject.toml`                    | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
-| 4     | `Cargo.toml`                        | Exists                                     | `cargo test`                                                                     |
-| 5     | `go.mod`                            | Exists                                     | `go test ./...`                                                                  |
-| 6     | `Gemfile` + `Rakefile`              | Has `test` task                            | `bundle exec rake test`                                                          |
-| 7     | `mix.exs`                           | Exists                                     | `mix test`                                                                       |
-| 8     | `build.gradle` / `build.gradle.kts` | Exists                                     | `./gradlew test`                                                                 |
-| 9     | `pom.xml`                           | Exists                                     | `mvn test`                                                                       |
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
 
 If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
 
@@ -28,19 +28,19 @@ If multiple match, prefer the first in order. If `Makefile` exists with a `test`
 
 Detect from lock files (most specific wins):
 
-| Lock File           | Package Manager | Run Command   |
-| ------------------- | --------------- | ------------- |
-| `pnpm-lock.yaml`    | pnpm            | `pnpm run`    |
-| `bun.lockb`         | bun             | `bun run`     |
-| `yarn.lock`         | yarn            | `yarn run`    |
-| `package-lock.json` | npm             | `npm run`     |
-| `uv.lock`           | uv              | `uv run`      |
-| `poetry.lock`       | poetry          | `poetry run`  |
-| `Pipfile.lock`      | pipenv          | `pipenv run`  |
-| `Cargo.lock`        | cargo           | `cargo`       |
-| `go.sum`            | go modules      | `go`          |
-| `Gemfile.lock`      | bundler         | `bundle exec` |
-| `mix.lock`          | mix             | `mix`         |
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
 
 If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
 
@@ -50,14 +50,14 @@ If no lock file: fall back to manifest file detection (`package.json` → npm, `
 
 Check in order:
 
-| Strategy         | Detection                                          | Read                             | Write                                  |
-| ---------------- | -------------------------------------------------- | -------------------------------- | -------------------------------------- |
-| `VERSION` file   | File named `VERSION` at repo root                  | Read contents                    | Write new version                      |
-| `package.json`   | Has `version` field                                | `jq -r .version package.json`    | `jq '.version = "X.Y.Z"' package.json` |
-| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML                       | Update TOML                            |
-| `Cargo.toml`     | Has `[package] version`                            | Parse TOML                       | Update TOML (+ `Cargo.lock`)           |
-| `mix.exs`        | Has `version:` in project config                   | Regex extract                    | Regex replace                          |
-| Git tags only    | No version file, but `v*` tags exist               | `git describe --tags --abbrev=0` | `git tag vX.Y.Z`                       |
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
 
 For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
 
@@ -68,81 +68,76 @@ For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit c
 Detect by analyzing dependencies and configuration files:
 
 ### Python
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Django    | `django` in dependencies, `manage.py` exists  |
-| FastAPI   | `fastapi` in dependencies                     |
-| Flask     | `flask` in dependencies                       |
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
 | Starlette | `starlette` in dependencies (without FastAPI) |
 
 ### JavaScript/TypeScript
-
-| Framework      | Detection                                          |
-| -------------- | -------------------------------------------------- |
-| Next.js        | `next` in dependencies, `next.config.*` exists     |
-| Remix          | `@remix-run/node` in dependencies                  |
-| SvelteKit      | `@sveltejs/kit` in dependencies                    |
-| Nuxt           | `nuxt` in dependencies                             |
-| Express        | `express` in dependencies (without meta-framework) |
-| Astro          | `astro` in dependencies                            |
-| Vite (library) | `vite` in dependencies (without meta-framework)    |
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
 
 ### Ruby
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Rails     | `rails` in Gemfile, `config/routes.rb` exists |
-| Sinatra   | `sinatra` in Gemfile                          |
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
 
 ### Go
-
-| Framework        | Detection                              |
-| ---------------- | -------------------------------------- |
-| Gin              | `github.com/gin-gonic/gin` in `go.mod` |
-| Echo             | `github.com/labstack/echo` in `go.mod` |
-| Chi              | `github.com/go-chi/chi` in `go.mod`    |
-| Standard library | No framework dependency                |
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
 
 ### Rust
-
-| Framework | Detection                   |
-| --------- | --------------------------- |
+| Framework | Detection |
+|-----------|-----------|
 | Actix-web | `actix-web` in `Cargo.toml` |
-| Axum      | `axum` in `Cargo.toml`      |
-| Rocket    | `rocket` in `Cargo.toml`    |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
 
 ### Default Ports by Framework
 
-| Framework     | Default Port |
-| ------------- | ------------ |
-| Next.js       | 3000         |
-| Remix         | 3000         |
-| SvelteKit     | 5173         |
-| Nuxt          | 3000         |
-| Vite          | 5173         |
-| Express       | 3000         |
-| Django        | 8000         |
-| FastAPI       | 8000         |
-| Flask         | 5000         |
-| Rails         | 3000         |
-| Phoenix       | 4000         |
-| Go (common)   | 8080         |
-| Rust (common) | 8080         |
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
 
 ---
 
 ## Monorepo Detection
 
-| Signal                                    | Tool                 | Configuration                             |
-| ----------------------------------------- | -------------------- | ----------------------------------------- |
-| `pnpm-workspace.yaml`                     | pnpm workspaces      | `packages:` array lists workspace globs   |
-| `turbo.json`                              | Turborepo            | `pipeline:` defines task dependencies     |
-| `nx.json`                                 | Nx                   | `targetDefaults:` defines build graph     |
-| `lerna.json`                              | Lerna                | `packages:` array lists package locations |
-| `[workspace]` in `Cargo.toml`             | Cargo workspaces     | `members:` array lists crate paths        |
-| `go.work`                                 | Go workspaces        | `use` directives list module paths        |
-| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects     |
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
 
 For monorepos, scope operations to the relevant workspace/package when a path is specified.
 
@@ -150,40 +145,35 @@ For monorepos, scope operations to the relevant workspace/package when a path is
 
 ## CI/CD Detection
 
-| Path                      | System                         |
-| ------------------------- | ------------------------------ |
-| `.github/workflows/*.yml` | GitHub Actions                 |
-| `.gitlab-ci.yml`          | GitLab CI                      |
-| `Jenkinsfile`             | Jenkins                        |
-| `.circleci/config.yml`    | CircleCI                       |
-| `bitbucket-pipelines.yml` | Bitbucket Pipelines            |
-| `.travis.yml`             | Travis CI                      |
-| `azure-pipelines.yml`     | Azure DevOps                   |
-| `.buildkite/pipeline.yml` | Buildkite                      |
-| `Taskfile.yml`            | Task (not CI, but task runner) |
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
 
 ---
 
 ## Changelog Detection
 
-| File           | Format                         |
-| -------------- | ------------------------------ |
+| File | Format |
+|------|--------|
 | `CHANGELOG.md` | Keep a Changelog (most common) |
-| `CHANGES.md`   | Variant naming                 |
-| `HISTORY.md`   | Variant naming                 |
-| `NEWS.md`      | GNU-style                      |
-| None           | Skip changelog updates         |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
 
 Keep a Changelog format:
-
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
-
 ### Added
-
 ### Changed
-
 ### Fixed
-
 ### Removed
 ```

--- a/skills/ship-workflow/references/project-detection.md
+++ b/skills/ship-workflow/references/project-detection.md
@@ -8,17 +8,17 @@ Stack-agnostic project detection patterns for identifying test commands, package
 
 Detect the project's test command by checking these files in order:
 
-| Check | File                                | Condition                                  | Command                                                                          |
-| ----- | ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
-| 1     | `Makefile`                          | Has `test:` target                         | `make test`                                                                      |
-| 2     | `package.json`                      | Has `scripts.test`                         | `{pkg-manager} run test`                                                         |
-| 3     | `pyproject.toml`                    | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
-| 4     | `Cargo.toml`                        | Exists                                     | `cargo test`                                                                     |
-| 5     | `go.mod`                            | Exists                                     | `go test ./...`                                                                  |
-| 6     | `Gemfile` + `Rakefile`              | Has `test` task                            | `bundle exec rake test`                                                          |
-| 7     | `mix.exs`                           | Exists                                     | `mix test`                                                                       |
-| 8     | `build.gradle` / `build.gradle.kts` | Exists                                     | `./gradlew test`                                                                 |
-| 9     | `pom.xml`                           | Exists                                     | `mvn test`                                                                       |
+| Check | File | Condition | Command |
+|-------|------|-----------|---------|
+| 1 | `Makefile` | Has `test:` target | `make test` |
+| 2 | `package.json` | Has `scripts.test` | `{pkg-manager} run test` |
+| 3 | `pyproject.toml` | Has `[tool.pytest]` or `pytest` dependency | `uv run pytest` (if `uv.lock`), `poetry run pytest` (if `poetry.lock`), `pytest` |
+| 4 | `Cargo.toml` | Exists | `cargo test` |
+| 5 | `go.mod` | Exists | `go test ./...` |
+| 6 | `Gemfile` + `Rakefile` | Has `test` task | `bundle exec rake test` |
+| 7 | `mix.exs` | Exists | `mix test` |
+| 8 | `build.gradle` / `build.gradle.kts` | Exists | `./gradlew test` |
+| 9 | `pom.xml` | Exists | `mvn test` |
 
 If multiple match, prefer the first in order. If `Makefile` exists with a `test` target, it is always authoritative — projects use Makefiles to wrap their actual test commands.
 
@@ -28,19 +28,19 @@ If multiple match, prefer the first in order. If `Makefile` exists with a `test`
 
 Detect from lock files (most specific wins):
 
-| Lock File           | Package Manager | Run Command   |
-| ------------------- | --------------- | ------------- |
-| `pnpm-lock.yaml`    | pnpm            | `pnpm run`    |
-| `bun.lockb`         | bun             | `bun run`     |
-| `yarn.lock`         | yarn            | `yarn run`    |
-| `package-lock.json` | npm             | `npm run`     |
-| `uv.lock`           | uv              | `uv run`      |
-| `poetry.lock`       | poetry          | `poetry run`  |
-| `Pipfile.lock`      | pipenv          | `pipenv run`  |
-| `Cargo.lock`        | cargo           | `cargo`       |
-| `go.sum`            | go modules      | `go`          |
-| `Gemfile.lock`      | bundler         | `bundle exec` |
-| `mix.lock`          | mix             | `mix`         |
+| Lock File | Package Manager | Run Command |
+|-----------|----------------|-------------|
+| `pnpm-lock.yaml` | pnpm | `pnpm run` |
+| `bun.lockb` | bun | `bun run` |
+| `yarn.lock` | yarn | `yarn run` |
+| `package-lock.json` | npm | `npm run` |
+| `uv.lock` | uv | `uv run` |
+| `poetry.lock` | poetry | `poetry run` |
+| `Pipfile.lock` | pipenv | `pipenv run` |
+| `Cargo.lock` | cargo | `cargo` |
+| `go.sum` | go modules | `go` |
+| `Gemfile.lock` | bundler | `bundle exec` |
+| `mix.lock` | mix | `mix` |
 
 If no lock file: fall back to manifest file detection (`package.json` → npm, `pyproject.toml` → check for `[tool.poetry]` or default to uv).
 
@@ -50,14 +50,14 @@ If no lock file: fall back to manifest file detection (`package.json` → npm, `
 
 Check in order:
 
-| Strategy         | Detection                                          | Read                             | Write                                  |
-| ---------------- | -------------------------------------------------- | -------------------------------- | -------------------------------------- |
-| `VERSION` file   | File named `VERSION` at repo root                  | Read contents                    | Write new version                      |
-| `package.json`   | Has `version` field                                | `jq -r .version package.json`    | `jq '.version = "X.Y.Z"' package.json` |
-| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML                       | Update TOML                            |
-| `Cargo.toml`     | Has `[package] version`                            | Parse TOML                       | Update TOML (+ `Cargo.lock`)           |
-| `mix.exs`        | Has `version:` in project config                   | Regex extract                    | Regex replace                          |
-| Git tags only    | No version file, but `v*` tags exist               | `git describe --tags --abbrev=0` | `git tag vX.Y.Z`                       |
+| Strategy | Detection | Read | Write |
+|----------|-----------|------|-------|
+| `VERSION` file | File named `VERSION` at repo root | Read contents | Write new version |
+| `package.json` | Has `version` field | `jq -r .version package.json` | `jq '.version = "X.Y.Z"' package.json` |
+| `pyproject.toml` | Has `[project] version` or `[tool.poetry] version` | Parse TOML | Update TOML |
+| `Cargo.toml` | Has `[package] version` | Parse TOML | Update TOML (+ `Cargo.lock`) |
+| `mix.exs` | Has `version:` in project config | Regex extract | Regex replace |
+| Git tags only | No version file, but `v*` tags exist | `git describe --tags --abbrev=0` | `git tag vX.Y.Z` |
 
 For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit confirmation.
 
@@ -68,81 +68,76 @@ For PATCH bumps: increment automatically. For MINOR or MAJOR: require explicit c
 Detect by analyzing dependencies and configuration files:
 
 ### Python
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Django    | `django` in dependencies, `manage.py` exists  |
-| FastAPI   | `fastapi` in dependencies                     |
-| Flask     | `flask` in dependencies                       |
+| Framework | Detection |
+|-----------|-----------|
+| Django | `django` in dependencies, `manage.py` exists |
+| FastAPI | `fastapi` in dependencies |
+| Flask | `flask` in dependencies |
 | Starlette | `starlette` in dependencies (without FastAPI) |
 
 ### JavaScript/TypeScript
-
-| Framework      | Detection                                          |
-| -------------- | -------------------------------------------------- |
-| Next.js        | `next` in dependencies, `next.config.*` exists     |
-| Remix          | `@remix-run/node` in dependencies                  |
-| SvelteKit      | `@sveltejs/kit` in dependencies                    |
-| Nuxt           | `nuxt` in dependencies                             |
-| Express        | `express` in dependencies (without meta-framework) |
-| Astro          | `astro` in dependencies                            |
-| Vite (library) | `vite` in dependencies (without meta-framework)    |
+| Framework | Detection |
+|-----------|-----------|
+| Next.js | `next` in dependencies, `next.config.*` exists |
+| Remix | `@remix-run/node` in dependencies |
+| SvelteKit | `@sveltejs/kit` in dependencies |
+| Nuxt | `nuxt` in dependencies |
+| Express | `express` in dependencies (without meta-framework) |
+| Astro | `astro` in dependencies |
+| Vite (library) | `vite` in dependencies (without meta-framework) |
 
 ### Ruby
-
-| Framework | Detection                                     |
-| --------- | --------------------------------------------- |
-| Rails     | `rails` in Gemfile, `config/routes.rb` exists |
-| Sinatra   | `sinatra` in Gemfile                          |
+| Framework | Detection |
+|-----------|-----------|
+| Rails | `rails` in Gemfile, `config/routes.rb` exists |
+| Sinatra | `sinatra` in Gemfile |
 
 ### Go
-
-| Framework        | Detection                              |
-| ---------------- | -------------------------------------- |
-| Gin              | `github.com/gin-gonic/gin` in `go.mod` |
-| Echo             | `github.com/labstack/echo` in `go.mod` |
-| Chi              | `github.com/go-chi/chi` in `go.mod`    |
-| Standard library | No framework dependency                |
+| Framework | Detection |
+|-----------|-----------|
+| Gin | `github.com/gin-gonic/gin` in `go.mod` |
+| Echo | `github.com/labstack/echo` in `go.mod` |
+| Chi | `github.com/go-chi/chi` in `go.mod` |
+| Standard library | No framework dependency |
 
 ### Rust
-
-| Framework | Detection                   |
-| --------- | --------------------------- |
+| Framework | Detection |
+|-----------|-----------|
 | Actix-web | `actix-web` in `Cargo.toml` |
-| Axum      | `axum` in `Cargo.toml`      |
-| Rocket    | `rocket` in `Cargo.toml`    |
+| Axum | `axum` in `Cargo.toml` |
+| Rocket | `rocket` in `Cargo.toml` |
 
 ### Default Ports by Framework
 
-| Framework     | Default Port |
-| ------------- | ------------ |
-| Next.js       | 3000         |
-| Remix         | 3000         |
-| SvelteKit     | 5173         |
-| Nuxt          | 3000         |
-| Vite          | 5173         |
-| Express       | 3000         |
-| Django        | 8000         |
-| FastAPI       | 8000         |
-| Flask         | 5000         |
-| Rails         | 3000         |
-| Phoenix       | 4000         |
-| Go (common)   | 8080         |
-| Rust (common) | 8080         |
+| Framework | Default Port |
+|-----------|-------------|
+| Next.js | 3000 |
+| Remix | 3000 |
+| SvelteKit | 5173 |
+| Nuxt | 3000 |
+| Vite | 5173 |
+| Express | 3000 |
+| Django | 8000 |
+| FastAPI | 8000 |
+| Flask | 5000 |
+| Rails | 3000 |
+| Phoenix | 4000 |
+| Go (common) | 8080 |
+| Rust (common) | 8080 |
 
 ---
 
 ## Monorepo Detection
 
-| Signal                                    | Tool                 | Configuration                             |
-| ----------------------------------------- | -------------------- | ----------------------------------------- |
-| `pnpm-workspace.yaml`                     | pnpm workspaces      | `packages:` array lists workspace globs   |
-| `turbo.json`                              | Turborepo            | `pipeline:` defines task dependencies     |
-| `nx.json`                                 | Nx                   | `targetDefaults:` defines build graph     |
-| `lerna.json`                              | Lerna                | `packages:` array lists package locations |
-| `[workspace]` in `Cargo.toml`             | Cargo workspaces     | `members:` array lists crate paths        |
-| `go.work`                                 | Go workspaces        | `use` directives list module paths        |
-| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects     |
+| Signal | Tool | Configuration |
+|--------|------|---------------|
+| `pnpm-workspace.yaml` | pnpm workspaces | `packages:` array lists workspace globs |
+| `turbo.json` | Turborepo | `pipeline:` defines task dependencies |
+| `nx.json` | Nx | `targetDefaults:` defines build graph |
+| `lerna.json` | Lerna | `packages:` array lists package locations |
+| `[workspace]` in `Cargo.toml` | Cargo workspaces | `members:` array lists crate paths |
+| `go.work` | Go workspaces | `use` directives list module paths |
+| `settings.gradle` / `settings.gradle.kts` | Gradle multi-project | `include` statements list subprojects |
 
 For monorepos, scope operations to the relevant workspace/package when a path is specified.
 
@@ -150,40 +145,35 @@ For monorepos, scope operations to the relevant workspace/package when a path is
 
 ## CI/CD Detection
 
-| Path                      | System                         |
-| ------------------------- | ------------------------------ |
-| `.github/workflows/*.yml` | GitHub Actions                 |
-| `.gitlab-ci.yml`          | GitLab CI                      |
-| `Jenkinsfile`             | Jenkins                        |
-| `.circleci/config.yml`    | CircleCI                       |
-| `bitbucket-pipelines.yml` | Bitbucket Pipelines            |
-| `.travis.yml`             | Travis CI                      |
-| `azure-pipelines.yml`     | Azure DevOps                   |
-| `.buildkite/pipeline.yml` | Buildkite                      |
-| `Taskfile.yml`            | Task (not CI, but task runner) |
+| Path | System |
+|------|--------|
+| `.github/workflows/*.yml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `Jenkinsfile` | Jenkins |
+| `.circleci/config.yml` | CircleCI |
+| `bitbucket-pipelines.yml` | Bitbucket Pipelines |
+| `.travis.yml` | Travis CI |
+| `azure-pipelines.yml` | Azure DevOps |
+| `.buildkite/pipeline.yml` | Buildkite |
+| `Taskfile.yml` | Task (not CI, but task runner) |
 
 ---
 
 ## Changelog Detection
 
-| File           | Format                         |
-| -------------- | ------------------------------ |
+| File | Format |
+|------|--------|
 | `CHANGELOG.md` | Keep a Changelog (most common) |
-| `CHANGES.md`   | Variant naming                 |
-| `HISTORY.md`   | Variant naming                 |
-| `NEWS.md`      | GNU-style                      |
-| None           | Skip changelog updates         |
+| `CHANGES.md` | Variant naming |
+| `HISTORY.md` | Variant naming |
+| `NEWS.md` | GNU-style |
+| None | Skip changelog updates |
 
 Keep a Changelog format:
-
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
-
 ### Added
-
 ### Changed
-
 ### Fixed
-
 ### Removed
 ```


### PR DESCRIPTION
## Summary
  - add the handoff skill for maintaining .docs/handoff.md
  - add /handoff command, Stop hook, and session-continuity preset
  - register packages in manifest and README catalog
  - sync generated reference templates

  ## Validation
  - package-evaluator: handoff 96/100
  - uv run scripts/validate_frontmatter.py
  - uv run scripts/validate_evals.py
  - uv run pytest tests/ -v