### PR TITLE
Fix stacked PR merge branch deletion safety

### DIFF
--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -119,7 +119,9 @@ Start at the first branch above the base and continue toward the leaf. Stop on c
 
 Validate the stack as reviewable slices. Run cheap checks on every branch when practical; run expensive full checks on the leaf when branch-by-branch validation is not reasonable. Record exactly what ran in each PR body.
 
-For this armory package implementation, use:
+Use the target repository's detected local gate and provider checks. Do not run armory package-evaluation commands when operating on another repository's stack.
+
+For this armory package implementation only, use:
 
 ```bash
 uv run python scripts/validate_evals.py
@@ -132,7 +134,9 @@ uv run python scripts/evaluate_package.py --path skills/stacked-prs
 Merge root to leaf:
 
 ```bash
-gh pr merge <root-pr> --merge --delete-branch
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
+gh pr merge <root-pr> --merge
 git fetch origin --prune
 git switch <child-branch>
 git rebase origin/main
@@ -140,7 +144,7 @@ git push --force-with-lease origin <child-branch>
 gh pr edit <child-pr> --base main
 ```
 
-Repeat for each child. Require parent checks and provider merge confirmation before moving to the next branch.
+On GitHub, do not pass `--delete-branch` while any open PR still has the branch being merged as its `baseRefName`. Deleting a parent branch that is still a child PR base can close the child PR unmerged. Repeat for each child. Require parent checks and provider merge confirmation before moving to the next branch.
 
 ### 6. Cleanup
 
@@ -155,6 +159,14 @@ git branch -d <merged-stack-branch>
 ```
 
 Delete only branches confirmed merged into the current base.
+
+Delete remote stack branches only after every stack PR has landed or been retargeted away from the branch:
+
+```bash
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<merged-stack-branch>")'
+git push origin --delete <merged-stack-branch>
+```
 
 ## Splitting One Branch Into A Stack
 
@@ -196,10 +208,23 @@ Do not publish if the leaf differs from the source branch.
 | Dirty worktree before mutation | Stop and report changed paths |
 | Ambiguous parent order | Request explicit branch order or `.stack-prs.yaml` |
 | Existing closed unmerged PR | Stop before creating replacements |
+| Closed unmerged child after parent branch deletion | Confirm the head branch and intended commit still exist, recreate the PR against `main` or the current merged parent, wait for checks, then continue |
 | Rebase or cherry-pick conflict | Stop, report branch and conflicted files, do not continue children |
 | Remote branch changed since fetch | Stop; do not retry without a fresh inspect |
 | Failed validation | Record the failed command and stop merge or publish |
 | Top split branch differs from source | Stop before PR creation and report remaining diff |
+
+## Recovery: Deleted Parent Branch Closed A Child PR
+
+Use this only when a provider closed a child PR because its base branch was deleted during stack landing.
+
+1. Confirm the closed PR is unmerged.
+2. Confirm the closed PR's base branch was deleted by the parent merge or cleanup command.
+3. Confirm the child head branch still exists on `origin`.
+4. Confirm the child head commit is the intended stack slice.
+5. Recreate the PR against `main` or the current merged parent.
+6. Wait for required checks on the recreated PR.
+7. Continue the root-to-leaf merge sequence.
 
 ## Output Format
 

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -63,6 +63,7 @@ cases:
       - "activates stacked-prs"
       - "merges root PR before children"
       - "retargets each child after the parent lands"
+      - "does not delete parent branches while child PRs still target them"
     trigger_expected: true
     assertions:
       - type: matches_regex
@@ -70,6 +71,9 @@ cases:
         weight: 0.8
       - type: matches_regex
         target: "gh pr merge"
+        weight: 0.8
+      - type: matches_regex
+        target: "baseRefName"
         weight: 0.8
       - type: matches_regex
         target: "gh pr edit[\\s\\S]*--base"

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -7,15 +7,20 @@ Stacked PRs land bottom-up from the base perspective: merge the root PR first, t
 - Require parent PR checks before merging a child.
 - Merge only one stack PR at a time.
 - After each merge, fetch, rebase the next child onto the updated base, push with lease, and retarget the child PR.
-- Delete remote branches only through provider-confirmed merge or explicit cleanup.
+- Do not delete a branch while any open PR still has that branch as its base.
+- Delete remote stack branches only during final cleanup after descendants are merged or retargeted.
 - Delete local branches only when `git branch --merged <base>` proves they are merged.
 
 ## Root Merge
 
 ```bash
-gh pr merge <root-pr> --merge --delete-branch
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
+gh pr merge <root-pr> --merge
 git fetch origin --prune
 ```
+
+If the child-base guard returns any PRs, keep the parent branch. On GitHub, deleting a branch that is still a child PR base can close the child PR unmerged.
 
 ## Promote Next Child
 
@@ -38,7 +43,27 @@ git branch --merged main
 git branch -d <merged-stack-branch>
 ```
 
+Before deleting any remote stack branch, verify no open PR still targets it:
+
+```bash
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<merged-stack-branch>")'
+git push origin --delete <merged-stack-branch>
+```
+
 Never use `git branch -D` for stack cleanup unless the user explicitly asks to delete an unmerged branch after reviewing the risk.
+
+## Recovery: Deleted Parent Branch Closed A Child PR
+
+Use this path only for the specific provider failure where a child PR was closed unmerged because its base branch disappeared.
+
+1. Confirm the closed child PR has `mergedAt: null`.
+2. Confirm the deleted branch was the closed PR's `baseRefName`.
+3. Confirm the child `headRefName` still exists on `origin`.
+4. Confirm the child head commit is still the intended stack slice.
+5. Recreate the PR against `main` or the current merged parent.
+6. Wait for required provider checks on the recreated PR.
+7. Continue root-to-leaf merging.
 
 ## Stop Conditions
 
@@ -47,5 +72,6 @@ Never use `git branch -D` for stack cleanup unless the user explicitly asks to d
 - Provider reports branch protection failure.
 - Rebase conflict occurs after parent merge.
 - Local branch is not listed by `git branch --merged <base>`.
+- A closed unmerged child PR cannot be traced to deleted-base recovery.
 
 Report the stopped branch and next safe command.

--- a/skills/stacked-prs/references/provider-adapters.md
+++ b/skills/stacked-prs/references/provider-adapters.md
@@ -45,15 +45,34 @@ View checks:
 gh pr checks <number>
 ```
 
+Watch current PR checks:
+
+```bash
+gh pr checks <number> --watch --fail-fast
+```
+
+When using `gh pr view --json statusCheckRollup`, filter results to the current head SHA. Retargeting and rebasing can leave duplicate historical check runs in rollup output.
+
+Find child PRs that still use a branch as their base:
+
+```bash
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
+```
+
 Merge a root PR:
 
 ```bash
-gh pr merge <number> --merge --delete-branch
+gh pr merge <number> --merge
 ```
 
-Delete a remote branch only after provider-confirmed merge:
+Do not use `--delete-branch` while any open PR still has the branch being merged as `baseRefName`. For GitHub stacks, branch deletion can close descendant PRs unmerged when their base branch disappears.
+
+Delete a remote stack branch only after provider-confirmed merge and after no open PR targets it as a base:
 
 ```bash
+gh pr list --state open --json number,baseRefName,headRefName \
+  --jq '.[] | select(.baseRefName == "<merged-stack-branch>")'
 git push origin --delete <branch>
 ```
 
@@ -83,6 +102,7 @@ Regenerate the stack section after publish, sync, retarget, or merge.
 - Provider rejects changing a PR base.
 - Required checks fail.
 - Branch protection prevents merge.
+- An open child PR still targets a branch selected for deletion.
 - Provider reports branch deletion failure after merge.
 
 Do not retry by changing topology. Report the provider error and the exact command that failed.

--- a/skills/stacked-prs/references/sync-algorithm.md
+++ b/skills/stacked-prs/references/sync-algorithm.md
@@ -60,10 +60,13 @@ If `--force-with-lease` fails, the remote branch changed since fetch. Stop and r
 
 ## Validation After Sync
 
-Run validation according to the repository's detected gates. For armory package development:
+Run validation according to the target repository's detected gates and required provider checks. Do not substitute armory package-evaluation commands for another repository's local gate.
+
+For armory package development only:
 
 ```bash
 uv run python scripts/validate_evals.py
+uv run python scripts/generate_manifest.py
 uv run python scripts/evaluate_package.py --path skills/stacked-prs
 ```
 


### PR DESCRIPTION
## Summary

- Prevent GitHub stacked-PR merges from deleting parent branches while child PRs still use them as `baseRefName`.
- Add explicit child-base guards before stack merge and remote branch cleanup operations.
- Document recovery for the deleted-base failure mode where GitHub closes a child PR unmerged.
- Split target-repository validation from armory package self-validation.
- Add check-watching guidance that avoids stale `statusCheckRollup` entries after retarget/rebase.
- Extend stacked-prs eval coverage so merge guidance must include the active base branch guard.

## Context

The existing stacked-prs merge recipe used:

```bash
gh pr merge <root-pr> --merge --delete-branch
```

That is unsafe for GitHub stacks when the branch being merged is still the base branch of an open child PR. If GitHub deletes that parent branch, the child PR can be closed unmerged because its base branch disappeared.

This branch changes the documented merge discipline so stack branches are retained during root-to-leaf landing and cleaned only after descendants have either landed or been retargeted away from the branch.

## Changes

### Merge safety

- Replaces intermediate `gh pr merge ... --delete-branch` guidance with `gh pr merge ... --merge`.
- Adds a GitHub child-base guard before merging or deleting stack branches:

```bash
gh pr list --state open --json number,baseRefName,headRefName \
  --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
```

- Adds explicit rule: do not delete a branch while any open PR still targets it as base.
- Moves remote stack branch deletion into final cleanup.

### Recovery guidance

- Adds a deleted-parent-branch recovery flow for the specific case where a child PR is closed unmerged because its base branch was deleted.
- Requires confirming the closed PR is unmerged, the head branch still exists, the head commit is still the intended stack slice, and the recreated PR passes checks before continuing.

### Validation guidance

- Clarifies that target repos must use their own local gates and provider checks.
- Keeps armory package commands under armory-specific self-validation only.
- Adds `gh pr checks <number> --watch --fail-fast` as the preferred current-check watch path.
- Notes that `statusCheckRollup` can include historical duplicate check runs after rebase/retarget and should be filtered to the current head SHA.

### Eval coverage

- Updates `skills/stacked-prs/evals/cases.yaml` so the merge-stack scenario expects the active base branch guard.

## Validation

Ran locally before pushing:

```bash
uv run python scripts/validate_evals.py
uv run python scripts/generate_manifest.py
uv run python scripts/evaluate_package.py --path skills/stacked-prs
git diff --check
```

Results:

- `validate_evals.py`: passed for all packages.
- `evaluate_package.py --path skills/stacked-prs`: `96/100`, `PASS`.
- `git diff --check`: passed.
