### PR TITLE
Add project context workflow conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 125](https://img.shields.io/badge/packages-125-informational)](manifest.yaml)
+[![packages: 126](https://img.shields.io/badge/packages-126-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -63,6 +63,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [tavily](skills/tavily/)                         | AI-optimized web search and content extraction via Tavily API with structured output parsing                                                                |
 | [test-harness](skills/test-harness/)             | Comprehensive pytest suite generation — happy path, edge cases, error conditions, fixtures, mocks, async, parametrized tests                                |
 | [debug-investigator](skills/debug-investigator/) | Systematic debugging framework — hypothesis-driven investigation with bisection, log analysis, instrumentation, and minimal reproduction                    |
+| [project-context-setup](skills/project-context-setup/) | Scaffold repo-local agent context — issue tracker rules, triage labels, domain glossary layout, ADR lookup, agent brief conventions                  |
 | [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub                        |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |

--- a/agents/project-planner/AGENT.md
+++ b/agents/project-planner/AGENT.md
@@ -23,7 +23,7 @@ metadata:
   enabled: true
   orchestrates:
     skills:
-      [task-decomposer, estimate-calibrator, plan-review, engineering-retro]
+      [project-context-setup, task-decomposer, estimate-calibrator, plan-review, engineering-retro]
     agents: []
   tags: [planning, decomposition, estimation, sonnet]
   difficulty: intermediate
@@ -77,6 +77,12 @@ If an architecture document is provided, extract scope from it. If only a descri
 | plan-review         | skill | Phase 6       | Stress-test the plan for gaps, unrealistic estimates, missing dependencies   |
 | engineering-retro   | skill | Post-delivery | Retrospective comparing actual vs estimated for calibration feedback         |
 
+If `docs/agents/domain.md` exists, read it before Phase 1 and use the repo's domain
+glossary and ADR lookup rules. If `docs/agents/triage-labels.md` exists, use its readiness
+labels when marking tasks as AFK or HITL. If these files are missing, continue with inferred
+project context and recommend `project-context-setup` when persistent agent workflow would
+materially improve follow-on work.
+
 ---
 
 ## Workflow Phases
@@ -101,7 +107,9 @@ Requirements for the decomposition:
 - Each task has a clear definition of done
 - Dependencies between tasks are explicit (task B requires task A)
 - Parallelization flags indicate which tasks can run concurrently
-- Tasks are grouped into logical phases (setup, core implementation, integration, testing, polish)
+- User-facing work is grouped into tracer-bullet vertical slices where each slice is demoable or independently verifiable
+- Tasks are marked **AFK** when a fresh agent can execute them from the plan and **HITL** when human judgment, credentials, design approval, or release authority is required
+- AFK tasks include agent-brief notes: desired behavior, key interfaces, acceptance criteria, and out-of-scope boundaries
 
 ### Phase 3: Estimation
 
@@ -159,6 +167,7 @@ Revise the plan based on review findings before delivering.
 | Task Breakdown Table | Markdown table | All tasks with estimates, dependencies, parallelization flags |
 | Milestone Timeline   | Markdown list  | Ordered milestones with durations or target dates             |
 | Risk Log             | Markdown table | Risks with probability, impact, and mitigation                |
+| Agent Brief Notes    | Markdown list  | AFK-ready behavior contracts and scope boundaries             |
 
 ---
 
@@ -176,7 +185,7 @@ When spawned by another agent (e.g., `project-architect` or `team-lead`):
 
 - Returns structured markdown plan with clear sections
 - Includes machine-parseable summary line: `**Estimate:** X-Y hours across Z milestones, W tasks`
-- Passes task breakdown to `full-stack-builder` or implementation agents
+- Passes vertical slices and agent brief notes to `full-stack-builder` or implementation agents
 - Includes risk log for ongoing tracking
 
 ---
@@ -204,10 +213,10 @@ When spawned by another agent (e.g., `project-architect` or `team-lead`):
 
 ## Task Breakdown
 
-| ID  | Task | Phase | Depends On | Parallel | Optimistic | Expected | Pessimistic | Weighted |
-| --- | ---- | ----- | ---------- | -------- | ---------- | -------- | ----------- | -------- |
-| T1  | ...  | Setup | —          | Yes      | 1h         | 2h       | 4h          | 2.2h     |
-| T2  | ...  | Core  | T1         | No       | 2h         | 3h       | 6h          | 3.3h     |
+| ID  | Slice / Task | Type | Phase | Depends On | Parallel | Optimistic | Expected | Pessimistic | Weighted |
+| --- | ------------ | ---- | ----- | ---------- | -------- | ---------- | -------- | ----------- | -------- |
+| T1  | ...          | AFK  | Setup | —          | Yes      | 1h         | 2h       | 4h          | 2.2h     |
+| T2  | ...          | HITL | Slice | T1         | No       | 2h         | 3h       | 6h          | 3.3h     |
 
 ...
 
@@ -222,6 +231,11 @@ When spawned by another agent (e.g., `project-architect` or `team-lead`):
 ## Critical Path
 
 T1 → T3 → T5 → T8 (total: Xh expected)
+
+## Agent Brief Notes
+
+- T1: desired behavior, key interfaces, acceptance criteria, out-of-scope boundaries
+- T2: human decision or access required before this can become AFK
 
 ## Buffer
 
@@ -242,3 +256,5 @@ T1 → T3 → T5 → T8 (total: Xh expected)
 8. Identify the critical path and highlight it in the plan
 9. Mark parallelizable tasks explicitly so team leads can distribute work
 10. Confirm scope with the user before proceeding past Phase 1
+11. Prefer vertical slices over horizontal layer queues for user-facing features
+12. Do not mark work AFK unless the plan contains enough brief detail for a fresh agent

--- a/commands/route/COMMAND.md
+++ b/commands/route/COMMAND.md
@@ -46,6 +46,7 @@ When the user invokes `/route [task]`, match their task to the best armory packa
 | Competitive analysis | `competitive-analyzer` skill | `market-analyzer` |
 | Feasibility assessment | `feasibility-assessor` skill | `estimate-calibrator` |
 | Full business validation pipeline | `idea-scout` agent | (orchestrates all four above) |
+| Set up repo-local agent context | `project-context-setup` skill | `adr-writer`, `github` |
 
 ## Plan Phase — "I need to plan the work"
 
@@ -53,6 +54,7 @@ When the user invokes `/route [task]`, match their task to the best armory packa
 |------|----------------|-------------|
 | Break down a project into tasks | `task-decomposer` skill | `estimate-calibrator` |
 | Estimate effort/timeline | `estimate-calibrator` skill | `task-decomposer` |
+| Configure issue tracker, triage labels, glossary, and ADR lookup | `project-context-setup` skill | `task-decomposer`, `project-planner` |
 | Design system architecture | `project-architect` agent | `architecture-diagram` skill |
 | Record architecture decisions | `adr-writer` skill | `architecture-reviewer` skill |
 | Plan a full project | `project-planner` agent | `task-decomposer`, `estimate-calibrator` |

--- a/commands/tdd/COMMAND.md
+++ b/commands/tdd/COMMAND.md
@@ -29,29 +29,43 @@ When the user invokes `/tdd [target]`, execute this workflow exactly.
 
 1. Identify the target function, class, or module from the argument.
 2. If the argument is ambiguous, search the codebase for matching symbols.
-3. If the target does not exist yet, ask the user for:
+3. Check repo-local agent context before naming tests or interfaces:
+   - `docs/agents/domain.md` for domain doc layout
+   - `CONTEXT.md` or the relevant context-local glossary for project vocabulary
+   - ADRs in the touched area for decisions the tests must respect
+4. If the target does not exist yet, ask the user for:
    - Input types and expected output types.
    - One concrete example of expected behavior.
    - Any known constraints or invariants.
-4. If the target exists, read its signature, docstring, and callers to infer requirements.
-5. State the requirements back in a numbered list. Do not proceed until the user confirms.
+5. If the target exists, read its signature, docstring, and callers to infer requirements.
+6. State the requirements back in a numbered list. Do not proceed until the user confirms.
 
-## Step 2: Write Failing Tests (RED)
+## Step 2: Pick One Vertical Slice
+
+Choose one behavior that cuts through the real public interface. Do not write every planned
+test first. Each cycle is one tracer bullet:
+
+```text
+RED: one behavior test -> GREEN: minimal implementation -> repeat
+```
+
+Prefer behavior that proves the path end-to-end before edge cases. Test names should use the
+project's domain terms when a glossary exists.
+
+## Step 3: Write One Failing Test (RED)
 
 1. Create the test file if it does not exist. Follow project conventions:
    - Python: `tests/test_{module}.py` or `tests/{module}/test_{name}.py`.
    - TypeScript/JavaScript: `{name}.test.ts` or `__tests__/{name}.test.ts`.
-2. Write test functions covering:
-   - **Happy path**: the primary expected behavior (1-2 tests).
-   - **Edge cases**: empty input, boundary values, type boundaries (2-3 tests).
-   - **Error conditions**: invalid input, missing dependencies, overflow (1-2 tests).
+2. Write exactly one test for the current behavior slice.
 3. Test naming convention: `test_{behavior}_when_{condition}_returns_{outcome}` (Python) or
    `it('should {behavior} when {condition}')` (JS/TS).
-4. Each assertion tests one behavior. No multi-assertion tests unless testing a composite result.
-5. Run the tests. Confirm they fail. If any test passes before implementation, it is testing
+4. Test public behavior, not private implementation. Do not mock internal collaborators.
+5. Each assertion tests one behavior. No multi-assertion tests unless testing a composite result.
+6. Run the test. Confirm it fails. If it passes before implementation, it is testing
    the wrong thing — delete and rewrite.
 
-## Step 3: Implement Minimal Code (GREEN)
+## Step 4: Implement Minimal Code (GREEN)
 
 1. Write the minimum code to make all failing tests pass.
 2. Do not add functionality beyond what the tests require.
@@ -59,7 +73,7 @@ When the user invokes `/tdd [target]`, execute this workflow exactly.
 4. Run all tests. Every test must pass.
 5. If a test fails, fix the implementation — not the test — unless the test has a specification error.
 
-## Step 4: Refactor
+## Step 5: Refactor
 
 1. With all tests green, refactor the implementation:
    - Extract repeated logic into helpers.
@@ -69,10 +83,10 @@ When the user invokes `/tdd [target]`, execute this workflow exactly.
 2. After each refactoring step, re-run all tests. If any test breaks, revert the refactoring step.
 3. Do not change test assertions during refactoring. Tests are the specification.
 
-## Step 5: Next Cycle Decision
+## Step 6: Next Cycle Decision
 
 1. Review the requirements list from Step 1.
-2. If uncovered requirements remain, return to Step 2 with the next requirement.
+2. If uncovered requirements remain, return to Step 2 with the next behavior slice.
 3. If all requirements are covered, assess:
    - Are there integration points not yet tested?
    - Are there concurrency or timing edge cases?
@@ -109,6 +123,7 @@ Stop the TDD cycle when:
 ## Rules
 
 - Never write implementation before a failing test exists for that behavior.
+- Never batch all tests up front. Use vertical red-green-refactor slices.
 - Never modify a test to make it pass — modify the implementation.
 - Tests must be deterministic. No randomness, no network calls, no filesystem side effects
   without explicit fixtures or mocks.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -846,6 +846,23 @@ packages:
     category: review
     difficulty: intermediate
     phase: review
+  - name: project-context-setup
+    version: 1.0.0
+    description: 'Scaffolds per-repository agent context so coding agents share the same issue tracker rules, triage label
+      vocabulary, domain glossary, ADR layout, and handoff conventions. Triggers on: "set up project context", "configure
+      agent docs", "create CONTEXT.md", "setup agent workflow", "agent issue tracker setup", "triage labels", "domain glossary
+      for agents". Use when a repo needs durable context files before planning, triage, debugging, TDD, architecture review,
+      or multi-agent implementation.'
+    path: skills/project-context-setup
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/project-context-setup/SKILL.md
+    tags:
+    - agent-context
+    - project-setup
+    - domain-glossary
+    - triage
+    category: development
+    difficulty: intermediate
+    phase: define
   - name: prompt-lab
     version: 1.1.1
     description: 'LLM prompt engineering: analyzes failure modes, generates variants (direct, few-shot, CoT), designs rubrics,

--- a/skills/architecture-reviewer/SKILL.md
+++ b/skills/architecture-reviewer/SKILL.md
@@ -59,6 +59,18 @@ FORMULA:  Overall% = (Σ dimension_score × weight) / 5 × 100
 
 ## Phase 1: Input Classification & Context Gathering
 
+### Step 0: Project Context Scan
+
+Before classifying the input, check for repo-local agent context when reviewing a codebase:
+
+- `docs/agents/domain.md` for `CONTEXT.md`, `CONTEXT-MAP.md`, and ADR lookup rules
+- root or context-local `CONTEXT.md` files for domain vocabulary
+- `docs/adr/` and context-local ADR directories for accepted architecture decisions
+
+Use glossary terms in findings and recommendations. Treat ADRs as constraints unless the
+observed friction is severe enough to justify reopening the decision. If context files are
+absent, continue with inferred vocabulary.
+
 ### Step 1: Classify Input Mode
 
 Determine the review mode from what the user provides:
@@ -160,6 +172,10 @@ Evaluate the architecture across 7 weighted dimensions. For each dimension:
 
 **Progressive loading:** Read each reference file only when analyzing that dimension. Do not
 load all references at once.
+
+When analyzing Structural Integrity, also consult `references/deep-module-analysis.md` if
+the review involves module boundaries, testability, service decomposition, or refactoring
+recommendations.
 
 **Mode-specific guidance:**
 

--- a/skills/architecture-reviewer/references/deep-module-analysis.md
+++ b/skills/architecture-reviewer/references/deep-module-analysis.md
@@ -1,0 +1,55 @@
+# Deep Module Analysis
+
+Use this reference during Structural Integrity review when assessing module boundaries,
+testability, and AI navigability.
+
+## Vocabulary
+
+| Term | Meaning |
+| ---- | ------- |
+| Module | Anything with an interface and implementation: function, class, package, service, workflow |
+| Interface | Everything callers must know: types, invariants, errors, ordering, config, side effects |
+| Implementation | Code hidden behind the interface |
+| Deep module | Small interface hiding substantial behavior |
+| Shallow module | Interface nearly as complex as its implementation |
+| Seam | A place where behavior can change without editing callers |
+| Adapter | Concrete implementation behind a seam |
+| Locality | Bugs, changes, and knowledge concentrated in one module |
+| Leverage | Amount of useful behavior gained through a small interface |
+
+## Signals Of Shallow Modules
+
+- Pass-through wrappers that rename or forward calls without hiding complexity.
+- Callers that must know internal ordering, retries, lifecycle, or data-shaping rules.
+- Many small helper functions extracted only for tests while real bugs live in call choreography.
+- Interfaces that expose implementation details such as storage layout, HTTP mechanics, cache keys, or framework internals.
+- One adapter behind an abstract seam with no realistic second implementation.
+
+## Deletion Test
+
+For a suspected shallow module, ask:
+
+- If deleted, does complexity disappear or simply move into callers?
+- Would callers become simpler, unchanged, or more complex?
+- Does the module concentrate policy or merely distribute it?
+
+If deleting the module makes the system easier to understand without duplicating real policy, the module is not earning its interface.
+
+## Finding Shape
+
+Use this shape for actionable recommendations:
+
+```markdown
+**Finding:** `<module>` is shallow: callers must understand `<leaked concept>` to use it safely.
+
+**Impact:** Low locality. Changes to `<behavior>` require edits across `<callers>`, and tests must mock implementation choreography instead of stable behavior.
+
+**Recommendation:** Deepen `<module>` around `<domain concept>`. Move `<policy>` behind the interface, expose `<small contract>`, and test behavior through that interface.
+```
+
+## Guardrails
+
+- Do not recommend abstractions only because code is duplicated.
+- Do not introduce a seam unless there is a real second adapter, a testing need at a stable boundary, or a volatile external dependency.
+- Prefer domain-named modules from `CONTEXT.md` when project context exists.
+- Respect ADRs. If a deepening recommendation contradicts an ADR, call out the conflict and justify reopening the decision.

--- a/skills/debug-investigator/SKILL.md
+++ b/skills/debug-investigator/SKILL.md
@@ -12,9 +12,10 @@ metadata:
 # Debug Investigator
 
 Structured debugging methodology that replaces ad-hoc exploration with hypothesis-driven
-investigation. Captures symptoms, analyzes evidence (stacktraces, logs, state), generates
-ranked hypotheses, designs bisection strategies, identifies instrumentation points, and
-produces minimal reproductions — documenting every step so dead ends are never revisited.
+investigation. Captures symptoms, builds a deterministic feedback loop, analyzes evidence
+(stacktraces, logs, state), generates ranked hypotheses, designs bisection strategies,
+identifies instrumentation points, and produces minimal reproductions — documenting every
+step so dead ends are never revisited.
 
 > **When to use this skill vs native debugging:** The base model handles straightforward
 > debugging (clear stacktraces, obvious errors) natively. Use this skill for non-obvious bugs
@@ -37,6 +38,17 @@ produces minimal reproductions — documenting every step so dead ends are never
 - **Access to source code** — cannot debug opaque binaries
 - **Reproducible environment** — or at minimum, error output (stacktrace, logs)
 
+## Project Context
+
+Before deep investigation, check for repo-local agent context:
+
+- `docs/agents/domain.md` for `CONTEXT.md`, `CONTEXT-MAP.md`, and ADR lookup rules
+- `CONTEXT.md` or relevant context-local glossary for domain vocabulary
+- `docs/adr/` and context-local ADRs for decisions near the failing area
+
+Use the project glossary in hypotheses, repro names, and prevention recommendations. If the
+repo lacks these files, continue normally; do not block debugging on context setup.
+
 ## Workflow
 
 ### Phase 1: Symptom Capture
@@ -54,7 +66,35 @@ Before touching code, document the observable problem:
 5. **Environment** — Python version, OS, dependency versions, configuration differences
    between working and broken environments.
 
-### Phase 2: Evidence Analysis
+### Phase 2: Build a Feedback Loop
+
+Create a fast, deterministic pass/fail signal for the reported bug before ranking hypotheses
+or changing production code. The loop must reproduce the user's symptom, not a nearby failure.
+
+Try these seams in order:
+
+1. Failing test at the smallest public interface that reaches the bug.
+2. CLI or script invocation with fixture input and asserted output.
+3. Curl or HTTP request against a local server with asserted response, logs, or state.
+4. Browser automation for UI bugs with DOM, console, and network assertions.
+5. Replayed trace, event payload, HAR, or log fixture through the real code path.
+6. Throwaway harness that boots the minimal subsystem needed to trigger the path.
+7. Property, fuzz, or stress loop for intermittent failures.
+8. `git bisect run` harness when the bug appeared between known good and bad revisions.
+
+Improve the loop before moving on:
+
+- Make it faster by narrowing setup and caching expensive fixtures.
+- Make it sharper by asserting the exact symptom.
+- Make it more deterministic by pinning time, seeds, filesystem paths, and network access.
+- For intermittent bugs, raise reproduction rate with repeated runs, concurrency, stress, or
+  timing probes until the failure is frequent enough to debug.
+
+If no credible loop can be built, stop and state what was tried. Request the missing artifact:
+environment access, captured payloads, logs, screen recording with timestamps, or permission
+for temporary instrumentation. Do not proceed to speculative fixes.
+
+### Phase 3: Evidence Analysis
 
 Examine all available evidence before forming hypotheses:
 
@@ -81,7 +121,7 @@ Examine all available evidence before forming hypotheses:
    - Focus on files touched by the error's call chain
    - Look for typos, wrong variable names, missing null checks
 
-### Phase 3: Hypothesis Generation
+### Phase 4: Hypothesis Generation
 
 Generate ranked hypotheses — never start fixing without a hypothesis:
 
@@ -103,7 +143,7 @@ Generate ranked hypotheses — never start fixing without a hypothesis:
    - Concurrency bugs: race condition, deadlock, resource starvation
    - Environment bugs: missing dependency, wrong config, version mismatch
 
-### Phase 4: Investigation Plan
+### Phase 5: Investigation Plan
 
 Design specific steps to test each hypothesis:
 
@@ -125,7 +165,7 @@ Design specific steps to test each hypothesis:
    - At decision points (if/else branches)
    - See `references/instrumentation-points.md`
 
-### Phase 5: Execution
+### Phase 6: Execution
 
 Execute the investigation plan, updating hypotheses as evidence arrives:
 
@@ -138,7 +178,7 @@ Execute the investigation plan, updating hypotheses as evidence arrives:
 4. **Know when to escalate** — If all hypotheses are exhausted, the bug is in a
    category you haven't considered. Step back and re-examine assumptions.
 
-### Phase 6: Resolution Documentation
+### Phase 7: Resolution Documentation
 
 After finding the root cause:
 
@@ -238,8 +278,8 @@ After finding the root cause:
    Record what was tested and what was learned.
 4. **Simplest explanation first.** Test typos, wrong variable names, and missing imports
    before considering race conditions, compiler bugs, or cosmic rays.
-5. **Reproduce before fixing.** If you cannot reproduce the bug in a controlled environment,
-   any fix is speculative. Invest in reproduction first.
+5. **Feedback loop before hypotheses.** If you cannot reproduce the bug with a controlled
+   pass/fail signal, any fix is speculative. Invest in the loop first.
 6. **Root cause, not symptoms.** A fix that addresses the symptom (adding a null check)
    without understanding the root cause (why was it null?) leaves the real bug alive.
 

--- a/skills/project-context-setup/SKILL.md
+++ b/skills/project-context-setup/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: project-context-setup
+description: 'Scaffolds per-repository agent context so coding agents share the same issue tracker rules, triage label vocabulary, domain glossary, ADR layout, and handoff conventions. Triggers on: "set up project context", "configure agent docs", "create CONTEXT.md", "setup agent workflow", "agent issue tracker setup", "triage labels", "domain glossary for agents". Use when a repo needs durable context files before planning, triage, debugging, TDD, architecture review, or multi-agent implementation.'
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [agent-context, project-setup, domain-glossary, triage]
+  difficulty: intermediate
+  phase: define
+---
+
+# Project Context Setup
+
+Scaffold the repo-local context files that make agent workflows consistent across sessions:
+issue tracker rules, triage labels, domain glossary layout, ADR layout, agent brief format,
+and out-of-scope memory.
+
+## When To Use
+
+| Use this skill | Use another package |
+| -------------- | ------------------- |
+| A repo lacks `docs/agents/` context files | `adr-writer` for one architecture decision |
+| Agents need consistent domain vocabulary | `task-decomposer` for an already-scoped feature |
+| Triage or issue publishing needs label conventions | `github` for direct GitHub CLI operations |
+| Multi-agent work needs durable issue briefs | `handoff` for session-local continuation notes |
+
+## Reference Files
+
+| File | Contents | Load When |
+| ---- | -------- | --------- |
+| `references/context-format.md` | `CONTEXT.md` and `CONTEXT-MAP.md` glossary format | Creating or editing domain docs |
+| `references/agent-brief.md` | Durable `ready-for-agent` issue brief contract | Preparing issue handoff |
+| `references/out-of-scope.md` | Persistent memory for rejected enhancements | Triage includes `wontfix` decisions |
+
+## Core Workflow
+
+### 1. Explore
+
+Inspect the actual repo state before writing:
+
+- `git remote -v` and `.git/config` for issue tracker hints
+- root `AGENTS.md` and `CLAUDE.md`
+- root `CONTEXT.md` and `CONTEXT-MAP.md`
+- `docs/adr/` and context-scoped ADR directories
+- existing `docs/agents/`
+- existing `.out-of-scope/`
+
+Report what exists and what is missing. Do not overwrite existing files blindly.
+
+### 2. Choose Setup Values
+
+Resolve these values with the user or from clear repo evidence:
+
+| Decision | Default | Output |
+| -------- | ------- | ------ |
+| Issue tracker | GitHub if a GitHub remote exists, otherwise local markdown | `docs/agents/issue-tracker.md` |
+| Triage labels | Canonical labels equal role names | `docs/agents/triage-labels.md` |
+| Domain docs | Single root context | `docs/agents/domain.md` |
+| Agent instructions file | Existing `AGENTS.md`, else existing `CLAUDE.md` | Updated `## Agent context` block |
+
+If both `AGENTS.md` and `CLAUDE.md` exist, update `AGENTS.md` for cross-agent portability.
+If neither exists, ask before creating one.
+
+### 3. Write Context Files
+
+Create or update these files:
+
+```text
+docs/agents/
+├── issue-tracker.md
+├── triage-labels.md
+└── domain.md
+```
+
+Use these conventions:
+
+- Keep issue tracker instructions operational: exact CLI, label mutation policy, and whether agents may comment or close issues.
+- Map canonical triage roles to real labels. Do not create duplicate labels when the repo already has equivalents.
+- Document whether the repo uses a single root `CONTEXT.md` or `CONTEXT-MAP.md` with per-context glossaries.
+- Record ADR lookup rules. Use `docs/adr/` for global decisions and context-local `docs/adr/` directories where present.
+
+### 4. Add Agent Context Block
+
+Add or update this block in the chosen instructions file:
+
+```markdown
+## Agent context
+
+### Issue tracker
+
+See `docs/agents/issue-tracker.md` for where issues live and which operations agents may perform.
+
+### Triage labels
+
+See `docs/agents/triage-labels.md` for canonical triage roles and their concrete label strings.
+
+### Domain docs
+
+See `docs/agents/domain.md` for `CONTEXT.md`, `CONTEXT-MAP.md`, and ADR lookup rules.
+```
+
+Update the existing block in place if it already exists. Do not append duplicates.
+
+### 5. Optional Domain Glossary
+
+Create `CONTEXT.md` only when the user has resolved at least one domain term. Use
+`references/context-format.md`. Do not fill it with generic programming concepts.
+
+Create `CONTEXT-MAP.md` only for multi-context repos where separate glossaries are needed.
+
+## Verification
+
+- `docs/agents/issue-tracker.md` exists and states the tracker, allowed operations, and required tools.
+- `docs/agents/triage-labels.md` maps `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`.
+- `docs/agents/domain.md` states single-context or multi-context layout and ADR lookup rules.
+- The chosen instructions file contains exactly one `## Agent context` block.
+- Existing user-authored content outside that block is preserved.

--- a/skills/project-context-setup/evals/cases.yaml
+++ b/skills/project-context-setup/evals/cases.yaml
@@ -1,0 +1,52 @@
+cases:
+  - id: setup_agent_context_docs
+    prompt: "Set up project context docs for this repo so agents know the issue tracker, triage labels, and domain glossary layout."
+    fixtures: []
+    rubric:
+      - "activates project-context-setup"
+      - "creates or updates docs/agents issue tracker, triage labels, and domain docs"
+      - "preserves existing AGENTS.md or CLAUDE.md content while adding an agent context block"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "docs/agents/(issue-tracker|triage-labels|domain)\\.md"
+        weight: 1.0
+      - type: matches_regex
+        target: "(CONTEXT\\.md|CONTEXT-MAP\\.md|domain glossary)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(needs-triage|ready-for-agent|ready-for-human)"
+        weight: 0.8
+
+  - id: create_domain_glossary
+    prompt: "Create a CONTEXT.md convention for our agents and document how ADRs should be discovered."
+    fixtures: []
+    rubric:
+      - "activates project-context-setup"
+      - "uses domain glossary conventions instead of implementation documentation"
+      - "documents ADR lookup rules"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "CONTEXT\\.md"
+        weight: 1.0
+      - type: matches_regex
+        target: "(docs/adr|ADR)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(Language|Relationships|Flagged Ambiguities)"
+        weight: 0.8
+
+  - id: negative_single_adr
+    prompt: "Write an ADR for choosing Postgres over MongoDB."
+    fixtures: []
+    rubric:
+      - "single decision record is adr-writer territory, not project context setup"
+    trigger_expected: false
+
+  - id: negative_direct_github_issue
+    prompt: "Create a GitHub issue for this bug using gh."
+    fixtures: []
+    rubric:
+      - "direct GitHub issue creation is github skill territory, not project context setup"
+    trigger_expected: false

--- a/skills/project-context-setup/references/agent-brief.md
+++ b/skills/project-context-setup/references/agent-brief.md
@@ -1,0 +1,52 @@
+# Agent Brief Contract
+
+An agent brief is the durable handoff placed on an issue when it becomes `ready-for-agent`.
+It is the implementation contract for an AFK agent.
+
+## Principles
+
+- Describe behavior, not procedural file edits.
+- Prefer stable interfaces, types, config shapes, CLI commands, and acceptance criteria.
+- Avoid line numbers and fragile file paths unless the file identity itself is the contract.
+- State out-of-scope work explicitly.
+- Make each acceptance criterion independently verifiable.
+
+## Template
+
+```markdown
+## Agent Brief
+
+**Category:** bug | enhancement
+**Summary:** one-line description
+
+**Current behavior:**
+What happens now. For bugs, describe the broken behavior. For enhancements, describe the status quo.
+
+**Desired behavior:**
+What must be true after implementation, including edge cases and error behavior.
+
+**Key interfaces:**
+- `TypeName` - expected contract change
+- `command` or endpoint - expected input/output behavior
+- Config shape - any new required or optional setting
+
+**Acceptance criteria:**
+- [ ] Specific, testable criterion
+- [ ] Specific, testable criterion
+- [ ] Validation command or manual verification path is documented
+
+**Out of scope:**
+- Adjacent capability that must not be changed
+- Follow-up work that belongs in a separate issue
+```
+
+## Readiness Rules
+
+Move an issue to `ready-for-agent` only when:
+
+- The desired behavior is clear enough for a new agent to implement without private context.
+- Required decisions have been made or explicitly scoped out.
+- The acceptance criteria can be checked by tests, commands, or a concrete manual procedure.
+- External access requirements are listed.
+
+Use `ready-for-human` when product judgment, credentials, stakeholder negotiation, or manual release authority is still required.

--- a/skills/project-context-setup/references/context-format.md
+++ b/skills/project-context-setup/references/context-format.md
@@ -1,0 +1,65 @@
+# Domain Context Format
+
+Use domain context files to define project-specific language for agents. The goal is shared
+vocabulary, not implementation documentation.
+
+## Single-Context Repo
+
+Use one root `CONTEXT.md`:
+
+```markdown
+# Project Context
+
+One or two sentences describing the business or product context.
+
+## Language
+
+**Order**:
+A customer request to buy one or more products.
+_Avoid_: purchase, transaction
+
+**Customer**:
+The person or organization that owns an order.
+_Avoid_: user, account
+
+## Relationships
+
+- A **Customer** can have many **Orders**
+- An **Order** belongs to exactly one **Customer**
+
+## Example Dialogue
+
+> **Dev:** "Can an **Order** exist without a **Customer**?"
+> **Domain expert:** "No. Guest checkout still creates a lightweight **Customer**."
+
+## Flagged Ambiguities
+
+- "account" was used for both **Customer** and auth **User**. Use **Customer** for commerce ownership and **User** for login identity.
+```
+
+## Multi-Context Repo
+
+Use a root `CONTEXT-MAP.md` that points to context-local glossaries:
+
+```markdown
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) - receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) - invoices and payment collection
+
+## Relationships
+
+- **Ordering -> Billing**: Ordering emits `OrderPlaced`; Billing consumes it to create invoices
+```
+
+## Rules
+
+- Include only project-specific domain terms.
+- Keep definitions to one sentence.
+- Prefer the canonical term and list ambiguous synonyms under `_Avoid_`.
+- Record relationships with cardinality where it clarifies behavior.
+- Add flagged ambiguities when a term has been overloaded or corrected.
+- Do not define generic engineering terms such as timeout, route, service, enum, or cache.
+- Update context files when planning, debugging, TDD, or architecture work resolves new terminology.

--- a/skills/project-context-setup/references/out-of-scope.md
+++ b/skills/project-context-setup/references/out-of-scope.md
@@ -1,0 +1,42 @@
+# Out-of-Scope Memory
+
+Use `.out-of-scope/` to preserve durable records of rejected enhancements. This prevents
+agents from re-litigating the same feature request in future triage sessions.
+
+## Directory Shape
+
+```text
+.out-of-scope/
+├── dark-mode.md
+├── graphql-api.md
+└── plugin-system.md
+```
+
+Use one file per rejected concept, not one file per issue.
+
+## File Format
+
+```markdown
+# Dark Mode
+
+This project does not support runtime theming.
+
+## Why this is out of scope
+
+Supporting runtime themes would require replacing the current static theme contract,
+threading theme state through every rendered surface, and adding persistence for user
+preferences. The project treats theming as a downstream embedding concern.
+
+## Prior requests
+
+- #42 - Add dark mode
+- #87 - Night theme for accessibility
+```
+
+## Triage Rules
+
+- Read `.out-of-scope/*.md` before rejecting or accepting similar enhancement requests.
+- Match by concept, not exact wording.
+- If the maintainer confirms the rejection still applies, append the new issue to the prior requests list.
+- If the maintainer reopens the decision, update or delete the out-of-scope file and continue normal triage.
+- Do not use `.out-of-scope/` for bugs. Bugs are fixed, marked unreproducible with evidence, or closed by policy.

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -12,9 +12,9 @@ metadata:
 # Task Decomposer
 
 Transforms ambiguous feature requests into concrete, implementable task sequences:
-identifies acceptance criteria, decomposes into phased work items with effort sizing,
-maps dependencies and parallelization, enumerates edge cases, plans testing, and flags
-risks — producing a ready-to-execute task board.
+identifies acceptance criteria, decomposes into tracer-bullet vertical slices with effort
+sizing, maps dependencies and parallelization, enumerates edge cases, plans testing, labels
+HITL/AFK readiness, and flags risks — producing a ready-to-execute task board.
 
 > **When to use this skill vs native decomposition:** The base model decomposes features
 > well in an ad-hoc format. Use this skill specifically when you need the structured output:
@@ -36,6 +36,17 @@ risks — producing a ready-to-execute task board.
 - Feature description or requirements (can be vague — the skill handles ambiguity)
 - Project context (tech stack, existing architecture, team size)
 
+## Project Context
+
+Before decomposing, check for repo-local agent context:
+
+- `docs/agents/domain.md` for `CONTEXT.md`, `CONTEXT-MAP.md`, and ADR lookup rules
+- `docs/agents/triage-labels.md` for readiness labels when tasks become issues
+- `CONTEXT.md` or relevant context-local glossary for task titles and acceptance criteria
+- `.out-of-scope/` for durable rejections that may affect scope
+
+Continue if these files are absent, but state that the plan is using inferred vocabulary.
+
 ## Workflow
 
 ### Phase 1: Understand the Feature
@@ -49,27 +60,36 @@ risks — producing a ready-to-execute task board.
 4. **Clarify scope boundaries** — What is explicitly out of scope? State this to
    prevent scope creep during implementation.
 
-### Phase 2: Decompose into Tasks
+### Phase 2: Decompose into Vertical Slices
 
-Break the feature into tasks at the right granularity:
+Break the feature into tracer-bullet slices first, then split oversized slices into tasks.
+Each slice should deliver a narrow but complete path through the affected layers. Avoid
+horizontal breakdowns where one issue only creates schema, another only creates API, and
+another only creates UI unless the work is pure infrastructure.
 
 | Granularity | Size                                           | Example                      |
 | ----------- | ---------------------------------------------- | ---------------------------- |
 | Too coarse  | "Build the search feature"                     | Not actionable               |
-| Right level | "Add full-text search index to products table" | Single PR, testable          |
+| Right level | "Exact-match product search returns results end-to-end" | Single PR, testable |
 | Too fine    | "Import the search library"                    | Not independently meaningful |
 
 **Right granularity test:** Each task should be completable in a single PR, testable
-in isolation, and deliverable independently (even if not user-visible alone).
+in isolation, and deliverable independently. A completed vertical slice should be demoable
+or verifiable without waiting for unrelated slices.
 
 Group tasks into phases:
 
-| Phase       | Purpose                              | Contains                                   |
-| ----------- | ------------------------------------ | ------------------------------------------ |
-| Foundation  | Data models, schemas, interfaces     | Types, database tables, API contracts      |
-| Core logic  | Business logic, algorithms           | The actual feature implementation          |
-| Integration | Connecting components, API endpoints | Routes, controllers, wire-up               |
-| Polish      | Edge cases, error handling, UX       | Validation, error messages, loading states |
+| Phase | Purpose | Contains |
+| ----- | ------- | -------- |
+| Setup | Shared contracts or migrations that unblock slices | Types, schemas, fixtures |
+| Slice 1 | First end-to-end behavior | Minimal data, logic, API, UI/CLI path |
+| Slice N | Incremental capability | One user-visible behavior or operational capability |
+| Hardening | Cross-slice edge cases and quality gates | Performance, security, docs, cleanup |
+
+Label each slice:
+
+- **AFK** — an agent can implement it from the issue brief with no further human context.
+- **HITL** — requires human judgment, external access, product approval, design review, or release authority.
 
 ### Phase 3: Identify Edge Cases
 
@@ -130,26 +150,21 @@ For each risk, identify mitigation:
 ### Task Breakdown
 
 #### Phase 1: Foundation
-| # | Task | Effort | Dependencies | Parallel |
-|---|------|--------|--------------|----------|
-| 1.1 | {task description} | {S/M/L} | None | Yes |
-| 1.2 | {task description} | {S/M/L} | 1.1 | No |
+| # | Slice / Task | Type | Effort | Dependencies | Parallel |
+|---|--------------|------|--------|--------------|----------|
+| 1.1 | {task description} | {AFK/HITL} | {S/M/L} | None | Yes |
+| 1.2 | {task description} | {AFK/HITL} | {S/M/L} | 1.1 | No |
 
-#### Phase 2: Core Logic
-| # | Task | Effort | Dependencies | Parallel |
-|---|------|--------|--------------|----------|
-| 2.1 | {task description} | {S/M/L} | 1.x | Yes |
-| 2.2 | {task description} | {S/M/L} | 1.x | Yes |
+#### Phase 2: Vertical Slices
+| # | Slice / Task | Type | Effort | Dependencies | Parallel |
+|---|--------------|------|--------|--------------|----------|
+| 2.1 | {end-to-end behavior} | {AFK/HITL} | {S/M/L} | 1.x | Yes |
+| 2.2 | {end-to-end behavior} | {AFK/HITL} | {S/M/L} | 1.x | Yes |
 
-#### Phase 3: Integration
-| # | Task | Effort | Dependencies | Parallel |
-|---|------|--------|--------------|----------|
-| 3.1 | {task description} | {S/M/L} | 2.x | No |
-
-#### Phase 4: Polish
-| # | Task | Effort | Dependencies | Parallel |
-|---|------|--------|--------------|----------|
-| 4.1 | {task description} | {S/M/L} | 3.x | Yes |
+#### Phase 3: Hardening
+| # | Task | Type | Effort | Dependencies | Parallel |
+|---|------|------|--------|--------------|----------|
+| 3.1 | {cross-slice quality gate} | {AFK/HITL} | {S/M/L} | 2.x | No |
 
 ### Edge Cases
 
@@ -170,12 +185,15 @@ For each risk, identify mitigation:
 
 ### Risk Flags
 - {Risk}: {mitigation strategy}
+
+### Agent Brief Notes
+- {Any interface contracts, acceptance criteria, or out-of-scope boundaries that should be copied into ready-for-agent issues}
 ```
 
 ## Calibration Rules
 
-1. **Right granularity.** Each task should be 1-3 days of work. Larger → decompose further.
-   Smaller → merge into a parent task.
+1. **Right granularity.** Each slice should be 1-3 days of work and each implementation task
+   should fit in one PR. Larger → decompose further. Smaller → merge into a parent slice.
 2. **Testable acceptance criteria.** "Make search work" is not testable. "Search returns
    relevant results within 200ms for queries up to 100 characters" is testable.
 3. **Dependencies are sacred.** If Task B truly depends on Task A, mark it. False
@@ -184,6 +202,10 @@ For each risk, identify mitigation:
    is empty, the analysis is incomplete.
 5. **Parallel = velocity.** Maximize parallel tasks. If 4 tasks can be done simultaneously,
    the phase takes the duration of the longest, not the sum.
+6. **Vertical first.** Prefer end-to-end slices over layer-only tasks. Use horizontal tasks
+   only for shared contracts, migrations, or infrastructure that genuinely unblocks slices.
+7. **Ready-for-agent requires a brief.** AFK slices need desired behavior, key interfaces,
+   acceptance criteria, and out-of-scope boundaries clear enough for a fresh agent.
 
 ## Error Handling
 

--- a/skills/task-decomposer/references/decomposition-patterns.md
+++ b/skills/task-decomposer/references/decomposition-patterns.md
@@ -6,23 +6,9 @@ Strategies for breaking features into implementable tasks at the right granulari
 
 ## Decomposition Strategies
 
-### By Layer (Vertical Slicing)
+### By Capability (Vertical Slicing)
 
-Break by architectural layer:
-
-```text
-Feature: User search
-├── Data layer: Add search index, write query function
-├── Logic layer: Search ranking, filtering, pagination
-├── API layer: GET /search endpoint, query params
-└── UI layer: Search bar, results list, loading state
-```
-
-**When to use:** Full-stack features touching multiple layers.
-
-### By Capability (Horizontal Slicing)
-
-Break by user-visible capability, implementing thin vertical slices:
+Break by user-visible capability, implementing thin tracer bullets:
 
 ```text
 Feature: User search
@@ -32,7 +18,24 @@ Feature: User search
 └── Slice 4: Add pagination
 ```
 
-**When to use:** When incremental delivery is valuable. Each slice is deployable.
+**When to use:** Default for feature implementation. Each slice is deployable,
+demoable, or independently verifiable.
+
+### By Layer (Horizontal Slicing)
+
+Break by architectural layer only when a shared contract or infrastructure step
+genuinely unblocks later vertical slices:
+
+```text
+Feature: User search
+├── Data layer: Add search index, write query function
+├── Logic layer: Search ranking, filtering, pagination
+├── API layer: GET /search endpoint, query params
+└── UI layer: Search bar, results list, loading state
+```
+
+**When to use:** Pure infrastructure, migrations, or contract setup. Avoid using this
+as the main plan for user-facing features because it creates non-demoable work queues.
 
 ### By Component
 
@@ -77,6 +80,7 @@ Each task should be:
 - **Independently testable** (can verify it works alone)
 - **Single PR** (one review, one merge)
 - **Describable in one sentence** (clear scope)
+- **Vertically meaningful** when user-facing behavior is involved
 
 ### Size Indicators
 
@@ -110,14 +114,14 @@ Tasks should be merged if:
 
 ## Phase Organization
 
-### Standard 4-Phase Model
+### Preferred Vertical-Slice Model
 
-| Phase       | Purpose                          | Characteristics                            |
-| ----------- | -------------------------------- | ------------------------------------------ |
-| Foundation  | Data models, schemas, interfaces | No business logic, defines contracts       |
-| Core        | Business logic, algorithms       | Implements the actual feature              |
-| Integration | Connecting pieces, endpoints     | Wiring, API routes, event handlers         |
-| Polish      | Edge cases, UX, error handling   | Validation, error messages, loading states |
+| Phase | Purpose | Characteristics |
+| ----- | ------- | --------------- |
+| Setup | Shared contract work that unblocks slices | Minimal schema/types/fixtures only |
+| Slice 1 | First narrow end-to-end behavior | Demoable tracer bullet |
+| Slice N | Additional capabilities | Each adds one observable behavior |
+| Hardening | Cross-slice quality gates | Performance, security, docs, cleanup |
 
 ### When to Collapse Phases
 


### PR DESCRIPTION
## Summary

This PR imports the highest-leverage workflow concepts from `mattpocock/skills` into armory as durable, repo-local agent conventions rather than a wholesale copy of the upstream package set.

The branch adds a new `project-context-setup` skill and wires its conventions into existing planning, TDD, debugging, and architecture-review workflows. The intent is to give agents a shared project language, consistent issue-readiness vocabulary, ADR lookup rules, vertical-slice planning discipline, and durable AFK handoff contracts.

## Changes

### New `project-context-setup` skill

Adds `skills/project-context-setup/` with:

- `SKILL.md` for scaffolding repo-local agent context.
- `references/context-format.md` for `CONTEXT.md` and `CONTEXT-MAP.md` glossary conventions.
- `references/agent-brief.md` for `ready-for-agent` issue handoff contracts.
- `references/out-of-scope.md` for rejected-enhancement memory under `.out-of-scope/`.
- `evals/cases.yaml` with positive and negative activation coverage.

The skill defines the standard `docs/agents/` context set:

- `docs/agents/issue-tracker.md`
- `docs/agents/triage-labels.md`
- `docs/agents/domain.md`

It also defines the `## Agent context` block expected in repo-level agent instruction files.

### Workflow consumers

Updates existing engineering workflows to consume repo-local context when available:

- `skills/debug-investigator/SKILL.md`
  - Adds project glossary and ADR lookup awareness.
  - Adds a hard `Build a Feedback Loop` gate before evidence analysis and hypothesis ranking.
  - Defines acceptable repro loops: failing tests, CLI scripts, curl/HTTP checks, browser automation, trace replay, throwaway harnesses, fuzz/stress loops, and `git bisect run` harnesses.

- `commands/tdd/COMMAND.md`
  - Adds `docs/agents/domain.md`, `CONTEXT.md`, and ADR checks before naming tests and interfaces.
  - Changes the TDD workflow from bulk test-writing to one vertical red-green-refactor slice at a time.
  - Explicitly blocks batching all tests up front.

- `skills/task-decomposer/SKILL.md`
  - Adds repo-local context lookup for domain docs, triage labels, ADR rules, and `.out-of-scope/` memory.
  - Reorients decomposition toward tracer-bullet vertical slices.
  - Adds `AFK` / `HITL` readiness labels.
  - Adds agent-brief notes for work intended to become `ready-for-agent` issues.

- `skills/task-decomposer/references/decomposition-patterns.md`
  - Makes vertical capability slicing the default model.
  - Reframes horizontal layer slicing as an exception for shared contracts, migrations, or infrastructure.

- `agents/project-planner/AGENT.md`
  - Adds `project-context-setup` to the orchestrated skill map.
  - Reads domain and triage-label context when present.
  - Adds vertical slices, `AFK` / `HITL` task typing, and agent-brief notes to the output contract.

### Architecture review deep-module analysis

Adds `skills/architecture-reviewer/references/deep-module-analysis.md` and wires it into `skills/architecture-reviewer/SKILL.md`.

This gives structural reviews a sharper vocabulary for module boundary analysis:

- module
- interface
- implementation
- deep module
- shallow module
- seam
- adapter
- locality
- leverage
- deletion test

The architecture reviewer now scans project context before classification and treats ADRs as constraints unless observed friction justifies reopening a decision.

### Catalog and routing

- Updates `README.md` package count and development tooling catalog.
- Updates `/route` to recommend `project-context-setup` for repo-local agent context setup.
- Regenerates `manifest.yaml`.

## Commit Breakdown

- `feat(skills): add project context setup`
- `feat(workflows): use project context conventions`
- `feat(review): add deep module architecture analysis`
- `docs(catalog): register project context setup`

## Validation

Passed:

- `uv run python scripts/generate_manifest.py`
- `uv run python scripts/validate_evals.py`
- `uv run python scripts/validate_frontmatter.py`
- `uv run python scripts/validate_references.py`
- `uv run python scripts/validate_agentskills.py`
- `uv run python scripts/evaluate_package.py --path skills/project-context-setup`
  - `84/100`, status `PASS`
- `uv run pytest tests/test_generate_manifest.py tests/test_frontmatter.py tests/test_package_types.py`
  - `77 passed`
- `git diff --check origin/main..HEAD`
- Fast branch-diff secret scan for high-signal token patterns

Known existing repo-wide gate state:

- `uv run ruff check` fails on pre-existing unrelated lint issues in scripts/templates.
- `uv run ruff format --check .` fails because 49 existing Python files would be reformatted.
- `uv run mypy --strict` fails because no default mypy target is configured.

## Scope Notes

This PR intentionally does not add full issue-tracker automation. It establishes the conventions first: issue tracker docs, triage labels, domain glossary layout, ADR lookup rules, agent brief format, and out-of-scope memory. A follow-up `issue-triage` skill can build on these conventions without duplicating setup logic.
