### PR TITLE
docs(stacked-prs): add durable stack provenance

### DIFF
--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -24,6 +24,7 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 | `references/sync-algorithm.md` | Rebase and force-with-lease synchronization workflow | Syncing a stack after a parent or base moves |
 | `references/merge-discipline.md` | Bottom-up merge and branch cleanup rules | Merging or closing out a stack |
 | `references/metadata-format.md` | Optional metadata schema and validation rules | `.stack-prs.yaml` exists or inference is ambiguous |
+| `references/provenance.md` | Commit-trailer stack identity, stamping, verification, merge-mode coupling | Creating, splitting, syncing, or merging any stack |
 
 ## When To Use
 
@@ -44,6 +45,9 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 - Never use plain `git push --force`; use `git push --force-with-lease origin <branch>`.
 - Merge from root to leaf. Never merge a child before its parent.
 - Do not delete unmerged stack branches without explicit user instruction.
+- Stamp `Stack-Id` and `Stack-Position` trailers on every commit the skill creates or splits; copy the ID from `.stack-prs.yaml` or mint it once when absent.
+- Verify trailers are present and consistent before merge.
+- Detect the provider merge mode before merging. Under squash-only repos, fold trailers into the squash body or stack identity is lost.
 
 ## Workflow
 
@@ -89,15 +93,23 @@ Generated PR bodies must include the stack order and validation state:
 ```markdown
 ## Stack
 
+Stack-Id: `auth-refactor-a1b2c3`
 Base: `main`
+Position: 1/3
 
 1. `feat/parser-core` -> this PR
-2. `feat/parser-cache` -> depends on #102
+2. `feat/parser-cache` -> #102
+3. `feat/parser-cli` -> #103
+
+Depends on: (none - root)
+Upstack: #102
 
 ## Validation
 
 - Pending: commands not run yet
 ```
+
+For non-root PRs, `Depends on:` lists the parent PR number. `Upstack:` lists the immediate child PR number when known.
 
 Stop when a branch has no commits beyond its parent, an existing PR is closed and unmerged, or the provider rejects base retargeting.
 
@@ -134,6 +146,9 @@ uv run python scripts/evaluate_package.py --path skills/stacked-prs
 Merge root to leaf:
 
 ```bash
+git log --format='%H %(trailers:key=Stack-Id,valueonly)' <parent>..<branch>
+gh api repos/{owner}/{repo} \
+  --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
 gh pr list --state open --json number,baseRefName,headRefName \
   --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
 gh pr merge <root-pr> --merge
@@ -144,7 +159,9 @@ git push --force-with-lease origin <child-branch>
 gh pr edit <child-pr> --base main
 ```
 
-On GitHub, do not pass `--delete-branch` while any open PR still has the branch being merged as its `baseRefName`. Deleting a parent branch that is still a child PR base can close the child PR unmerged. Repeat for each child. Require parent checks and provider merge confirmation before moving to the next branch.
+If merge commits are allowed, use `gh pr merge <pr> --merge`. If the repository is squash-only, use the squash-body path from `references/provenance.md` so the `Stack-Id` and `Stack-Position` trailers land in the squash commit body.
+
+On GitHub, do not pass `--delete-branch` while any open PR still has the branch being merged as its `baseRefName`. Deleting a parent branch that is still a child PR base can close the child PR unmerged. Repeat for each child. Require trailer verification, parent checks, and provider merge confirmation before moving to the next branch.
 
 ### 6. Cleanup
 
@@ -195,9 +212,14 @@ Select the safest split mode:
 After creating branches, compare the leaf with the source branch before publishing:
 
 ```bash
+git commit --amend --no-edit \
+  --trailer "Stack-Id: <stack-id>" \
+  --trailer "Stack-Position: <n>/<total>"
 git diff --stat <source-branch>...<leaf-branch>
 git diff --exit-code <source-branch>...<leaf-branch>
 ```
+
+Stamp trailers on each slice's commits per `references/provenance.md` before publishing. Stamping amends commit messages but does not change tree content, so the leaf-vs-source comparison remains a tree comparison with `git diff` and must still pass.
 
 Do not publish if the leaf differs from the source branch.
 
@@ -213,6 +235,9 @@ Do not publish if the leaf differs from the source branch.
 | Remote branch changed since fetch | Stop; do not retry without a fresh inspect |
 | Failed validation | Record the failed command and stop merge or publish |
 | Top split branch differs from source | Stop before PR creation and report remaining diff |
+| Commit in stack range missing `Stack-Id` trailer | Stop; stamp via provenance backfill before merge |
+| Trailer `Stack-Id` differs from `.stack-prs.yaml` | Stop; resolve canonical ID before mutation |
+| Squash-only repo without trailers folded into squash body | Stop; use the squash-body merge path |
 
 ## Recovery: Deleted Parent Branch Closed A Child PR
 

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -111,6 +111,99 @@ cases:
         target: "(PR body|Validation)"
         weight: 0.8
 
+  - id: create_stack_with_commit_trailers
+    prompt: "Create stacked PRs for feat/parser-core, feat/parser-cache, and feat/parser-cli and preserve the stack identity in git history."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "mints or reads one canonical stack id"
+      - "stamps every created stack commit with Stack-Id and Stack-Position trailers"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "Stack-Id"
+        weight: 1.0
+      - type: matches_regex
+        target: "Stack-Position"
+        weight: 1.0
+      - type: matches_regex
+        target: "(git interpret-trailers|git commit --amend --no-edit[\\s\\S]*--trailer)"
+        weight: 1.0
+
+  - id: recover_landed_stack_from_git_log
+    prompt: "After this stack lands, show me how to recover every slice from git history by stack id."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "uses Stack-Id trailers as the durable identity"
+      - "recovers stack commits with git log rather than provider metadata"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "git log --grep ['\"]Stack-Id:"
+        weight: 1.0
+      - type: matches_regex
+        target: "trailers:key=Stack-Position"
+        weight: 0.8
+
+  - id: squash_only_merge_preserves_stack_id
+    prompt: "Merge this stacked PR sequence in a repo that only allows squash merges without losing provenance."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "detects provider merge policy before merge"
+      - "folds stack trailers into the squash commit body"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh api repos/\\{owner\\}/\\{repo\\}"
+        weight: 0.8
+      - type: matches_regex
+        target: "allow_squash_merge"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh pr merge[\\s\\S]*--squash[\\s\\S]*--body[\\s\\S]*Stack-Id"
+        weight: 1.0
+
+  - id: backfill_existing_stack_trailers
+    prompt: "Backfill Stack-Id trailers onto this existing unmerged stack and prove the leaf tree still matches the original source branch."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "rewrites only unmerged stack branches"
+      - "adds trailers without altering tree content"
+      - "pushes rewritten branches with force-with-lease"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "git rebase[\\s\\S]*--exec[\\s\\S]*git commit --amend --no-edit[\\s\\S]*--trailer"
+        weight: 1.0
+      - type: matches_regex
+        target: "git diff --exit-code"
+        weight: 0.8
+      - type: matches_regex
+        target: "--force-with-lease"
+        weight: 0.8
+
+  - id: stack_id_mismatch_stops_mutation
+    prompt: "Validate this stack before merge; one commit has a Stack-Id trailer that differs from .stack-prs.yaml."
+    fixtures: []
+    rubric:
+      - "activates stacked-prs"
+      - "compares commit trailers against the canonical .stack-prs.yaml stack_id"
+      - "stops mutation when the ids differ"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "Stack-Id"
+        weight: 0.8
+      - type: matches_regex
+        target: "\\.stack-prs\\.yaml"
+        weight: 0.8
+      - type: matches_regex
+        target: "(stop|stops|do not|must not)[\\s\\S]*(mismatch|differs|different)"
+        weight: 1.0
+
   - id: negative_single_pr
     prompt: "Open a normal PR for my current branch against main."
     fixtures: []

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -14,11 +14,16 @@ Stacked PRs land bottom-up from the base perspective: merge the root PR first, t
 ## Root Merge
 
 ```bash
+git log --format='%H %(trailers:key=Stack-Id,valueonly)' <parent>..<branch>
+gh api repos/{owner}/{repo} \
+  --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
 gh pr list --state open --json number,baseRefName,headRefName \
   --jq '.[] | select(.baseRefName == "<branch-being-merged>")'
 gh pr merge <root-pr> --merge
 git fetch origin --prune
 ```
+
+Verify `Stack-Id` and `Stack-Position` trailers before each merge. Prefer `gh pr merge <pr> --merge` when merge commits are allowed. If the repository is squash-only, use the squash-body path from `references/provenance.md`; do not merge until the trailers are folded into the squash commit body.
 
 If the child-base guard returns any PRs, keep the parent branch. On GitHub, deleting a branch that is still a child PR base can close the child PR unmerged.
 
@@ -69,6 +74,8 @@ Use this path only for the specific provider failure where a child PR was closed
 
 - Parent PR is not merged.
 - Required checks are failing or pending.
+- A stack commit is missing `Stack-Id` or has a `Stack-Id` that differs from `.stack-prs.yaml`.
+- The repository is squash-only and the squash body does not include stack trailers.
 - Provider reports branch protection failure.
 - Rebase conflict occurs after parent merge.
 - Local branch is not listed by `git branch --merged <base>`.

--- a/skills/stacked-prs/references/metadata-format.md
+++ b/skills/stacked-prs/references/metadata-format.md
@@ -5,6 +5,7 @@
 ## Schema
 
 ```yaml
+stack_id: auth-refactor-a1b2c3
 base: main
 provider: github
 branches:
@@ -23,6 +24,7 @@ branches:
 
 | Field | Required | Rule |
 | --- | --- | --- |
+| `stack_id` | no | Stable slug plus random suffix, e.g. `auth-refactor-a1b2c3`. Minted once per stack. When absent, mint in-memory at creation time and stamp commits and PRs anyway. |
 | `base` | yes | Default branch or explicit base branch |
 | `provider` | no | Defaults from remote URL when omitted |
 | `branches` | yes | Non-empty ordered list |
@@ -32,12 +34,25 @@ branches:
 
 ## Validation Rules
 
+- `stack_id`, when present, must match `^[a-z0-9][a-z0-9-]*-[a-z0-9]{4,8}$` and must be identical across every commit trailer and PR body in the stack. Mismatch stops mutation.
 - `base` must not appear in `branches`.
 - Branch names must be unique.
 - Every `parent` must be `base` or another listed branch.
 - Exactly one branch must have `parent: <base>`.
 - The parent graph must be a single linear chain for this release.
 - Provider PR bases must match metadata; conflicting provider state stops mutation.
+
+## Stack Identity
+
+`stack_id` is the canonical stack identity. It is copied into:
+
+- every commit trailer (`Stack-Id`, `Stack-Position`)
+- every PR body (`Stack-Id`, `Depends on`, `Upstack`)
+
+Minting: `<purpose-slug>-<random 6-char base36>`. The slug is derived from the
+user's stated stack purpose or the base branch name; never inferred from
+unrelated branch names. The random suffix prevents collisions between stacks
+sharing a slug. Once minted, the ID is immutable for the life of the stack.
 
 ## Commit Policy
 

--- a/skills/stacked-prs/references/provenance.md
+++ b/skills/stacked-prs/references/provenance.md
@@ -1,0 +1,111 @@
+# Stack Provenance
+
+Stack identity must survive in plain git history, not only in the provider.
+Branch topology is not recoverable after a rebase-based merge; stack identity is,
+via commit trailers.
+
+## Trailers
+
+Every commit in a stack carries:
+
+```text
+Stack-Id: <slug>-<shortid>
+Stack-Position: <n>/<total>
+```
+
+Trailers live in the last paragraph of the commit message, separated from the
+body by one blank line. Because they are part of the message, they survive
+rebase, cherry-pick, and amend.
+
+## Stamping On Commit Creation
+
+When the skill itself creates commits, including split-mode cherry-picks and
+any commit it authors, append trailers with `git interpret-trailers`:
+
+```bash
+git interpret-trailers --in-place \
+  --trailer "Stack-Id: <stack-id>" \
+  --trailer "Stack-Position: <n>/<total>" \
+  <commit-msg-file>
+```
+
+For an existing commit that needs trailers added during split:
+
+```bash
+git commit --amend --no-edit \
+  --trailer "Stack-Id: <stack-id>" \
+  --trailer "Stack-Position: <n>/<total>"
+```
+
+`git commit --trailer` requires Git >= 2.32. If unavailable, pipe the message
+through `git interpret-trailers` and amend with `-F`.
+
+## Backfilling An Existing Stack
+
+To stamp a stack that was created before provenance existed, rewrite each
+branch's commit range that is unique to that branch above its parent, adding
+trailers without changing tree content:
+
+```bash
+git rebase <parent> <branch> \
+  --exec 'git commit --amend --no-edit \
+    --trailer "Stack-Id: <stack-id>" \
+    --trailer "Stack-Position: <n>/<total>"'
+```
+
+This is history-rewriting. Apply only to unmerged stack branches, then
+force-with-lease push. Never backfill commits already merged into the base.
+
+## Verifying Trailers
+
+Before merge, confirm every commit unique to each branch carries the correct
+trailers:
+
+```bash
+git log --format='%H %(trailers:key=Stack-Id,valueonly)' <parent>..<branch>
+```
+
+Stop if any commit in the range is missing `Stack-Id` or carries a different ID
+than `.stack-prs.yaml`.
+
+## Recovering A Stack From History
+
+After the stack has landed:
+
+```bash
+git log --grep 'Stack-Id: <stack-id>' --oneline
+git log --grep 'Stack-Id: <stack-id>' \
+  --format='%(trailers:key=Stack-Position,valueonly) %h %s' | sort
+```
+
+## Merge Mode Coupling
+
+Trailer survival depends on merge mode:
+
+| Merge mode | Commit messages | Trailers survive |
+| --- | --- | --- |
+| `gh pr merge --merge` | Original commits preserved | Yes, automatically |
+| `gh pr merge --rebase` | Original commits replayed | Yes, automatically |
+| `gh pr merge --squash` | Messages collapsed and rewritten | No, unless folded into squash body |
+
+The documented merge path uses `--merge`, so trailers survive as-is. If a
+target repo enforces squash merges, inject the trailers into the squash commit
+body because GitHub's squash default discards per-commit messages:
+
+```bash
+gh pr merge <pr> --squash \
+  --subject "<pr-title>" \
+  --body "$(printf '%s\n\n%s\n%s' \
+    '<pr-summary>' \
+    'Stack-Id: <stack-id>' \
+    'Stack-Position: <n>/<total>')"
+```
+
+Detect the repo's merge policy before merging:
+
+```bash
+gh api repos/{owner}/{repo} \
+  --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
+```
+
+If only squash is allowed, take the squash-body path. Otherwise prefer `--merge`.

--- a/skills/stacked-prs/references/provider-adapters.md
+++ b/skills/stacked-prs/references/provider-adapters.md
@@ -63,8 +63,12 @@ gh pr list --state open --json number,baseRefName,headRefName \
 Merge a root PR:
 
 ```bash
+gh api repos/{owner}/{repo} \
+  --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
 gh pr merge <number> --merge
 ```
+
+Prefer `--merge` when merge commits are allowed. If the repository is squash-only, use the squash-body merge path in `references/provenance.md` so `Stack-Id` and `Stack-Position` survive in history.
 
 Do not use `--delete-branch` while any open PR still has the branch being merged as `baseRefName`. For GitHub stacks, branch deletion can close descendant PRs unmerged when their base branch disappears.
 
@@ -83,10 +87,16 @@ Every generated or updated stack PR body must include:
 ```markdown
 ## Stack
 
+Stack-Id: `auth-refactor-a1b2c3`
 Base: `main`
+Position: 1/3
 
 1. `feat/parser-core` -> this PR
-2. `feat/parser-cache` -> depends on #102
+2. `feat/parser-cache` -> #102
+3. `feat/parser-cli` -> #103
+
+Depends on: (none - root)
+Upstack: #102
 
 ## Validation
 


### PR DESCRIPTION
## Summary

Adds durable stack identity guidance to the `stacked-prs` skill so stack membership survives after rebase-based landing and branch cleanup. The branch documents `Stack-Id` and `Stack-Position` commit trailers, wires that identity into PR body metadata, and adds eval coverage for the provenance-critical paths.

## Changes

- Documented `.stack-prs.yaml` `stack_id` as the canonical stack identity, including format validation and mismatch stop behavior.
- Added `references/provenance.md` with trailer stamping, existing-stack backfill, pre-merge verification, post-merge recovery, and merge-mode coupling.
- Updated `SKILL.md` core rules to require trailer stamping for created/split commits, trailer verification before merge, and merge-mode detection.
- Extended the generated PR body template with `Stack-Id`, `Position`, `Depends on`, and `Upstack` metadata.
- Updated split-mode guidance to stamp trailers before the leaf-vs-source tree comparison and clarify that message-only amendments do not affect `git diff` equivalence checks.
- Updated merge guidance to check GitHub merge policy and use the squash-body preservation path when only squash merges are available.
- Aligned `provider-adapters.md` and `merge-discipline.md` with the new provenance and squash-only handling.
- Added eval cases for trailer stamping, history recovery with `git log --grep`, squash-only provenance preservation, backfilling unmerged stacks without tree drift, and stack-id mismatch stop behavior.

## Validation

- `uv run python scripts/validate_evals.py`
- `uv run python scripts/generate_manifest.py`
- `uv run python scripts/evaluate_package.py --path skills/stacked-prs`
- `git diff --check`

## Notes

No runtime dependencies were added. This is a documentation and eval update scoped to `skills/stacked-prs/`. The generated manifest command was run and produced no committed manifest diff.