### PR TITLE
Add stacked PR package family

### DIFF
--- a/commands/stack-pr/COMMAND.md
+++ b/commands/stack-pr/COMMAND.md
@@ -1,0 +1,98 @@
+---
+name: stack-pr
+type: command
+description: 'Slash-command wrapper for the stacked-prs skill. Triggers on: "/stack-pr inspect", "/stack-pr split", "/stack-pr publish", "/stack-pr sync", "/stack-pr validate", "/stack-pr merge", "/stack-pr cleanup", "stack-pr publish", "stack-pr split". Use this command when a user wants a concise command surface for inspecting, creating, publishing, synchronizing, validating, merging, or cleaning up stacked pull requests while delegating topology decisions to skills/stacked-prs.'
+metadata:
+  version: 0.1.0
+  category: development
+  tags: [git, pull-requests, stacked-prs, slash-command]
+  difficulty: advanced
+  phase: ship
+command:
+  syntax: /stack-pr <inspect|split|publish|sync|validate|merge|cleanup> [args]
+  handler: inline
+  dependencies:
+    - skills/stacked-prs
+---
+
+# Stack PR Command
+
+Thin slash-command entry point for `skills/stacked-prs`. This command defines command syntax and dispatch rules only. The skill owns stack inference, provider adapters, safety checks, split discipline, validation, merge order, and cleanup.
+
+## Workflow
+
+1. Parse the subcommand.
+2. Load `skills/stacked-prs`.
+3. Pass the raw arguments to the matching skill workflow.
+4. Preserve provider-neutral language in user-facing output.
+5. Report the exact `git`, provider CLI, and validation commands executed.
+
+## Operations
+
+| Command | Delegates To | Behavior |
+| --- | --- | --- |
+| `/stack-pr inspect` | Inspect workflow | Build a stack table without mutation |
+| `/stack-pr publish` | Publish workflow | Create missing PRs and retarget wrong bases |
+| `/stack-pr sync` | Sync workflow | Rebase branches parent-to-child and push with lease |
+| `/stack-pr validate` | Validate workflow | Validate stack slices and record results |
+| `/stack-pr merge` | Merge workflow | Merge root to leaf and retarget children |
+| `/stack-pr cleanup` | Cleanup workflow | Delete only confirmed merged stack branches |
+| `/stack-pr split` | Split workflow | Convert one source branch into ordered stack branches |
+
+## Syntax
+
+Publish an explicit stack:
+
+```text
+/stack-pr publish --base main feat/parser-core feat/parser-cache feat/parser-cli
+```
+
+Split one source branch:
+
+```text
+/stack-pr split \
+  --source feat/parser-system \
+  --base main \
+  feat/parser-core feat/parser-cache feat/parser-cli
+```
+
+Sync an existing stack:
+
+```text
+/stack-pr sync --base main feat/parser-core feat/parser-cache feat/parser-cli
+```
+
+Merge an existing stack:
+
+```text
+/stack-pr merge --base main feat/parser-core feat/parser-cache feat/parser-cli
+```
+
+## Argument Rules
+
+- Accept branch names positionally after options.
+- Treat positional branch order as authoritative for parent order.
+- `--base <branch>` sets the root parent; default branch detection is allowed when omitted.
+- `--source <branch>` is required for `split`.
+- Do not require `.stack-prs.yaml` for one-off command use.
+- Stop when command arguments conflict with provider PR base metadata.
+
+## Error Handling
+
+| Problem | Resolution |
+| --- | --- |
+| Unknown subcommand | List supported subcommands and stop |
+| Missing branch arguments for publish, sync, merge, or cleanup | Run inspect only when the skill can infer an unambiguous stack |
+| Missing `--source` for split | Stop and request source branch |
+| Dirty worktree before mutation | Stop through `skills/stacked-prs` safety rules |
+| Provider CLI unavailable | Stop unless the requested operation is inspect-only and local-only |
+
+## Output
+
+Return the delegated skill result:
+
+1. Stack table.
+2. Commands executed.
+3. PR URLs or numbers changed.
+4. Validation results.
+5. Next safe action.

--- a/commands/stack-pr/evals/cases.yaml
+++ b/commands/stack-pr/evals/cases.yaml
@@ -1,0 +1,86 @@
+cases:
+  - id: slash_split
+    prompt: "/stack-pr split --source feat/parser-system --base main feat/parser-core feat/parser-cache feat/parser-cli"
+    fixtures: []
+    rubric:
+      - "activates stack-pr command"
+      - "delegates to skills/stacked-prs split workflow"
+      - "preserves source branch, base branch, and ordered target branches"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "skills/stacked-prs"
+        weight: 0.8
+      - type: matches_regex
+        target: "split"
+        weight: 0.8
+      - type: matches_regex
+        target: "feat/parser-system"
+        weight: 0.8
+
+  - id: slash_publish
+    prompt: "/stack-pr publish --base main feat/parser-core feat/parser-cache feat/parser-cli"
+    fixtures: []
+    rubric:
+      - "activates stack-pr command"
+      - "delegates to skills/stacked-prs publish workflow"
+      - "uses positional branch order as stack order"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "publish"
+        weight: 0.8
+      - type: matches_regex
+        target: "positional|order"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh pr create"
+        weight: 0.8
+
+  - id: slash_sync
+    prompt: "/stack-pr sync --base main feat/parser-core feat/parser-cache"
+    fixtures: []
+    rubric:
+      - "activates stack-pr command"
+      - "delegates to skills/stacked-prs sync workflow"
+      - "uses force-with-lease for rewritten branches"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "sync"
+        weight: 0.8
+      - type: matches_regex
+        target: "--force-with-lease"
+        weight: 1.0
+
+  - id: slash_validate
+    prompt: "/stack-pr validate --base main feat/parser-core feat/parser-cache feat/parser-cli"
+    fixtures: []
+    rubric:
+      - "activates stack-pr command"
+      - "delegates to skills/stacked-prs validation workflow"
+      - "records exact validation commands"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "validate|validation"
+        weight: 0.8
+      - type: matches_regex
+        target: "commands executed|exact"
+        weight: 0.6
+
+  - id: negative_ship_it
+    prompt: "Ship it: merge main, run tests, open the release PR, and write the changelog."
+    fixtures: []
+    rubric:
+      - "release workflow belongs to ship-workflow, not stack-pr"
+      - "does not activate stack-pr command"
+    trigger_expected: false
+
+  - id: negative_single_pr
+    prompt: "Create one PR for the current branch against main."
+    fixtures: []
+    rubric:
+      - "normal PR creation is outside stack-pr"
+      - "does not activate stack-pr command"
+    trigger_expected: false

--- a/hooks/stack-guard/HOOK.md
+++ b/hooks/stack-guard/HOOK.md
@@ -1,0 +1,71 @@
+---
+name: stack-guard
+type: hook
+description: 'PreToolUse Bash hook that adds stacked-PR-specific safety checks. Triggers on: "stack guard", "stacked PR safety hook", "block git push --force", "warn wrong stack base", "protect stacked branches", "stack workflow hook". Use this hook with stacked-prs workflows to block plain force pushes, allow force-with-lease, and warn when commands appear to violate `.stack-prs.yaml` branch topology.'
+metadata:
+  version: 0.1.0
+  category: operations
+  tags: [git, stacked-prs, hooks, safety]
+  difficulty: intermediate
+  phase: ship
+hook:
+  events: [PreToolUse]
+  matcher: Bash
+  handler: {type: command, command: bash handler.sh, timeout_ms: 5000}
+---
+
+# Stack Guard
+
+Adds conservative safety checks for stacked PR workflows. It complements `git-protection` by focusing on stack topology instead of generic destructive Git commands.
+
+## Workflow
+
+1. Read the Bash command from the PreToolUse hook payload.
+2. Block plain `git push --force` and `git push -f`.
+3. Allow `git push --force-with-lease`.
+4. When `.stack-prs.yaml` exists, inspect declared branch parents.
+5. Warn when a PR creation command targets a base that conflicts with metadata.
+6. Warn when pushing a child while its declared parent has unpushed commits.
+7. Warn before PR merge commands in repos with stack metadata so the agent verifies parent-first merge order.
+
+## Behavior
+
+| Operation | Result | Reason |
+| --- | --- | --- |
+| `git push --force origin branch` | Block | Plain force can overwrite collaborator work |
+| `git push -f origin branch` | Block | Short force flag has the same risk |
+| `git push --force-with-lease origin branch` | Allow | Lease protects against unseen remote changes |
+| `gh pr create --base main --head child` with metadata parent `parent` | Warn | Review diff would include unrelated parent changes |
+| `git push origin child` while `parent` has unpushed commits | Warn | Remote child can reference parent commits not available remotely |
+| `gh pr merge <number>` with stack metadata | Warn | Merge order must be parent-first |
+
+## Metadata Scope
+
+The hook reads the straightforward `.stack-prs.yaml` shape documented by `skills/stacked-prs`:
+
+```yaml
+base: main
+branches:
+  - name: feat/parser-core
+    parent: main
+  - name: feat/parser-cache
+    parent: feat/parser-core
+```
+
+If the file is absent, only force-push protection runs.
+
+## Output
+
+- Blocked commands write a `BLOCKED:` diagnostic to stderr and exit non-zero.
+- Topology concerns write a `WARNING:` diagnostic to stderr and exit 0.
+- Safe commands exit 0 without output.
+
+## Error Handling
+
+| Problem | Resolution |
+| --- | --- |
+| Hook payload lacks a Bash command | Exit 0 |
+| `.stack-prs.yaml` absent | Run force-push protection only |
+| Metadata branch is not found locally | Warn only on commands that can be checked from command text |
+| Parent remote ref is absent | Warn that parent has no remote ref |
+

--- a/hooks/stack-guard/evals/cases.yaml
+++ b/hooks/stack-guard/evals/cases.yaml
@@ -1,0 +1,73 @@
+cases:
+  - id: block_plain_force_push
+    prompt: "Run git push --force origin feat/parser-cache after rebasing the stack."
+    fixtures: []
+    rubric:
+      - "Hook blocks plain force push"
+      - "Diagnostic recommends force-with-lease"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "BLOCKED"
+        weight: 0.8
+      - type: matches_regex
+        target: "--force-with-lease"
+        weight: 1.0
+
+  - id: allow_force_with_lease
+    prompt: "Run git push --force-with-lease origin feat/parser-cache after a clean stack rebase."
+    fixtures: []
+    rubric:
+      - "Hook allows force-with-lease"
+      - "Hook does not block safe stack rebase pushes"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "allow|exit 0|force-with-lease"
+        weight: 0.8
+
+  - id: warn_wrong_stack_base
+    prompt: "With .stack-prs.yaml declaring feat/parser-cache parent feat/parser-core, run gh pr create --base main --head feat/parser-cache."
+    fixtures: []
+    rubric:
+      - "Hook warns that the PR base conflicts with stack metadata"
+      - "Hook exits 0 because wrong-base detection is warning-only in v1"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "WARNING"
+        weight: 0.8
+      - type: matches_regex
+        target: "parent|base"
+        weight: 0.8
+
+  - id: warn_child_parent_unpushed
+    prompt: "With .stack-prs.yaml declaring feat/parser-cache parent feat/parser-core, run git push origin feat/parser-cache while the parent has unpushed commits."
+    fixtures: []
+    rubric:
+      - "Hook warns about pushing a child before its parent"
+      - "Hook does not block the push"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "WARNING"
+        weight: 0.8
+      - type: matches_regex
+        target: "push parent before child|unpushed"
+        weight: 0.8
+
+  - id: allow_status
+    prompt: "Run git status --short in a repo with .stack-prs.yaml."
+    fixtures: []
+    rubric:
+      - "Hook allows unrelated Git status commands"
+      - "Hook emits no stack warning"
+    trigger_expected: false
+
+  - id: allow_normal_push_without_metadata
+    prompt: "Run git push origin feat/simple-branch in a repo without .stack-prs.yaml."
+    fixtures: []
+    rubric:
+      - "Hook allows normal push"
+      - "Hook does not require stack metadata"
+    trigger_expected: false

--- a/hooks/stack-guard/handler.sh
+++ b/hooks/stack-guard/handler.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -1)
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+is_git_push=false
+case "$CMD" in
+  *git\ push*) is_git_push=true ;;
+esac
+
+if [ "$is_git_push" = true ]; then
+  if printf '%s\n' "$CMD" | grep -Eq '(^|[[:space:]])--force-with-lease([=[:space:]]|$)'; then
+    :
+  elif printf '%s\n' "$CMD" | grep -Eq '(^|[[:space:]])(--force|-f)([[:space:]]|$)'; then
+    echo "BLOCKED: plain git push --force rewrites remote history; use --force-with-lease for stack rebases." >&2
+    exit 1
+  fi
+fi
+
+metadata=".stack-prs.yaml"
+if [ ! -f "$metadata" ]; then
+  exit 0
+fi
+
+declared_parent() {
+  branch="$1"
+  awk -v wanted="$branch" '
+    /^[[:space:]]*-[[:space:]]*name:[[:space:]]*/ {
+      current=$0
+      sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", current)
+      gsub(/^"|"$/, "", current)
+      gsub(/^'\''|'\''$/, "", current)
+      next
+    }
+    current == wanted && /^[[:space:]]*parent:[[:space:]]*/ {
+      parent=$0
+      sub(/^[[:space:]]*parent:[[:space:]]*/, "", parent)
+      gsub(/^"|"$/, "", parent)
+      gsub(/^'\''|'\''$/, "", parent)
+      print parent
+      exit
+    }
+  ' "$metadata"
+}
+
+extract_flag_value() {
+  flag="$1"
+  printf '%s\n' "$CMD" | awk -v flag="$flag" '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == flag && i < NF) {
+          print $(i + 1)
+          exit
+        }
+        if (index($i, flag "=") == 1) {
+          value=$i
+          sub(flag "=", "", value)
+          print value
+          exit
+        }
+      }
+    }
+  '
+}
+
+if printf '%s\n' "$CMD" | grep -Eq '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  base=$(extract_flag_value "--base")
+  head=$(extract_flag_value "--head")
+  if [ -n "$base" ] && [ -n "$head" ]; then
+    parent=$(declared_parent "$head")
+    if [ -n "$parent" ] && [ "$parent" != "$base" ]; then
+      echo "WARNING: .stack-prs.yaml declares parent '$parent' for '$head', but PR command uses base '$base'." >&2
+    fi
+  fi
+fi
+
+if [ "$is_git_push" = true ]; then
+  branch=$(printf '%s\n' "$CMD" | awk '
+    {
+      for (i = NF; i >= 1; i--) {
+        if ($i !~ /^-/ && $i != "push" && $i != "git" && $i != "origin") {
+          print $i
+          exit
+        }
+      }
+    }
+  ')
+  if [ -z "$branch" ] || [ "$branch" = "$CMD" ]; then
+    branch=$(git branch --show-current 2>/dev/null || true)
+  fi
+  parent=$(declared_parent "$branch")
+  if [ -n "$parent" ]; then
+    if ! git show-ref --verify --quiet "refs/remotes/origin/$parent"; then
+      echo "WARNING: parent branch '$parent' for '$branch' has no origin ref; push parent before child." >&2
+    elif [ -n "$(git log --oneline "origin/$parent..$parent" 2>/dev/null)" ]; then
+      echo "WARNING: parent branch '$parent' has unpushed commits; push parent before child '$branch'." >&2
+    fi
+  fi
+fi
+
+if printf '%s\n' "$CMD" | grep -Eq '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+  echo "WARNING: stack metadata exists; verify parent PRs are merged before merging a child PR." >&2
+fi
+
+exit 0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1042,6 +1042,23 @@ packages:
     category: data
     difficulty: intermediate
     phase: build
+  - name: stacked-prs
+    version: 0.1.0
+    description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create
+      stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs",
+      "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches". Use when local branches or
+      one source branch need to become a dependency-ordered PR stack with correct parent bases, validation, synchronization,
+      merge order, and cleanup.'
+    path: skills/stacked-prs
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/stacked-prs/SKILL.md
+    tags:
+    - git
+    - pull-requests
+    - stacked-prs
+    - workflow
+    category: development
+    difficulty: advanced
+    phase: ship
   - name: static-web-artifacts-builder
     version: 1.1.1
     description: 'Build self-contained static HTML artifacts opened in a browser: interactive diagrams, dashboards, infographics.
@@ -1677,6 +1694,24 @@ packages:
     - efficiency
     category: operations
     difficulty: intermediate
+  - name: stack-guard
+    version: 0.1.0
+    description: 'PreToolUse Bash hook that adds stacked-PR-specific safety checks. Triggers on: "stack guard", "stacked PR
+      safety hook", "block git push --force", "warn wrong stack base", "protect stacked branches", "stack workflow hook".
+      Use this hook with stacked-prs workflows to block plain force pushes, allow force-with-lease, and warn when commands
+      appear to violate `.stack-prs.yaml` branch topology.'
+    path: hooks/stack-guard
+    source: https://github.com/Mathews-Tom/armory/blob/main/hooks/stack-guard/HOOK.md
+    events:
+    - PreToolUse
+    tags:
+    - git
+    - stacked-prs
+    - hooks
+    - safety
+    category: operations
+    difficulty: intermediate
+    phase: ship
   rules:
   - name: adaptive-thinking-control
     version: 1.0.0
@@ -1856,6 +1891,22 @@ packages:
     category: review
     difficulty: intermediate
     phase: review
+  - name: stack-pr
+    version: 0.1.0
+    description: 'Slash-command wrapper for the stacked-prs skill. Triggers on: "/stack-pr inspect", "/stack-pr split", "/stack-pr
+      publish", "/stack-pr sync", "/stack-pr validate", "/stack-pr merge", "/stack-pr cleanup", "stack-pr publish", "stack-pr
+      split". Use this command when a user wants a concise command surface for inspecting, creating, publishing, synchronizing,
+      validating, merging, or cleaning up stacked pull requests while delegating topology decisions to skills/stacked-prs.'
+    path: commands/stack-pr
+    source: https://github.com/Mathews-Tom/armory/blob/main/commands/stack-pr/COMMAND.md
+    tags:
+    - git
+    - pull-requests
+    - stacked-prs
+    - slash-command
+    category: development
+    difficulty: advanced
+    phase: ship
   - name: tdd
     version: 1.0.0
     description: 'Test-driven development workflow for functions, modules, or features. Guides Claude through the red-green-refactor
@@ -2098,6 +2149,22 @@ packages:
     - pipeline
     category: meta
     difficulty: advanced
+  - name: stack-workflow
+    version: 0.1.0
+    description: 'Bundles stacked pull request workflow packages for teams that regularly ship dependent PR chains. Triggers
+      on: "stack workflow preset", "install stacked PR workflow", "stacked PR team setup", "enable stack guard", "stack-pr
+      preset", "stacked branch workflow". Use this preset when a project wants the stacked-prs skill, /stack-pr command, stack-guard
+      hook, git-protection hook, and PR review packages installed as one workflow.'
+    path: presets/stack-workflow
+    source: https://github.com/Mathews-Tom/armory/blob/main/presets/stack-workflow/PRESET.md
+    tags:
+    - git
+    - pull-requests
+    - stacked-prs
+    - preset
+    category: development
+    difficulty: advanced
+    phase: ship
   - name: terse-mode
     version: 1.0.0
     description: 'Enforces terse, no-narration output from Claude Code. Bundles the prompt-context hook with a curated terse

--- a/presets/stack-workflow/PRESET.md
+++ b/presets/stack-workflow/PRESET.md
@@ -1,0 +1,74 @@
+---
+name: stack-workflow
+type: preset
+description: 'Bundles stacked pull request workflow packages for teams that regularly ship dependent PR chains. Triggers on: "stack workflow preset", "install stacked PR workflow", "stacked PR team setup", "enable stack guard", "stack-pr preset", "stacked branch workflow". Use this preset when a project wants the stacked-prs skill, /stack-pr command, stack-guard hook, git-protection hook, and PR review packages installed as one workflow.'
+packages:
+  - skills/stacked-prs
+  - commands/stack-pr
+  - hooks/git-protection
+  - hooks/stack-guard
+  - skills/pre-landing-review
+  - skills/pr-review
+metadata:
+  version: 0.1.0
+  category: development
+  tags: [git, pull-requests, stacked-prs, preset]
+  difficulty: advanced
+  phase: ship
+preset:
+  packages:
+    skills:
+      - { name: stacked-prs }
+      - { name: pre-landing-review }
+      - { name: pr-review }
+    commands:
+      - { name: stack-pr }
+    hooks:
+      - { name: git-protection }
+      - { name: stack-guard }
+---
+
+# Stack Workflow
+
+Installs the packages needed for repeated stacked PR work: stack modeling, slash-command dispatch, force-push protection, stack-specific warnings, and review gates.
+
+## Included Packages
+
+| Type | Package | Role |
+| --- | --- | --- |
+| Skill | stacked-prs | Inspect, publish, sync, validate, split, merge, and clean stacks |
+| Command | stack-pr | Provides `/stack-pr` command syntax |
+| Hook | git-protection | Blocks broadly destructive Git operations |
+| Hook | stack-guard | Blocks plain force pushes and warns on stack topology risks |
+| Skill | pre-landing-review | Final merge-readiness gate |
+| Skill | pr-review | Diff-based PR review |
+
+## Workflow
+
+1. Use `stacked-prs` or `/stack-pr inspect` to model the current stack.
+2. Use `/stack-pr publish` or `/stack-pr split` to create reviewable PR slices.
+3. Let `git-protection` block destructive Git operations.
+4. Let `stack-guard` warn when commands conflict with `.stack-prs.yaml`.
+5. Use `pr-review` on individual PR diffs.
+6. Use `pre-landing-review` before merging each stack slice.
+7. Merge root to leaf and clean up confirmed merged branches.
+
+## When To Use
+
+Use this preset for teams that frequently maintain dependent PR chains or long-running feature stacks.
+
+Do not install it just to open occasional single PRs. The `stacked-prs` skill is request-scoped and does not force stack behavior, but global hooks add friction that simple-branch projects do not need.
+
+## Output
+
+The preset installs packages only. It does not create `.stack-prs.yaml`, branch stacks, PRs, or repository metadata by itself.
+
+## Error Handling
+
+| Problem | Resolution |
+| --- | --- |
+| User needs one normal PR | Use the normal PR workflow instead of this preset |
+| Team has no stack metadata | `stack-guard` still blocks plain force push and otherwise stays quiet |
+| Existing project already has `git-protection` | Keep one installed copy; do not duplicate hooks |
+| Hosted provider is not GitHub | Use `stacked-prs` local inspection and add an adapter before PR mutation |
+

--- a/presets/stack-workflow/evals/cases.yaml
+++ b/presets/stack-workflow/evals/cases.yaml
@@ -1,0 +1,64 @@
+cases:
+  - id: install_stack_workflow
+    prompt: "Install the stacked PR workflow preset for this team."
+    fixtures: []
+    rubric:
+      - "activates stack-workflow preset"
+      - "includes stacked-prs skill and stack-pr command"
+      - "includes stack-guard and git-protection hooks"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "stacked-prs"
+        weight: 0.8
+      - type: matches_regex
+        target: "stack-pr"
+        weight: 0.8
+      - type: matches_regex
+        target: "stack-guard|git-protection"
+        weight: 0.8
+
+  - id: enable_stack_guard
+    prompt: "Enable the stack guard and stacked PR command for our repo."
+    fixtures: []
+    rubric:
+      - "routes to stack-workflow when the user asks for the bundled setup"
+      - "mentions stack-guard and stack-pr"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "stack-guard"
+        weight: 0.8
+      - type: matches_regex
+        target: "stack-pr"
+        weight: 0.8
+
+  - id: team_stacked_branch_setup
+    prompt: "Our team uses dependent PR chains every week; install the workflow that protects those branches."
+    fixtures: []
+    rubric:
+      - "activates stack-workflow preset"
+      - "explains that it is for repeated stacked PR work"
+      - "does not create .stack-prs.yaml automatically"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "dependent PR|stacked PR|branch stack"
+        weight: 0.8
+      - type: matches_regex
+        target: "does not create|metadata"
+        weight: 0.6
+
+  - id: negative_single_pr
+    prompt: "Open one normal pull request for my current branch."
+    fixtures: []
+    rubric:
+      - "does not activate stack-workflow because one normal PR does not need the preset"
+    trigger_expected: false
+
+  - id: negative_core_quality
+    prompt: "Install the basic code review and commit hygiene preset."
+    fixtures: []
+    rubric:
+      - "does not activate stack-workflow; core preset owns basic review and commit hygiene"
+    trigger_expected: false

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: stacked-prs
+description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs", "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches". Use when local branches or one source branch need to become a dependency-ordered PR stack with correct parent bases, validation, synchronization, merge order, and cleanup.'
+metadata:
+  version: 0.1.0
+  category: development
+  tags: [git, pull-requests, stacked-prs, workflow]
+  difficulty: advanced
+  phase: ship
+---
+
+# Stacked PRs
+
+Build, publish, synchronize, validate, merge, and clean up stacked pull requests without corrupting branch topology.
+
+The package identity is provider-neutral. Git is the source of truth for branch ancestry; provider PR metadata is the source of truth for review bases. GitHub through `gh` is the first documented provider adapter.
+
+## Reference Files
+
+| File | Contents | Load When |
+| --- | --- | --- |
+| `references/stack-model.md` | Stack inference, explicit ordering, and `.stack-prs.yaml` rules | Inspecting, publishing, validating, or cleaning a stack |
+| `references/provider-adapters.md` | Provider adapter contract and GitHub `gh` commands | Creating, retargeting, checking, merging, or deleting PRs |
+| `references/sync-algorithm.md` | Rebase and force-with-lease synchronization workflow | Syncing a stack after a parent or base moves |
+| `references/merge-discipline.md` | Bottom-up merge and branch cleanup rules | Merging or closing out a stack |
+| `references/metadata-format.md` | Optional metadata schema and validation rules | `.stack-prs.yaml` exists or inference is ambiguous |
+
+## When To Use
+
+| Use this skill | Use another package |
+| --- | --- |
+| Multiple dependent branches need PRs against parent branches | `ship-workflow` for one independent release PR |
+| A feature branch must be split into reviewable dependent branches | `task-decomposer` for planning tasks before code exists |
+| An existing stack needs rebasing, retargeting, validation, or merge sequencing | `pr-review` for reviewing one PR diff |
+| A stack must be cleaned after merge | General Git commands for unrelated branch cleanup |
+
+## Core Rules
+
+- Run `git rev-parse --show-toplevel` before any workflow.
+- Run `git status --porcelain` before rebases, pushes, PR creation, PR retargeting, merge, or cleanup.
+- Stop on a dirty worktree unless the user explicitly scopes the operation to inspection only.
+- Prefer existing PR `baseRefName` values over inferred ancestry.
+- Use explicit branch order or `.stack-prs.yaml` when parent inference is ambiguous.
+- Never use plain `git push --force`; use `git push --force-with-lease origin <branch>`.
+- Merge from root to leaf. Never merge a child before its parent.
+- Do not delete unmerged stack branches without explicit user instruction.
+
+## Workflow
+
+### 1. Inspect
+
+Build a stack model without modifying anything:
+
+```bash
+git rev-parse --show-toplevel
+git status --porcelain
+git branch --show-current
+git for-each-ref --format='%(refname:short)' refs/heads
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+gh pr list --state open --json number,title,headRefName,baseRefName,state,url
+```
+
+Produce a table with one row per stack branch:
+
+| Order | Branch | Parent | PR | State | Checks |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | `feat/parser-core` | `main` | `#101` | open | pending |
+| 2 | `feat/parser-cache` | `feat/parser-core` | `#102` | open | pending |
+
+Stop when no provider adapter is available, no local branches match the requested stack, or parent order cannot be inferred from PR bases, explicit order, or metadata.
+
+### 2. Publish
+
+Create missing PRs and retarget wrong bases:
+
+```bash
+git status --porcelain
+git push -u origin <branch>
+gh pr create \
+  --base <parent-branch> \
+  --head <branch> \
+  --title "<title>" \
+  --body-file <generated-body-file>
+gh pr edit <number> --base <parent-branch>
+```
+
+Generated PR bodies must include the stack order and validation state:
+
+```markdown
+## Stack
+
+Base: `main`
+
+1. `feat/parser-core` -> this PR
+2. `feat/parser-cache` -> depends on #102
+
+## Validation
+
+- Pending: commands not run yet
+```
+
+Stop when a branch has no commits beyond its parent, an existing PR is closed and unmerged, or the provider rejects base retargeting.
+
+### 3. Sync
+
+Rebase each stack branch onto its parent after `main` or any parent branch moves:
+
+```bash
+git status --porcelain
+git fetch origin --prune
+git switch <branch>
+git rebase <parent-branch>
+git push --force-with-lease origin <branch>
+```
+
+Start at the first branch above the base and continue toward the leaf. Stop on conflicts, remote lease failures, or a parent PR that closed without merge.
+
+### 4. Validate
+
+Validate the stack as reviewable slices. Run cheap checks on every branch when practical; run expensive full checks on the leaf when branch-by-branch validation is not reasonable. Record exactly what ran in each PR body.
+
+For this armory package implementation, use:
+
+```bash
+uv run python scripts/validate_evals.py
+uv run python scripts/generate_manifest.py
+uv run python scripts/evaluate_package.py --path skills/stacked-prs
+```
+
+### 5. Merge
+
+Merge root to leaf:
+
+```bash
+gh pr merge <root-pr> --merge --delete-branch
+git fetch origin --prune
+git switch <child-branch>
+git rebase origin/main
+git push --force-with-lease origin <child-branch>
+gh pr edit <child-pr> --base main
+```
+
+Repeat for each child. Require parent checks and provider merge confirmation before moving to the next branch.
+
+### 6. Cleanup
+
+After the stack lands:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch --prune origin
+git branch --merged main
+git branch -d <merged-stack-branch>
+```
+
+Delete only branches confirmed merged into the current base.
+
+## Splitting One Branch Into A Stack
+
+Use split mode when one source branch contains a feature that needs reviewable dependent PRs. Require the source branch, base branch, and target branch order from the user or from unambiguous commit names.
+
+Inspect first:
+
+```bash
+git status --porcelain
+git fetch origin --prune
+git merge-base <base> <source-branch>
+git log --oneline --reverse <base>..<source-branch>
+git diff --stat <base>...<source-branch>
+git diff --name-status <base>...<source-branch>
+```
+
+Select the safest split mode:
+
+| Mode | Use When | Behavior |
+| --- | --- | --- |
+| Commit-range split | Contiguous commits map cleanly to slices | Create dependent branches and cherry-pick ranges |
+| Commit-list split | Non-contiguous commits map cleanly to slices | Cherry-pick explicit commit lists in stack order |
+| Patch-guided split | File or hunk boundaries are clear but commits are mixed | Stop for user-approved split map before mutation |
+| Refuse automatic split | Changes are tangled across required boundaries | Report why the split is unsafe |
+
+After creating branches, compare the leaf with the source branch before publishing:
+
+```bash
+git diff --stat <source-branch>...<leaf-branch>
+git diff --exit-code <source-branch>...<leaf-branch>
+```
+
+Do not publish if the leaf differs from the source branch.
+
+## Error Handling
+
+| Condition | Action |
+| --- | --- |
+| Dirty worktree before mutation | Stop and report changed paths |
+| Ambiguous parent order | Request explicit branch order or `.stack-prs.yaml` |
+| Existing closed unmerged PR | Stop before creating replacements |
+| Rebase or cherry-pick conflict | Stop, report branch and conflicted files, do not continue children |
+| Remote branch changed since fetch | Stop; do not retry without a fresh inspect |
+| Failed validation | Record the failed command and stop merge or publish |
+| Top split branch differs from source | Stop before PR creation and report remaining diff |
+
+## Output Format
+
+Report:
+
+1. Stack order with branch, parent, PR number or URL, and state.
+2. Mutations performed, including PR creation, base edits, rebases, pushes, merges, or branch deletion.
+3. Validation commands and exact pass/fail status.
+4. Next safe action, usually merge root PR, fix validation, resolve conflict, or provide explicit branch order.

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -1,0 +1,124 @@
+cases:
+  - id: create_three_branch_stack
+    prompt: "Create stacked PRs for feat/parser-core, feat/parser-cache, and feat/parser-cli based on main."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "publishes each branch against its parent branch"
+      - "checks for dirty worktree before PR creation or push"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh pr create[\\s\\S]*--base"
+        weight: 1.0
+      - type: matches_regex
+        target: "(feat/parser-core.*main|main.*feat/parser-core)"
+        weight: 0.8
+      - type: matches_regex
+        target: "git status --porcelain"
+        weight: 0.8
+
+  - id: split_single_branch_stack
+    prompt: "Split feat/parser-system into stacked PRs for core, cache, and CLI, then validate and publish the stack."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "inspects source branch relative to base"
+      - "uses conservative split modes and verifies leaf equivalence before publishing"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "git log --oneline --reverse"
+        weight: 0.8
+      - type: matches_regex
+        target: "(commit-range|commit-list|patch-guided|refuse)"
+        weight: 1.0
+      - type: matches_regex
+        target: "git diff --exit-code"
+        weight: 0.8
+
+  - id: sync_stack_after_main_moves
+    prompt: "Sync my PR stack after main moved and push the rebased stack safely."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "fetches current remote state before rebasing"
+      - "uses force-with-lease for rewritten stack branches"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "git fetch origin --prune"
+        weight: 0.8
+      - type: matches_regex
+        target: "git rebase"
+        weight: 0.8
+      - type: matches_regex
+        target: "--force-with-lease"
+        weight: 1.0
+
+  - id: merge_stack_bottom_up
+    prompt: "Merge the stack once checks pass, then clean up the branches."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "merges root PR before children"
+      - "retargets each child after the parent lands"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(root|parent).*(merge|PR)"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh pr merge"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh pr edit[\\s\\S]*--base"
+        weight: 0.8
+
+  - id: retarget_existing_stack
+    prompt: "Retarget the child PRs so each PR points at the correct parent branch in the stack."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "inspects existing provider PR bases"
+      - "uses provider edit operation instead of recreating PRs"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh pr list"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh pr edit[\\s\\S]*--base"
+        weight: 1.0
+
+  - id: validate_stack_slices
+    prompt: "Validate every slice in this stacked PR sequence and update the PR bodies with what ran."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "validates stack slices rather than only the leaf"
+      - "records exact validation commands"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(validate|validation).*(branch|slice|stack)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(PR body|Validation)"
+        weight: 0.8
+
+  - id: negative_single_pr
+    prompt: "Open a normal PR for my current branch against main."
+    fixtures: []
+    rubric:
+      - "normal one-branch PR creation belongs to the standard PR workflow"
+      - "does not activate stacked-prs"
+    trigger_expected: false
+
+  - id: negative_git_rebase_tutorial
+    prompt: "Explain how Git rebase works with a simple example."
+    fixtures: []
+    rubric:
+      - "general Git education is not a stacked PR workflow"
+      - "does not activate stacked-prs"
+    trigger_expected: false

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -1,0 +1,51 @@
+# Merge Discipline
+
+Stacked PRs land bottom-up from the base perspective: merge the root PR first, then the next child, then the leaf.
+
+## Rules
+
+- Require parent PR checks before merging a child.
+- Merge only one stack PR at a time.
+- After each merge, fetch, rebase the next child onto the updated base, push with lease, and retarget the child PR.
+- Delete remote branches only through provider-confirmed merge or explicit cleanup.
+- Delete local branches only when `git branch --merged <base>` proves they are merged.
+
+## Root Merge
+
+```bash
+gh pr merge <root-pr> --merge --delete-branch
+git fetch origin --prune
+```
+
+## Promote Next Child
+
+```bash
+git switch <child-branch>
+git rebase origin/main
+git push --force-with-lease origin <child-branch>
+gh pr edit <child-pr> --base main
+```
+
+Then validate and merge that child.
+
+## Cleanup
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch --prune origin
+git branch --merged main
+git branch -d <merged-stack-branch>
+```
+
+Never use `git branch -D` for stack cleanup unless the user explicitly asks to delete an unmerged branch after reviewing the risk.
+
+## Stop Conditions
+
+- Parent PR is not merged.
+- Required checks are failing or pending.
+- Provider reports branch protection failure.
+- Rebase conflict occurs after parent merge.
+- Local branch is not listed by `git branch --merged <base>`.
+
+Report the stopped branch and next safe command.

--- a/skills/stacked-prs/references/metadata-format.md
+++ b/skills/stacked-prs/references/metadata-format.md
@@ -1,0 +1,44 @@
+# Metadata Format
+
+`.stack-prs.yaml` is optional. Use it only when stack inference is ambiguous or the team wants durable topology.
+
+## Schema
+
+```yaml
+base: main
+provider: github
+branches:
+  - name: feat/parser-core
+    parent: main
+    pr_title: "feat(parser): add core parser API"
+  - name: feat/parser-cache
+    parent: feat/parser-core
+    pr_title: "feat(parser): add parser cache"
+  - name: feat/parser-cli
+    parent: feat/parser-cache
+    pr_title: "feat(parser): expose parser CLI"
+```
+
+## Required Fields
+
+| Field | Required | Rule |
+| --- | --- | --- |
+| `base` | yes | Default branch or explicit base branch |
+| `provider` | no | Defaults from remote URL when omitted |
+| `branches` | yes | Non-empty ordered list |
+| `branches[*].name` | yes | Local branch name |
+| `branches[*].parent` | yes | Base branch or previous stack branch |
+| `branches[*].pr_title` | no | Provider PR title |
+
+## Validation Rules
+
+- `base` must not appear in `branches`.
+- Branch names must be unique.
+- Every `parent` must be `base` or another listed branch.
+- Exactly one branch must have `parent: <base>`.
+- The parent graph must be a single linear chain for this release.
+- Provider PR bases must match metadata; conflicting provider state stops mutation.
+
+## Commit Policy
+
+Commit `.stack-prs.yaml` only for long-running team stacks. For one-off stacks, prefer explicit branch order in the user request and avoid adding repository metadata.

--- a/skills/stacked-prs/references/provider-adapters.md
+++ b/skills/stacked-prs/references/provider-adapters.md
@@ -1,0 +1,88 @@
+# Provider Adapters
+
+Package names stay provider-neutral. Provider-specific behavior lives behind an adapter contract.
+
+## Adapter Contract
+
+| Operation | Inputs | Output |
+| --- | --- | --- |
+| `list_prs` | repository | PR number, title, head branch, base branch, state, URL |
+| `create_pr` | head branch, base branch, title, body file | PR URL and number |
+| `edit_base` | PR number, base branch | Updated PR metadata |
+| `checks` | PR number or branch | Check conclusions |
+| `merge_pr` | PR number, merge method | Merged state |
+| `delete_remote_branch` | branch | Deletion result |
+
+## GitHub Adapter
+
+Require `gh` to be installed and authenticated before provider mutation.
+
+List open PRs:
+
+```bash
+gh pr list --state open --json number,title,headRefName,baseRefName,state,url
+```
+
+Create a PR against its parent:
+
+```bash
+gh pr create \
+  --base <parent-branch> \
+  --head <branch> \
+  --title "<title>" \
+  --body-file <generated-body-file>
+```
+
+Retarget a PR:
+
+```bash
+gh pr edit <number> --base <parent-branch>
+```
+
+View checks:
+
+```bash
+gh pr checks <number>
+```
+
+Merge a root PR:
+
+```bash
+gh pr merge <number> --merge --delete-branch
+```
+
+Delete a remote branch only after provider-confirmed merge:
+
+```bash
+git push origin --delete <branch>
+```
+
+## PR Body Stack Section
+
+Every generated or updated stack PR body must include:
+
+```markdown
+## Stack
+
+Base: `main`
+
+1. `feat/parser-core` -> this PR
+2. `feat/parser-cache` -> depends on #102
+
+## Validation
+
+- `uv run pytest tests/parser`: passed
+```
+
+Regenerate the stack section after publish, sync, retarget, or merge.
+
+## Provider Stop Conditions
+
+- Provider CLI is missing or not authenticated.
+- Existing PR is closed and unmerged.
+- Provider rejects changing a PR base.
+- Required checks fail.
+- Branch protection prevents merge.
+- Provider reports branch deletion failure after merge.
+
+Do not retry by changing topology. Report the provider error and the exact command that failed.

--- a/skills/stacked-prs/references/stack-model.md
+++ b/skills/stacked-prs/references/stack-model.md
@@ -1,0 +1,65 @@
+# Stack Model
+
+A stack is an ordered set of branches where each branch depends on the branch before it.
+
+```text
+main
+  -> feat/parser-core
+      -> feat/parser-cache
+          -> feat/parser-cli
+```
+
+## Sources Of Truth
+
+Use these sources in order:
+
+1. User-supplied explicit branch order.
+2. Open PR metadata from the provider: `headRefName` and `baseRefName`.
+3. `.stack-prs.yaml` when it exists.
+4. Git ancestry only when it produces a single unambiguous parent chain.
+
+Provider PR bases beat ancestry because review diff correctness depends on the hosted base ref, not only the local merge base.
+
+## Inspection Commands
+
+```bash
+git rev-parse --show-toplevel
+git status --porcelain
+git branch --show-current
+git for-each-ref --format='%(refname:short)' refs/heads
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+gh pr list --state open --json number,title,headRefName,baseRefName,state,url
+```
+
+For candidate parent checks:
+
+```bash
+git merge-base <branch> <candidate-parent>
+git log --oneline <candidate-parent>..<branch>
+```
+
+## Required Model
+
+Represent each stack entry with:
+
+| Field | Meaning |
+| --- | --- |
+| `order` | 1-based position above the base branch |
+| `branch` | Local head branch |
+| `parent` | Base branch for review and rebase |
+| `pr_number` | Provider PR number when one exists |
+| `pr_state` | Provider state |
+| `url` | Provider PR URL |
+| `checks` | Latest known validation or provider check state |
+
+## Stop Conditions
+
+- No Git repository is detected.
+- The stack has fewer than two dependent branches and the user asked for a normal PR.
+- A requested branch does not exist locally.
+- A branch appears more than once.
+- Two candidate parents are equally plausible.
+- Provider PR metadata contradicts explicit branch order.
+- `.stack-prs.yaml` exists but fails schema validation.
+
+When parent order is ambiguous, stop and request explicit branch order. Do not invent semantic relationships from branch names.

--- a/skills/stacked-prs/references/sync-algorithm.md
+++ b/skills/stacked-prs/references/sync-algorithm.md
@@ -1,0 +1,70 @@
+# Sync Algorithm
+
+Sync rebases every stack branch onto its current parent and pushes rewritten history with a lease.
+
+## Preflight
+
+```bash
+git rev-parse --show-toplevel
+git status --porcelain
+git fetch origin --prune
+gh pr list --state open --json number,title,headRefName,baseRefName,state,url
+```
+
+Stop if the worktree is dirty or the parent chain is ambiguous.
+
+## Rebase Order
+
+Start at the root branch above the base and walk toward the leaf:
+
+```bash
+git switch <root-branch>
+git rebase <base-branch>
+git push --force-with-lease origin <root-branch>
+
+git switch <child-branch>
+git rebase <root-branch>
+git push --force-with-lease origin <child-branch>
+```
+
+Use the local parent branch after rebasing it. Do not rebase children onto stale remote refs.
+
+## Retargeting After Parent Merge
+
+When a parent lands into `main`, the child must be rebased onto `origin/main` and its PR base retargeted to `main`:
+
+```bash
+git fetch origin --prune
+git switch <child-branch>
+git rebase origin/main
+git push --force-with-lease origin <child-branch>
+gh pr edit <child-pr> --base main
+```
+
+Then repeat for the next child.
+
+## Conflict Handling
+
+On conflict:
+
+```bash
+git status --short
+git diff --name-only --diff-filter=U
+```
+
+Report the active branch, parent branch, and conflicted files. Do not continue to children. Do not auto-resolve conflicts.
+
+## Lease Failure
+
+If `--force-with-lease` fails, the remote branch changed since fetch. Stop and run a fresh inspect. Do not use plain `--force`.
+
+## Validation After Sync
+
+Run validation according to the repository's detected gates. For armory package development:
+
+```bash
+uv run python scripts/validate_evals.py
+uv run python scripts/evaluate_package.py --path skills/stacked-prs
+```
+
+Record validation results in PR bodies when provider mutation is part of the requested workflow.


### PR DESCRIPTION
## Summary

Adds a provider-neutral stacked pull request package family to armory. The branch introduces the primary `stacked-prs` skill, a thin `/stack-pr` command wrapper, a conservative `stack-guard` hook, a team-level `stack-workflow` preset, and generated manifest registrations.

The package family is designed around standard Git topology plus provider adapters. GitHub through `gh` is documented as the first adapter, but package names and workflows stay provider-neutral.

## What changed

### `skills/stacked-prs`

Adds the primary workflow skill for dependent branch stacks. It covers:

- stack inspection from local branches, PR base refs, explicit branch order, and optional `.stack-prs.yaml`
- publishing PRs against parent branches with generated stack sections in PR bodies
- syncing stacks parent-to-child with `git rebase` and `git push --force-with-lease`
- validating stack slices and recording exact commands in PR bodies
- merging root-to-leaf with child retargeting after each parent lands
- cleaning up only branches confirmed merged
- splitting one source branch into ordered stack branches using conservative commit-range, commit-list, or user-approved patch-guided modes

Reference docs added under `skills/stacked-prs/references/`:

- `stack-model.md`
- `provider-adapters.md`
- `sync-algorithm.md`
- `merge-discipline.md`
- `metadata-format.md`

Eval coverage includes stacked PR creation, source-branch splitting, sync after base movement, bottom-up merge, retargeting, validation, and negative cases for normal PRs and generic rebase explanation.

### `commands/stack-pr`

Adds a slash-command surface that delegates to `skills/stacked-prs` instead of duplicating workflow logic.

Supported subcommands:

- `/stack-pr inspect`
- `/stack-pr split`
- `/stack-pr publish`
- `/stack-pr sync`
- `/stack-pr validate`
- `/stack-pr merge`
- `/stack-pr cleanup`

The command accepts positional branch order for ergonomics and treats that order as authoritative when provided. Eval coverage exercises split, publish, sync, validation, and negative non-stack workflows.

### `hooks/stack-guard`

Adds a PreToolUse Bash hook for stack-specific guardrails:

- blocks plain `git push --force` and `git push -f`
- allows `git push --force-with-lease`
- warns when `.stack-prs.yaml` declares a parent but `gh pr create` targets another base
- warns when pushing a child branch whose declared parent has no remote ref or unpushed commits
- warns before `gh pr merge` when stack metadata exists so agents verify parent-first merge order

The hook intentionally warns, rather than blocks, on topology concerns in the first version. Destructive plain force push is the only blocked stack-specific operation.

### `presets/stack-workflow`

Adds a preset for teams that regularly use dependent PR chains. It composes:

- `skills/stacked-prs`
- `commands/stack-pr`
- `hooks/git-protection`
- `hooks/stack-guard`
- `skills/pre-landing-review`
- `skills/pr-review`

The preset documents that it installs packages only. It does not create `.stack-prs.yaml`, branches, PRs, or repo metadata by itself.

### Manifest integration

Regenerated `manifest.yaml` so the new packages are discoverable:

- `stacked-prs`
- `stack-pr`
- `stack-guard`
- `stack-workflow`

## Design notes

- Package identity stays provider-neutral; GitHub is only adapter v1.
- Git topology and hosted PR base refs are treated as the operational source of truth.
- `.stack-prs.yaml` is optional and only needed for durable or ambiguous stack topology.
- Rewritten branch pushes require `--force-with-lease`.
- Merge discipline is root-to-leaf, with child rebase and retargeting after each parent lands.
- Split workflow refuses ambiguous automatic decomposition instead of inventing semantic boundaries.

## Validation

Ran these gates on the completed branch:

```text
uv run python scripts/validate_frontmatter.py
uv run python scripts/validate_references.py
uv run python scripts/validate_evals.py
uv run python scripts/evaluate_package.py --path skills/stacked-prs
uv run python scripts/evaluate_package.py --path commands/stack-pr
uv run python scripts/evaluate_package.py --path hooks/stack-guard
uv run python scripts/evaluate_package.py --path presets/stack-workflow
uv run pytest -q
```

Results:

```text
validate_frontmatter.py: passed, 130 packages
validate_references.py: passed, 130 packages
validate_evals.py: passed, 68 skills, 17 agents, 9 hooks, 5 rules, 7 commands, 3 utilities, 11 presets
skills/stacked-prs: 96/100, PASS
commands/stack-pr: 87/100, PASS
hooks/stack-guard: 87/100, PASS
presets/stack-workflow: 83/100, PASS
pytest: 408 passed
```

Additional hook smoke checks:

```text
git push --force: blocked with force-with-lease guidance
git push --force-with-lease: allowed
wrong-base gh pr create with .stack-prs.yaml: warning emitted, exit 0
```
