### PR TITLE
feat(rules): add intent-discipline rule package

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -85,6 +85,7 @@ The upstream repo structures prompts as Python functions returning f-strings. We
 | Porter's Five Forces / Lean Canvas / JTBD      | Standard business frameworks                                                                                            | `competitive-analyzer`, `idea-validator` |
 | OWASP Top 10                                   | [OWASP Foundation](https://owasp.org/www-project-top-ten/)                                                              | `security-reviewer`                      |
 | ADR format                                     | [joelparkerhenderson/architecture-decision-record](https://github.com/joelparkerhenderson/architecture-decision-record) | `adr-writer`                             |
+| Four-principle LLM coding guidelines           | [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876); Claude-Code packaging by [forrestchang/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) (MIT) | `intent-discipline`                      |
 
 ## Community & Research
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 130](https://img.shields.io/badge/packages-130-informational)](manifest.yaml)
+[![packages: 131](https://img.shields.io/badge/packages-131-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -194,6 +194,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | ----------------------------------------------- | ---------------------------------------------- |
 | [adaptive-thinking-control](rules/adaptive-thinking-control/) | Prompt-level control for Opus 4.7 adaptive thinking and effort-level trade-offs |
 | [commit-standards](rules/commit-standards/)     | Conventional commit format, branch naming      |
+| [intent-discipline](rules/intent-discipline/)   | Surface assumptions, minimum-viable code, surgical diffs, verifiable success criteria |
 | [test-standards](rules/test-standards/)         | Coverage thresholds, test quality requirements |
 | [security-standards](rules/security-standards/) | Secret management, input validation, auth      |
 | [token-efficiency](rules/token-efficiency/)     | Token-efficient tool usage patterns            |

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1752,6 +1752,28 @@ packages:
     - branch-naming
     category: content
     difficulty: beginner
+  - name: intent-discipline
+    version: 1.0.0
+    description: 'Behavioral guardrails keeping coding agents honest about intent, scope, and verifiability. Forces explicit
+      assumption surfacing on ambiguous requests, minimum-viable code over speculative abstractions, surgical diffs that trace
+      every changed line to the request, and conversion of imperative tasks ("fix it", "make it faster") into verifiable success
+      criteria the agent can loop against. Counters silent assumption-running, bloated abstractions, drive-by refactors, and
+      weak success criteria. Use on non-trivial dev, refactor, or review work where scope creep or misinterpreted intent would
+      be costly. Triggers on: "intent discipline", "surface assumptions", "stop overengineering", "scope creep", "surgical
+      changes", "minimum viable code", "goal-driven", "verifiable success criteria", "stay surgical", "no drive-by refactor",
+      "ambiguous request", "multiple interpretations", "push back when warranted", "Karpathy guidelines".'
+    path: rules/intent-discipline
+    source: https://github.com/Mathews-Tom/armory/blob/main/rules/intent-discipline/RULE.md
+    scope: global
+    tags:
+    - intent
+    - scope
+    - simplicity
+    - surgical-edits
+    - verifiability
+    - karpathy
+    category: development
+    difficulty: beginner
   - name: security-standards
     version: 1.0.0
     description: Defines security standards for application development including secret management (environment variables,

--- a/rules/intent-discipline/RULE.md
+++ b/rules/intent-discipline/RULE.md
@@ -1,0 +1,179 @@
+---
+name: intent-discipline
+type: rule
+description: >
+  Behavioral guardrails keeping coding agents honest about intent, scope,
+  and verifiability. Forces explicit assumption surfacing on ambiguous
+  requests, minimum-viable code over speculative abstractions, surgical
+  diffs that trace every changed line to the request, and conversion of
+  imperative tasks ("fix it", "make it faster") into verifiable success
+  criteria the agent can loop against. Counters silent assumption-running,
+  bloated abstractions, drive-by refactors, and weak success criteria.
+  Use on non-trivial dev, refactor, or review work where scope creep or
+  misinterpreted intent would be costly. Triggers on: "intent discipline",
+  "surface assumptions", "stop overengineering", "scope creep", "surgical
+  changes", "minimum viable code", "goal-driven", "verifiable success
+  criteria", "stay surgical", "no drive-by refactor", "ambiguous request",
+  "multiple interpretations", "push back when warranted", "Karpathy
+  guidelines".
+metadata:
+  version: 1.0.0
+  scope: global
+  applies_to:
+    languages: ["*"]
+  category: development
+  tags: [intent, scope, simplicity, surgical-edits, verifiability, karpathy]
+  difficulty: beginner
+---
+
+# Intent Discipline
+
+Behavioral guardrails for coding agents to honor user intent over agent ambition. Counters four failure modes documented in [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls: silent assumption-running, bloated abstractions, drive-by refactors, and weak success criteria.
+
+**Tradeoff:** This rule biases toward caution over speed. For trivial tasks (typo fixes, one-line tweaks, obvious renames), apply judgment — not every change needs the full rigor. See [When NOT to Apply](#when-not-to-apply).
+
+## When to Use This Rule vs Related Rules
+
+| Concern                                  | Use this rule         | Use instead                                       |
+| ---------------------------------------- | --------------------- | ------------------------------------------------- |
+| Scope creep, drive-by refactors          | intent-discipline §3  | —                                                 |
+| Ambiguous user request                   | intent-discipline §1  | —                                                 |
+| Premature abstraction                    | intent-discipline §2  | —                                                 |
+| Test-first execution mechanics           | intent-discipline §4  | `test-standards` (coverage thresholds, fixtures)  |
+| Diff traceability in commit message      | intent-discipline §3  | `commit-standards` (message format, footers)      |
+| Token-efficient tool calls               | —                     | `token-efficiency`                                |
+| Reasoning depth control                  | —                     | `adaptive-thinking-control`                       |
+
+## 1. Surface Intent Before Implementation
+
+**Don't assume. Don't hide confusion. Don't pick silently.**
+
+Before writing or modifying code:
+
+- **State assumptions explicitly.** If a request leaves a decision implicit (scope, format, target, edge cases), name the assumption you would otherwise run with.
+- **Present multiple interpretations.** When a request admits more than one reasonable reading, list them with the tradeoff for each — do not pick one silently.
+- **Push back when warranted.** If a simpler approach exists, propose it before implementing the requested one. The user can still choose the original.
+- **Stop when confused.** Name what is unclear and ask. A 30-second clarifying question is cheaper than a 30-minute wrong implementation.
+
+```
+# wrong — silent assumption
+User: "Add a feature to export users"
+Agent: <writes export_all_users_to_csv_file()>
+
+# right — surfaces assumptions
+Agent: "Before implementing:
+  - Scope: all users, or filtered subset? (privacy implications)
+  - Format: file download, background job, or API endpoint?
+  - Fields: which user fields are safe to include?
+  - Volume: rough scale — affects pagination vs streaming.
+  Default I'd pick: paginated JSON API endpoint, opt-in fields.
+  Confirm or correct?"
+```
+
+**Test:** Could a senior reviewer say "you guessed wrong on X"? If yes, the assumption was implicit — surface it before coding.
+
+## 2. Minimum Viable Implementation
+
+**Write the smallest code that solves the stated problem. Nothing speculative.**
+
+- **No features beyond what was asked.** Adjacent features the user did not request stay unimplemented.
+- **No abstractions for single-use code.** Base classes, strategy patterns, config objects, and protocols for one call site are noise — inline instead. Refactor when the second call site appears, not before.
+- **No "flexibility" or "configurability" not requested.** Parameters with default values that no caller sets are dead surface area.
+- **No error handling for impossible scenarios.** Validate at system boundaries (user input, external APIs). Internal calls trust contracts.
+- **200 → 50 line test.** If the implementation runs 200 lines and could plausibly be 50, rewrite it before reporting done.
+
+```python
+# wrong — overengineered for a single use case
+class DiscountStrategy(ABC): ...
+class PercentageDiscount(DiscountStrategy): ...
+class DiscountCalculator:
+    def __init__(self, config: DiscountConfig): ...
+# 50+ lines for a multiplication.
+
+# right — solves the actual request
+def calculate_discount(amount: float, percent: float) -> float:
+    return amount * (percent / 100)
+```
+
+**Test:** Would a senior engineer say this is overcomplicated? If yes, simplify before submitting.
+
+## 3. Surgical Changes
+
+**Touch only what the request requires. Clean up only your own mess.**
+
+When editing existing code:
+
+- **No "improvement" of adjacent code, comments, or formatting.** Match the file's existing style even when it diverges from your preference.
+- **No refactoring of code that isn't broken.** If you notice unrelated dead code, weak validation, or outdated comments, mention them in the response — do not include them in the diff.
+- **No quote-style, type-hint, docstring-format, or whitespace drift.** Conventions follow the file, not global defaults.
+
+When your changes create orphans:
+
+- **Remove imports/variables/functions that YOUR changes made unused.** Pre-existing dead code stays unless explicitly asked.
+- **A pre-refactor cleanup is a separate commit, stated in advance.**
+
+**Test:** Every added, removed, or modified line in the diff traces directly to the user's request. If a line does not, it does not ship.
+
+This rule pairs with `commit-standards` (one logical change per commit) — surgical diffs make conventional commit messages honest.
+
+## 4. Verifiable Goals Over Imperatives
+
+**Convert imperative tasks into success criteria. Loop until the criteria are met.**
+
+Strong success criteria let the agent execute independently. Weak criteria ("make it work", "fix it") force re-clarification mid-execution.
+
+| Instead of...        | Convert to...                                                          |
+| -------------------- | ---------------------------------------------------------------------- |
+| "Add validation"     | "Write tests for invalid inputs (empty, oversized, malformed), then make them pass" |
+| "Fix the bug"        | "Write a test that reproduces the bug, then make it pass"              |
+| "Refactor X"         | "Confirm tests pass before and after; no public API change"            |
+| "Make it faster"     | "Reduce p95 latency on benchmark Y from N ms to ≤M ms"                 |
+| "Clean this up"      | "Reduce file LOC by ≥X% while keeping all tests green"                 |
+
+For multi-step tasks, state a brief plan with explicit verification per step:
+
+```
+1. <step>     → verify: <check that proves the step succeeded>
+2. <step>     → verify: <check>
+3. <step>     → verify: <check>
+```
+
+The verify column is non-optional. A step without verification is a step that cannot be looped on.
+
+This rule defines the framing; `test-standards` defines the test-quality bar (naming, AAA structure, coverage thresholds) and `tdd` skill defines the red-green-refactor mechanics.
+
+## When NOT to Apply
+
+Apply judgment, not the full rigor, for:
+
+- **Typo fixes, one-line tweaks, obvious renames** — surfacing assumptions is overhead with no payoff.
+- **Local exploratory edits the user will review immediately** — interactive iteration replaces upfront clarification.
+- **Throwaway scripts with no second reader** — speculative-feature checks still apply, but interpretation checks can relax.
+
+The rule applies when: the change is non-trivial, will be reviewed asynchronously, touches production code paths, or is delegated to an autonomous agent loop.
+
+## Rationalizations to Reject
+
+| Excuse                                                | Rebuttal                                                                                  |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| "I added the abstraction to make future changes easier." | Future changes have not happened. Inline now; refactor when the second call site appears. |
+| "I cleaned up the adjacent code while I was there."   | The diff is now untraceable. Move the cleanup to a separate commit or revert it.          |
+| "The user probably meant X."                          | Probably is not certainty. State the assumption explicitly; let the user confirm.         |
+| "It's only 50 extra lines."                           | Fifty lines are fifty more to review, test, and maintain. Cut them.                       |
+| "I added error handling defensively."                 | Defensively against what? If the failure mode is impossible, the handler hides bugs.      |
+| "Tests are obvious; the change is small."             | Then writing the tests is also small. Goal-driven execution needs a verification anchor.  |
+
+## Red Flags
+
+Observable patterns that indicate this rule is being violated:
+
+- Diff includes file changes the user did not name and the agent did not surface.
+- Initial response is a code block with no clarifying questions on an ambiguous request.
+- Pull request description says "also refactored X for clarity" but X was not in the scope.
+- Implementation introduces a base class, factory, or strategy pattern with one concrete implementation.
+- Task is reported "done" but the verification step is "looks good" or "should work" — no executable check.
+- Comments include "for future flexibility", "in case we need it", or "TODO: extend later".
+
+## Attribution
+
+The four principles distilled here are derived from Andrej Karpathy's [public observations](https://x.com/karpathy/status/2015883857489522876) on common LLM coding failure modes. The framework was first packaged for Claude Code by [forrestchang/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) (MIT). This armory rule adapts the principles into armory's `RULE.md` format, cross-references existing armory rules to avoid duplication, adds explicit "when NOT to apply" guidance, and tightens the rationalization and red-flag inventories.

--- a/rules/intent-discipline/evals/cases.yaml
+++ b/rules/intent-discipline/evals/cases.yaml
@@ -1,0 +1,67 @@
+cases:
+  - id: ambiguous_export_request
+    prompt: "Add a feature to export users from the system."
+    fixtures: []
+    rubric:
+      - "surfaces scope ambiguity (all users vs filtered subset)"
+      - "asks about format target (file download, API endpoint, background job)"
+      - "names privacy/field-selection assumption before implementing"
+      - "does not silently pick one interpretation and write code"
+    trigger_expected: true
+
+  - id: overengineering_single_use
+    prompt: "Write a function to apply a percentage discount to an order total."
+    fixtures: []
+    rubric:
+      - "produces a minimal function, not a class hierarchy or strategy pattern"
+      - "rejects speculative DiscountStrategy/Calculator abstractions for single use"
+      - "cites the 200-to-50-line simplicity test or equivalent"
+    trigger_expected: true
+
+  - id: drive_by_refactor_temptation
+    prompt: "Fix the off-by-one bug in the pagination helper — but the file also has inconsistent quote styles I should probably normalize."
+    fixtures: []
+    rubric:
+      - "scopes the diff to the off-by-one fix only"
+      - "advises mentioning the quote-style drift in the response but not including it in the diff"
+      - "warns that mixing the cleanup makes the diff untraceable to the bug fix"
+    trigger_expected: true
+
+  - id: imperative_to_verifiable
+    prompt: "Make the search faster."
+    fixtures: []
+    rubric:
+      - "refuses to start implementation without a concrete success criterion"
+      - "asks for a target metric (e.g., p95 latency reduction from N ms to M ms)"
+      - "offers candidate criteria (response time, throughput, perceived speed) with tradeoffs"
+    trigger_expected: true
+
+  - id: plan_with_verification_steps
+    prompt: "Walk me through how you would migrate this module to the new logging API."
+    fixtures: []
+    rubric:
+      - "produces numbered steps with explicit per-step verification"
+      - "verification entries are executable checks, not 'looks good'"
+      - "calls out cleanup of newly orphaned imports as part of the surgical-change discipline"
+    trigger_expected: true
+
+  - id: negative_typing_question
+    prompt: "Should I use list[str] or List[str] for Python type hints?"
+    fixtures: []
+    rubric:
+      - "typing convention is the domain of typing-standards, not intent-discipline"
+    trigger_expected: false
+
+  - id: negative_test_coverage_thresholds
+    prompt: "What is the minimum unit test coverage we require on new code?"
+    fixtures: []
+    rubric:
+      - "coverage thresholds belong to test-standards, not intent-discipline"
+    trigger_expected: false
+
+  - id: negative_commit_message_format
+    prompt: "What prefix should I use for a commit that adds a new endpoint?"
+    fixtures: []
+    rubric:
+      - "commit message format belongs to commit-standards, not intent-discipline"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

Adds a new `rule`-type package, `intent-discipline`, that codifies four behavioral guardrails for non-trivial coding work. It targets the failure modes where an agent runs ahead of the user's actual intent: silently picking one interpretation of an ambiguous request, over-engineering single-use code, mixing drive-by refactors into an unrelated diff, and reporting work "done" against a success criterion too weak to verify.

The rule is deliberately distilled against the existing armory rule set so it adds discipline that no current rule covers, and cross-references the rules it borders rather than restating them.

## The four guardrails

1. **Surface intent before implementation** — state assumptions, present multiple interpretations for ambiguous requests, push back when a simpler approach exists, stop and ask when confused.
2. **Minimum viable implementation** — smallest code that solves the stated problem; no speculative abstractions for single-use code; the "200 → 50 line" simplicity test.
3. **Surgical changes** — every added/removed/modified line traces to the request; no adjacent "improvements" or style drift; remove only the orphans your own change created.
4. **Verifiable goals over imperatives** — convert "fix it" / "make it faster" into executable success criteria the agent can loop against; multi-step plans carry a non-optional verify column.

## Distillation against existing rules

The rule explicitly defers instead of duplicating:

| Concern | Owned by |
| --- | --- |
| Test-first execution mechanics, coverage thresholds | `test-standards` (cross-referenced) |
| Commit message format, diff-per-commit hygiene | `commit-standards` (cross-referenced) |
| Token-efficient tool calls | `token-efficiency` (out of scope) |
| Reasoning-depth control | `adaptive-thinking-control` (out of scope) |

A `When to Use This Rule vs Related Rules` table in the rule body draws these boundaries for the reader.

## Hardening

Beyond the source framework, the rule adds:

- **When NOT to Apply** — explicit trivial-task escape hatch (typo fixes, one-line tweaks, throwaway scripts) so the caution bias does not tax simple work.
- **Rationalizations to Reject** — six common agent excuses paired with factual rebuttals.
- **Red Flags** — observable patterns indicating the rule is being violated (unrequested file changes, code-block-first responses to ambiguous prompts, single-implementation abstractions, "should work" verification).

## Changes

- `rules/intent-discipline/RULE.md` — rule definition (frontmatter description trimmed to fit the 1024-char validator ceiling; triggers span the intent / simplicity / verifiability synonym families).
- `rules/intent-discipline/evals/cases.yaml` — five positive cases (ambiguous request, over-engineering, drive-by refactor, imperative-to-verifiable, plan-with-verification) and three negative cases that disambiguate from `typing-standards`, `test-standards`, and `commit-standards`.
- `manifest.yaml` — regenerated; rule count 5 → 6, total packages 130 → 131.
- `README.md` — rule added to the Rules table; package count badge 130 → 131.
- `ATTRIBUTIONS.md` — framework origin recorded under Conceptual Inspiration.

## Commits

Two logical, bisectable commits:

- `feat(rules): add intent-discipline rule package` — rule + evals + manifest (manifest travels with the package so the rule is self-consistent and CI-valid at this commit alone).
- `docs: surface intent-discipline in catalog and attributions` — README + ATTRIBUTIONS.

## Validation

| Check | Result |
| --- | --- |
| `validate_frontmatter.py` | 131/131 packages |
| `validate_evals.py` | all 6 rules |
| `validate_references.py` | 131 packages, references intact |
| `sync_templates.py` | in sync |
| Bisect check | commit 1 alone passes all three validators |

Cursor / Codex / Gemini adapters regenerate from the rule via `generate_adapters.py` (gitignored build artifacts, not committed).

## Test plan

- [ ] CI: manifest sync + eval validation pass
- [ ] Run `package-evaluator` against `rules/intent-discipline/` — target ≥70% (Adequate), aim ≥80% (Strong)
- [ ] Confirm the Rules table renders and the package count badge reads 131