### PR TITLE
feat(skills): add planning and milestone runner skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 133](https://img.shields.io/badge/packages-133-informational)](manifest.yaml)
+[![packages: 134](https://img.shields.io/badge/packages-134-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -67,6 +67,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [debug-investigator](skills/debug-investigator/) | Systematic debugging framework — hypothesis-driven investigation with bisection, log analysis, instrumentation, and minimal reproduction                    |
 | [project-context-setup](skills/project-context-setup/) | Scaffold repo-local agent context — issue tracker rules, triage labels, domain glossary layout, ADR lookup, agent brief conventions                  |
 | [stacked-prs](skills/stacked-prs/)               | Manage dependent branch stacks and stacked pull requests — inspect, split, publish, sync, validate, merge, and clean up stack topology                      |
+| [plan-prompts](skills/plan-prompts/)             | Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from source docs, with reviewed stacked-PR prompts |
 | [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub                        |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 134](https://img.shields.io/badge/packages-134-informational)](manifest.yaml)
+[![packages: 135](https://img.shields.io/badge/packages-135-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -68,6 +68,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [project-context-setup](skills/project-context-setup/) | Scaffold repo-local agent context — issue tracker rules, triage labels, domain glossary layout, ADR lookup, agent brief conventions                  |
 | [stacked-prs](skills/stacked-prs/)               | Manage dependent branch stacks and stacked pull requests — inspect, split, publish, sync, validate, merge, and clean up stack topology                      |
 | [plan-prompts](skills/plan-prompts/)             | Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from source docs, with reviewed stacked-PR prompts |
+| [milestone-runner](skills/milestone-runner/)     | Run `.docs/EXECUTION_PROMPTS.md` milestone stacks sequentially or in dependency-safe parallel waves, with CI/review gates and cleanup |
 | [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub                        |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -839,6 +839,29 @@ packages:
     category: research
     difficulty: advanced
     phase: build
+  - name: plan-prompts
+    version: 1.0.0
+    description: Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture,
+      or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate
+      execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md",
+      "plan implementation from .docs", "create milestone execution prompts", "convert architecture docs into stacked PR prompts",
+      or when given DOCS_DIR / REPO_CONTEXT / GLOBAL_CONSTRAINTS / STACK_DEPTH_HINT placeholders. NOT for auditing an existing
+      plan; use plan-review. NOT for executing the stack; use stacked-prs.
+    path: skills/plan-prompts
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/plan-prompts/SKILL.md
+    complements:
+    - stacked-prs
+    - plan-review
+    - task-decomposer
+    tags:
+    - planning
+    - execution-prompts
+    - milestones
+    - stacked-prs
+    - docs
+    category: development
+    difficulty: advanced
+    phase: plan
   - name: plan-review
     version: 1.0.1
     description: 'Pre-implementation plan audit stress-testing scope, assumptions, risks, and failure modes before code is
@@ -853,6 +876,8 @@ packages:
     - assumptions
     category: review
     difficulty: intermediate
+    complements:
+    - plan-prompts
   - name: pr-review
     version: 1.1.1
     description: 'Diff-based PR review across code quality, test coverage, silent failures, type design, and comment quality
@@ -1096,6 +1121,8 @@ packages:
     category: development
     difficulty: advanced
     phase: ship
+    complements:
+    - plan-prompts
   - name: static-web-artifacts-builder
     version: 1.1.1
     description: 'Build self-contained static HTML artifacts opened in a browser: interactive diagrams, dashboards, infographics.
@@ -1144,6 +1171,8 @@ packages:
     category: development
     difficulty: intermediate
     phase: plan
+    complements:
+    - plan-prompts
   - name: tavily
     version: 1.1.1
     description: 'AI-optimized web search via Tavily API when no URL is provided. Returns clean AI-ready snippets for current

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -776,6 +776,28 @@ packages:
     category: review
     difficulty: advanced
     phase: review
+  - name: milestone-runner
+    version: 1.0.0
+    description: Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel
+      when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run
+      the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue
+      the milestone sequence", "merge the stack", or "ensure CI is green and clean branches". NOT for generating plan files;
+      use plan-prompts. NOT for repairing one existing stack; use stacked-prs.
+    path: skills/milestone-runner
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/milestone-runner/SKILL.md
+    complements:
+    - plan-prompts
+    - stacked-prs
+    - ship-workflow
+    tags:
+    - milestones
+    - orchestration
+    - stacked-prs
+    - ci
+    - execution-prompts
+    category: development
+    difficulty: advanced
+    phase: ship
   - name: notebooklm
     version: 1.1.1
     description: 'Full NotebookLM API via notebooklm-py CLI: create notebooks, add sources, generate podcasts, videos, infographics,
@@ -853,6 +875,7 @@ packages:
     - stacked-prs
     - plan-review
     - task-decomposer
+    - milestone-runner
     tags:
     - planning
     - execution-prompts
@@ -1058,6 +1081,8 @@ packages:
     category: review
     difficulty: intermediate
     phase: ship
+    complements:
+    - milestone-runner
   - name: skill-distiller
     version: 1.0.1
     description: 'Converts Opus-quality skills into deterministic Haiku-executable workflows via trace-driven distillation
@@ -1122,6 +1147,7 @@ packages:
     difficulty: advanced
     phase: ship
     complements:
+    - milestone-runner
     - plan-prompts
   - name: static-web-artifacts-builder
     version: 1.1.1

--- a/skills/milestone-runner/SKILL.md
+++ b/skills/milestone-runner/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: milestone-runner
+description: 'Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue the milestone sequence", "merge the stack", or "ensure CI is green and clean branches". NOT for generating plan files; use plan-prompts. NOT for repairing one existing stack; use stacked-prs.'
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [milestones, orchestration, stacked-prs, ci, execution-prompts]
+  difficulty: advanced
+  phase: ship
+  complements:
+    - plan-prompts
+    - stacked-prs
+    - ship-workflow
+---
+
+# Milestone Runner
+
+Run milestone prompts produced by `plan-prompts` from `.docs/EXECUTION_PROMPTS.md`. The skill coordinates execution order, isolation, verification, CI checks, review gates, and optional stack merge/cleanup.
+
+This skill executes existing milestone prompts. It does not generate `DEVELOPMENT_PLAN.md` or `EXECUTION_PROMPTS.md`; use `plan-prompts` for that. It does not replace `stacked-prs`; it invokes that workflow when a stack must be validated, merged, retargeted, or cleaned.
+
+## Core model
+
+Milestone prompts are designed to stop at "PR stack open, checks green, reviewed, ready for human review." That is intentional. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when external state proves it.
+
+| Evidence | Use |
+| --- | --- |
+| `.docs/DEVELOPMENT_PLAN.md` dependency rows | Build the milestone DAG. |
+| `.docs/EXECUTION_PROMPTS.md` `/goal` blocks | Exact executable prompt text. |
+| Git branch/worktree state | Ensure isolated runs do not share an index or branch. |
+| Provider PR metadata | Confirm PRs exist and are based correctly. |
+| CI/check provider state | Confirm each PR is green before merge or handoff. |
+| Milestone verification commands | Confirm behavior after the stack is built and again after merge when continuing. |
+
+## Modes
+
+| Mode | Trigger | Behavior |
+| --- | --- | --- |
+| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, then stop for review/merge unless the user explicitly asked to continue after observed merge. |
+| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any failure. |
+| Resume | "continue the milestone sequence" | Read prior state, observe which milestone stacks are merged, then launch the next dependency-ready milestone or wave. |
+| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Use stacked-PR merge discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches. |
+
+Default to sequential build when the user does not explicitly request parallel execution. Default to human-review stop points; do not merge unless the user explicitly requests merge/cleanup.
+
+## Workflow
+
+### 1. Inspect inputs
+
+1. Read `.docs/EXECUTION_PROMPTS.md` and extract each milestone heading plus the fenced `/goal` block that follows it.
+2. Read `.docs/DEVELOPMENT_PLAN.md` when present and extract `Depends on` rows. Use these dependencies to build the DAG.
+3. If the plan is missing or dependency rows are ambiguous, fall back to file order and treat milestones as sequential unless the prompt text explicitly says they are independent.
+4. Confirm the worktree is clean before launching, merging, rebasing, or cleanup. Stop on dirty state unless the user only asked for inspection.
+5. Confirm the current branch/base context. Do not run milestone work on an unrelated dirty branch.
+
+### 2. Build the execution DAG
+
+Create a table before launching work:
+
+| Milestone | Depends on | Status | Runnable now | Execution lane |
+| --- | --- | --- | --- | --- |
+| M1 | none | pending | yes | wave-1 |
+| M2 | M1 | blocked | no | wave-2 |
+
+Rules:
+
+- A milestone with unmerged dependencies is blocked.
+- Milestones with no dependencies between them can share a wave.
+- Parallel wave members must run in separate git worktrees and separate headless sessions.
+- If two independent milestones touch the same files, prefer sequential execution unless the user accepts conflict risk.
+
+### 3. Launch milestone work
+
+Use a fresh top-level session per milestone. Do not use same-context subagents for milestone implementation; shared context and a shared checkout can hide ordering bugs.
+
+Preferred headless shape for omp environments:
+
+```bash
+omp -p --profile <run-name> --auto-approve --mode json --max-time <seconds> "<milestone /goal block>"
+```
+
+Isolation rules:
+
+1. Sequential mode can use the main checkout when the tree is clean.
+2. Parallel mode must create one worktree per milestone from the correct base.
+3. Name worktrees and temporary run branches with milestone IDs and a short slug; avoid branch names that imply chronology beyond the dependency DAG.
+4. Capture each run's final output, PR URLs, branch names, and verification output.
+
+### 4. Verify before advancing
+
+Treat runner output as a hint. Verify with external state:
+
+| Gate | Requirement |
+| --- | --- |
+| PR existence | Expected PR stack exists. |
+| PR bases | Root PR targets the intended base; child PRs target the previous PR branch. |
+| Checks | CI/checks are green or pending state is explicitly reported and treated as not done. |
+| Verification | Milestone `VERIFICATION` commands pass with expected output. |
+| Review | Generated prompt's per-PR and whole-stack review criteria are complete. |
+| Cleanliness | No accidental dirty files remain in the worktree. |
+
+If any gate fails, stop the sequence. Report the failure, the last safe state, and the next required human/agent action. Do not launch downstream milestones on a broken base.
+
+### 5. Merge and continue
+
+Only merge when the user explicitly asks. Use the `stacked-prs` skill for stack topology and merge discipline.
+
+Safe merge loop:
+
+1. Verify PR order, branch bases, and CI/check state.
+2. Merge root PR first.
+3. Fetch and update local state.
+4. Rebase or retarget the child PR onto the new base according to the stack workflow.
+5. Re-run checks before merging the next PR.
+6. After the final PR merges, clean merged local and remote branches.
+7. Re-run the milestone verification commands on the merged base before launching dependent milestones.
+
+If the user wants to preserve the human review gate, stop after reporting the stack as ready and wait for observed merge before continuing.
+
+## Output Format
+
+For inspection or launch planning, output:
+
+```text
+## Milestone Runner Plan
+
+| Milestone | Depends on | Mode | Worktree/Profile | Status |
+| --- | --- | --- | --- | --- |
+
+## Launches
+- M1: <command/session/worktree summary>
+
+## Gates
+- PR bases: <pass/fail/pending>
+- CI: <pass/fail/pending>
+- Verification: <pass/fail/pending>
+- Review: <pass/fail/pending>
+
+## Stop/Continue Decision
+<Continue to next ready milestone | Stop for human review | Stop on failure | Merge requested and complete>
+```
+
+For merge-and-clean requests, output:
+
+```text
+## Merge Result
+
+| PR | Branch | Base | CI before merge | Merge result | Cleanup |
+| --- | --- | --- | --- | --- | --- |
+
+## Remaining State
+- Open PRs:
+- Local branches:
+- Remote branches:
+- Verification after merge:
+```
+
+## Error handling
+
+| Problem | Resolution |
+| --- | --- |
+| Missing `.docs/EXECUTION_PROMPTS.md` | Stop; ask for the prompt file or run `plan-prompts` first. |
+| Ambiguous dependency graph | Use sequential execution unless the user explicitly authorizes parallel conflict risk. |
+| Dirty worktree | Stop before launching, merging, rebasing, or cleanup. |
+| Parallel run file overlap | Prefer sequential execution; parallel only with explicit approval. |
+| Headless command unavailable | Fall back to manual copy/paste execution guidance and preserve the same gates. |
+| A milestone fails | Stop all downstream work, report failed gate, leave worktrees/branches intact for debugging. |
+| CI pending | Treat as not complete; wait or stop with pending status. |
+| Merge conflict | Stop and invoke stack conflict resolution; do not continue to downstream milestones. |
+| User asks to merge without green checks | Refuse the merge and report failing checks. |
+
+## Safety checklist
+
+Before yielding:
+
+- Every launched milestone has an observed state: pending, running, ready for review, merged, or failed.
+- No downstream milestone launched before its dependencies were externally observed as merged.
+- Parallel milestones used isolated worktrees/sessions.
+- Merge happened only after explicit user request.
+- CI and verification evidence is reported exactly, not inferred from agent self-report.
+- Local/remote cleanup only removed branches verified as merged.

--- a/skills/milestone-runner/evals/cases.yaml
+++ b/skills/milestone-runner/evals/cases.yaml
@@ -1,0 +1,79 @@
+cases:
+  - id: sequential_milestone_execution
+    prompt: >
+      Run the milestone prompts in .docs/EXECUTION_PROMPTS.md one after another. Stop after each milestone stack is open, reviewed, and green so I can decide whether to merge before continuing.
+    fixtures: []
+    rubric:
+      - "parses EXECUTION_PROMPTS.md and identifies milestone /goal blocks"
+      - "runs dependent milestones sequentially rather than launching the whole file blindly"
+      - "uses external gates such as PR state, CI, verification commands, and review status before advancing"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(EXECUTION_PROMPTS\\.md|/goal|milestone)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(sequential|one after another|dependency|Depends on)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(CI|checks|verification|PR state|review)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(stop|halt|human review|merge before continuing)"
+        weight: 0.7
+
+  - id: parallel_independent_milestones
+    prompt: >
+      The plan has M2 and M3 with no dependency between them. Run the independent milestone prompts in parallel, but keep the runs isolated and stop the sequence if either one fails.
+    fixtures: []
+    rubric:
+      - "detects independent milestones from the dependency graph"
+      - "uses isolated worktrees or sessions for concurrent runs"
+      - "halts downstream work if any parallel lane fails"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(independent|parallel|wave|dependency graph|DAG)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(worktree|isolated|separate session|profile)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(fail|halt|stop|downstream)"
+        weight: 0.7
+
+  - id: merge_stack_and_cleanup
+    prompt: >
+      Let's merge the stack for the current milestone. Ensure CI is green for each PR. Once done, clean up all local and remote merged branches.
+    fixtures: []
+    rubric:
+      - "routes merge-and-clean workflow through stacked PR discipline"
+      - "requires green CI/checks before each merge"
+      - "cleans only branches verified as merged"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(merge root|root-to-leaf|stacked-prs|stack order)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(CI|checks|green)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(clean|cleanup|local.*remote|merged branches)"
+        weight: 0.7
+
+  - id: negative_generate_plan_prompts
+    prompt: >
+      Create DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md from the documents in docs/ and save them in .docs.
+    fixtures: []
+    rubric:
+      - "generating plan and prompt files is plan-prompts territory"
+    trigger_expected: false
+
+  - id: negative_single_stack_repair
+    prompt: >
+      This existing stacked PR chain has the wrong base on PR #42. Fix the branch topology and retarget the child PR.
+    fixtures: []
+    rubric:
+      - "repairing one existing stack is stacked-prs territory, not milestone orchestration"
+    trigger_expected: false

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: plan-prompts
+description: 'Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture, or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md", "plan implementation from .docs", "create milestone execution prompts", "convert architecture docs into stacked PR prompts", or when given DOCS_DIR / REPO_CONTEXT / GLOBAL_CONSTRAINTS / STACK_DEPTH_HINT placeholders. NOT for auditing an existing plan; use plan-review. NOT for executing the stack; use stacked-prs.'
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [planning, execution-prompts, milestones, stacked-prs, docs]
+  difficulty: advanced
+  phase: plan
+  complements:
+    - stacked-prs
+    - plan-review
+    - task-decomposer
+---
+
+# Development Plan and Execution Prompts
+
+Convert source documents into two standalone Markdown files:
+
+- `.docs/DEVELOPMENT_PLAN.md` — milestone plan with source traceability, dependencies, acceptance, verification, risks, and rollback notes.
+- `.docs/EXECUTION_PROMPTS.md` — one copy-paste `/goal` block per milestone that drives a reviewed stacked-PR implementation.
+
+This skill plans from documents only. Do not implement product code, create branches, open PRs, or execute the generated prompts.
+
+## Inputs
+
+Accept either input shape:
+
+| Input shape | Meaning |
+| --- | --- |
+| Folder path | Recursively ingest every supported document in that folder. |
+| Explicit file list | Ingest listed files only; treat the first file as the primary source of truth. |
+
+Optional context:
+
+| Field | Meaning | Default |
+| --- | --- | --- |
+| `REPO_CONTEXT` | Target repo path or description; use actual repo structure, tooling, CI, and style when a path exists. | Greenfield planning if absent. |
+| `GLOBAL_CONSTRAINTS` | Cross-cutting constraints not present in source docs: compliance, dependency policy, deadlines, perf budgets. | None. |
+| `STACK_DEPTH_HINT` | Maximum PRs per milestone stack. | 6. |
+
+## Workflow
+
+### Phase 0 — Ingest and ground the plan
+
+1. Inventory every capability, contract, data model, integration, workflow, and non-functional requirement in the source docs.
+2. Preserve source order, but resolve authority by input shape: explicit file list order wins; otherwise newer or more specific design docs refine broader overview docs.
+3. Build a traceability table from source references to planned capabilities. Use document paths plus section names or line ranges when available.
+4. Record `> ASSUMPTION:` for defensible defaults where docs are silent.
+5. Record `> GAP:` for missing, ambiguous, or contradictory requirements. Contradictions that change architecture, data semantics, security posture, or acceptance block file creation until resolved.
+6. Map dependencies between capabilities. Dependencies must be implementation-relevant, not topical adjacency.
+7. Inspect the target repo when available: CI workflows, package manager, test runner, type checker, linter, existing test naming, existing partial implementations, and repository conventions. Copy exact verification commands from the repo's own config or CI when possible.
+8. If the repo is greenfield, make M1 establish the minimal skeleton and verification surface needed for later milestones to be testable.
+
+Summarize Phase 0 in the chat response only. Do not duplicate the full ingest inventory inside the generated files.
+
+### Phase 1 — Write `.docs/DEVELOPMENT_PLAN.md`
+
+Create `.docs` if it does not exist. Write a standalone plan with this structure:
+
+```markdown
+# Development Plan — <System>
+
+## 1. Context & Source Map
+<2–4 sentences, then a table mapping plan sections and milestone groups to source documents/sections.>
+
+## 2. Assumptions & Gaps
+<Visible `> ASSUMPTION:` and `> GAP:` entries, or "None.">
+
+## 3. Dependency Graph
+```mermaid
+graph TD
+  M1 --> M2
+```
+
+## 4. Sections & Milestones
+### Section A — <name>
+#### M1 — <title>
+| Field | Value |
+| --- | --- |
+| Objective | Observable outcome, 1–2 sentences. |
+| In / Out of scope | Explicit boundaries. |
+| Depends on | `none` or milestone IDs. |
+| Deliverables | Concrete artifacts or behavior. |
+| Acceptance | Binary, testable statements. |
+| Verification | Exact command(s) and expected result. |
+| Risks & rollback | Failure modes; stack is the rollback unit unless a finer rollback is doc-traceable. |
+| Est. PRs | Integer ≤ `STACK_DEPTH_HINT`. |
+
+## 5. Cross-Cutting Concerns
+<Security, privacy, perf, observability, migrations, back-compat — only when source-traceable.>
+
+## 6. Critical Path
+<Ordered table or Mermaid diagram through the DAG.>
+```
+
+Planning rules:
+
+- Decompose by capability or layer, not by file.
+- Each milestone must be standalone and self-verifiable.
+- Split any milestone estimated above `STACK_DEPTH_HINT` PRs.
+- Order foundations before consumers.
+- Keep shared context in the preamble; do not repeat it in every milestone.
+- Every acceptance row must be checkable by a command, asserted script output, CI signal, or clearly flagged minimal manual check.
+- Use Mermaid and Markdown tables only for visuals.
+- Validate the Mermaid DAG before final output when Mermaid validation tooling is available.
+
+### Phase 2 — Write `.docs/EXECUTION_PROMPTS.md`
+
+Create one `/goal` block per milestone. The prompt must trace directly to the matching milestone's objective, deliverables, acceptance, and verification rows. Do not invent scope that is not in the plan.
+
+Use this file structure:
+
+```markdown
+# Execution Prompts — <System>
+
+## Global execution rules (apply to every goal)
+- Use the `stacked-prs` skill: each PR is based on the previous PR's branch until that base merges.
+- Conventional Commits, atomic commits, multiple commits per PR grouped into a reviewable narrative.
+- No attribution of any kind: no `Co-authored-by`, no AI/tool mentions, no generated-by text, no emoji.
+- Each PR is one coherent, independently reviewable unit.
+- Review each PR individually, then review the full stack for cumulative coherence.
+- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, ready for human review.
+
+### M1 — <title>
+```text
+/goal Deliver milestone M1 (<title>) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+
+CONTEXT: DEVELOPMENT_PLAN.md §4 M1 + source docs. Preconditions: <none | Mx merged>. Repo: <language, package manager, test runner, type/lint/CI surface>.
+OBJECTIVE: <objective and acceptance criteria as the success contract>.
+
+PLANNED STACK (stacked-prs skill; refine only to keep PRs reviewable):
+1. PR-1 <purpose> — scope: <areas>; commits: <c1>, <c2>; verification: <PR-specific command if narrower than milestone command>
+2. PR-2 <purpose, on PR-1> — scope: <areas>; commits: <c1>, <c2>
+
+CONSTRAINTS: Conventional Commits, atomic commits, multi-commit PRs, no attribution, no scope leakage across PRs, minimal dependencies, respect repo style.
+VERIFICATION (must pass): <exact command(s) + expected result from M1>.
+REVIEW:
+Per PR:
+- Scope boundary: diff matches PR purpose; no milestone leakage; no grab-bag changes.
+- Contract integrity: public APIs, schemas, CLI flags, config keys, and data shapes match the plan.
+- Tests: changed behavior has meaningful unit/integration coverage; assertions test behavior and invariants, not implementation trivia.
+- Error handling: failures are loud, typed/classified where useful, and not hidden behind broad fallbacks.
+- Security/privacy: input validation, secret handling, auth/authz, and data exposure risks are addressed where relevant.
+- Data safety: migrations or destructive operations are dry-run or opt-in where applicable, reversible where possible, and covered by rollback notes.
+- Maintainability: follows repo conventions; no speculative abstractions; no duplicate source of truth.
+- History: Conventional Commits, atomic commits, no attribution, no unrelated formatting churn.
+- Local verification: PR-specific commands pass and output is captured.
+Whole stack:
+- Topology: every PR is based on the previous PR branch; no orphan or duplicate commits.
+- Cumulative acceptance: the leaf stack satisfies every Mx acceptance row.
+- Integration: interfaces added lower in the stack are consumed consistently higher in the stack.
+- Regression surface: existing behavior remains covered; no test deletions without replacement.
+- CI/checks: checks green on every PR or pending provider checks are explicitly reported.
+- Rebase-clean: stack can be rebased from root to leaf without unresolved conflicts.
+- Human handoff: PR URLs, verification output, risks, and manual gates are reported.
+DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete. Report PR URLs and verification output.
+```
+```
+
+For any milestone involving deletion, destructive migrations, irreversible rewrites, user-data mutation, or source pruning, add this inside that milestone prompt:
+
+```text
+HUMAN REVIEW GATE: Do not merge or run destructive paths unattended until a human reviews dry-run output, rollback notes, and audit/tombstone logging.
+```
+
+## Quality gates
+
+Before yielding, check and fix:
+
+- Every inventoried capability maps to at least one milestone.
+- The dependency graph is acyclic.
+- Every milestone has binary acceptance and command-backed verification.
+- No milestone exceeds `STACK_DEPTH_HINT` PRs.
+- Every `/goal` block traces to one milestone's deliverables and verification.
+- Every `/goal` block contains no-attribution rules, per-PR review, and whole-stack review.
+- Assumptions and gaps are visible, not buried in prose.
+- Mermaid diagrams parse when Mermaid validation tooling is available.
+- The only files written are `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` unless the user explicitly requests otherwise.
+
+## Error handling
+
+| Problem | Resolution |
+| --- | --- |
+| Folder contains no readable docs | Stop and report the empty input set. Do not invent a plan. |
+| Explicit file path is missing | Stop and report the missing path. Do not silently skip it. |
+| Source docs contradict each other | Emit blocking `> GAP:` items in chat; proceed only if a defensible default does not change architecture, data semantics, security posture, or acceptance. |
+| Repo tooling is absent | Treat as greenfield and make M1 establish verification. |
+| Verification cannot be fully automated | Use the smallest manual binary check, flag it in the milestone, and explain why automation is unavailable. |
+| Existing `.docs/DEVELOPMENT_PLAN.md` or `.docs/EXECUTION_PROMPTS.md` exists | Read it first, then overwrite only when the user requested regeneration. Preserve no stale milestones. |
+
+## Output Format and Chat Response
+
+After writing files, respond with:
+
+1. Phase 0 ingest summary: capabilities, dependencies, assumptions, gaps, and verification surface.
+2. Paths written.
+3. Quality-gate result.
+4. Any destructive milestones requiring human review.
+
+Do not paste the full generated files into chat unless requested.

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -1,0 +1,88 @@
+cases:
+  - id: docs_folder_to_plan_and_prompts
+    prompt: >
+      Use the system docs in docs/ to create a source-faithful development plan and execution prompts.
+      Save the outputs as .docs/DEVELOPMENT_PLAN.md and .docs/EXECUTION_PROMPTS.md. Make the review process in each execution prompt robust enough for per-PR and whole-stack review.
+    fixtures: []
+    rubric:
+      - "creates exactly DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md under .docs"
+      - "includes source map, assumptions/gaps, dependency graph, milestones, acceptance, and verification"
+      - "includes one /goal block per milestone with detailed per-PR and whole-stack review criteria"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: ".docs/DEVELOPMENT_PLAN.md"
+        weight: 1.0
+      - type: contains
+        target: ".docs/EXECUTION_PROMPTS.md"
+        weight: 1.0
+      - type: matches_regex
+        target: "(Source Map|Assumptions|Gaps|Dependency Graph|Milestones)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(/goal|PLANNED STACK|Per PR|Whole stack|whole-stack)"
+        weight: 0.8
+      - type: output_format
+        target: markdown_table
+        weight: 0.6
+
+  - id: explicit_files_with_stack_depth
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md from docs/overview.md and docs/design.md,
+      treating docs/overview.md as the primary source of truth. Use STACK_DEPTH_HINT=4 and save the final files in .docs.
+    fixtures: []
+    rubric:
+      - "treats the first explicit file as primary source of truth"
+      - "caps each milestone planned stack at the requested depth"
+      - "keeps assumptions and gaps visible rather than burying them in prose"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(primary source|source of truth|docs/overview\\.md)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(STACK_DEPTH_HINT|4 PRs|≤ 4|<= 4)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(> ASSUMPTION:|> GAP:|Assumptions & Gaps)"
+        weight: 0.8
+      - type: contains
+        target: "EXECUTION_PROMPTS.md"
+        weight: 0.6
+
+  - id: greenfield_verification_surface
+    prompt: >
+      I have architecture notes in specs/ for a greenfield CLI tool. Turn them into .docs/DEVELOPMENT_PLAN.md
+      and .docs/EXECUTION_PROMPTS.md. There is no repo setup yet, so include whatever first milestone is needed to make later work verifiable.
+    fixtures: []
+    rubric:
+      - "plans a first milestone that establishes project skeleton and verification surface"
+      - "does not assume an existing CI, linter, type checker, or test runner without evidence"
+      - "keeps later milestones self-verifiable through the M1 tooling"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(M1|first milestone).*(verification|test|CI|skeleton|scaffold)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(greenfield|no repo setup|verification surface)"
+        weight: 0.6
+      - type: contains
+        target: "DEVELOPMENT_PLAN.md"
+        weight: 0.6
+
+  - id: negative_existing_plan_review
+    prompt: >
+      Review this existing DEVELOPMENT_PLAN.md and stress-test its assumptions, scope, risk, and failure modes before we implement it.
+    fixtures: []
+    rubric:
+      - "existing plan review is plan-review territory, not generation from source docs"
+    trigger_expected: false
+
+  - id: negative_execute_stack
+    prompt: >
+      Use the execution prompts in .docs/EXECUTION_PROMPTS.md to create the stacked PRs and drive them to green.
+    fixtures: []
+    rubric:
+      - "executing stacked PRs is stacked-prs territory, not plan/prompt generation"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

Adds two development workflow skills and registers them in the armory catalog:

- `plan-prompts`: generates `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from source documents, with source-traced milestones, command-backed verification, assumptions/gaps, and robust per-PR plus whole-stack review requirements in each generated `/goal` block.
- `milestone-runner`: executes milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` sequentially or in dependency-safe parallel waves, using external gates for PR state, CI/checks, verification commands, and review status before advancing. It only merges and cleans stacked branches when explicitly requested.

Also updates:

- `README.md` package count and Development & Tooling catalog rows.
- `manifest.yaml` generated package registry entries and complements.

## Skill Evaluator Results

```text
plan-prompts
Package: plan-prompts (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        16/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          92/100 (92%)
  Status: PASS

milestone-runner
Package: milestone-runner (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        16/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          92/100 (92%)
  Status: PASS
```

## Validation

```text
uv run python scripts/validate_evals.py
Validated 72 skills, 17 agents, 9 hooks, 6 rules, 7 commands, 3 utilities, 11 presets — all passed

uv run python scripts/validate_frontmatter.py
Validated 135 packages across 7 types — all passed

uv run python scripts/evaluate_package.py --path skills/plan-prompts
Overall: 92/100
Status: PASS

uv run python scripts/evaluate_package.py --path skills/milestone-runner
Overall: 92/100
Status: PASS
```

## Commit structure

```text
60cb8cb feat(skills): add plan-prompts package
d657ce6 docs(readme): list plan-prompts package
16f8b3b feat(skills): add milestone-runner package
```

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter with `name` and `description`
- [x] Skill name is kebab-case, under 64 characters
- [x] Description is 200-1024 characters with trigger phrases and "Use when" clause
- [x] No angle brackets or pushy language in description
- [x] No secrets, credentials, or internal URLs in any file
- [ ] Tested locally with Claude Code
- [x] All file references in `SKILL.md` resolve to existing files or user-provided project files
- [x] Skill evaluator score is 70% or above
- [x] No CRITICAL or HIGH findings from skill evaluator
