### PR TITLE
feat(skills): automate milestone merge readiness

### DIFF
--- a/skills/milestone-runner/SKILL.md
+++ b/skills/milestone-runner/SKILL.md
@@ -21,7 +21,7 @@ This skill executes existing milestone prompts. It does not generate `DEVELOPMEN
 
 ## Core model
 
-Milestone prompts are designed to stop at "PR stack open, checks green, reviewed, ready for human review." That is intentional. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when external state proves it.
+Milestone prompts are designed to end with a structured `GO`/`NO-GO` merge verdict. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when the milestone reports `GO` and external state proves every gate.
 
 | Evidence | Use |
 | --- | --- |
@@ -30,18 +30,19 @@ Milestone prompts are designed to stop at "PR stack open, checks green, reviewed
 | Git branch/worktree state | Ensure isolated runs do not share an index or branch. |
 | Provider PR metadata | Confirm PRs exist and are based correctly. |
 | CI/check provider state | Confirm each PR is green before merge or handoff. |
+| Milestone `GO`/`NO-GO` verdict | Confirm the implementation session reached an explicit merge-readiness decision. |
 | Milestone verification commands | Confirm behavior after the stack is built and again after merge when continuing. |
 
 ## Modes
 
 | Mode | Trigger | Behavior |
 | --- | --- | --- |
-| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, then stop for review/merge unless the user explicitly asked to continue after observed merge. |
-| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any failure. |
+| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, merge automatically after `GO` plus external gates, clean merged branches, then continue to the next dependency-ready milestone. |
+| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any `NO-GO` or failed external gate. Merge only stacks whose lane reports `GO` and whose external gates pass. |
 | Resume | "continue the milestone sequence" | Read prior state, observe which milestone stacks are merged, then launch the next dependency-ready milestone or wave. |
-| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Use stacked-PR merge discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches. |
+| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Treat the request as an explicit `GO` candidate for the current stack, then use stacked-PR discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches. |
 
-Default to sequential build when the user does not explicitly request parallel execution. Default to human-review stop points; do not merge unless the user explicitly requests merge/cleanup.
+Default to sequential build when the user does not explicitly request parallel execution. Default to autonomous merge-and-continue after a milestone reports `GO` and all external gates pass. Stop instead when the user explicitly requests human-review stop points, the milestone reports `NO-GO`, a required gate fails or is pending, or the milestone contains a `HUMAN REVIEW GATE`.
 
 ## Workflow
 
@@ -92,6 +93,7 @@ Treat runner output as a hint. Verify with external state:
 
 | Gate | Requirement |
 | --- | --- |
+| Stack verdict | Milestone final output contains `GO` with evidence; `NO-GO`, missing verdict, or ambiguous verdict stops the sequence. |
 | PR existence | Expected PR stack exists. |
 | PR bases | Root PR targets the intended base; child PRs target the previous PR branch. |
 | Checks | CI/checks are green or pending state is explicitly reported and treated as not done. |
@@ -103,7 +105,7 @@ If any gate fails, stop the sequence. Report the failure, the last safe state, a
 
 ### 5. Merge and continue
 
-Only merge when the user explicitly asks. Use the `stacked-prs` skill for stack topology and merge discipline.
+After a milestone reports `GO` and every external gate passes, merge the stack automatically unless the user explicitly requested no merge or the milestone contains a `HUMAN REVIEW GATE`. Use the `stacked-prs` skill for stack topology and merge discipline.
 
 Safe merge loop:
 
@@ -115,7 +117,7 @@ Safe merge loop:
 6. After the final PR merges, clean merged local and remote branches.
 7. Re-run the milestone verification commands on the merged base before launching dependent milestones.
 
-If the user wants to preserve the human review gate, stop after reporting the stack as ready and wait for observed merge before continuing.
+If the user wants to preserve the human review gate, stop after reporting the stack as ready and wait for observed merge before continuing. If the milestone reports `NO-GO`, do not merge; report the failed or pending gates.
 
 ## Output Format
 
@@ -131,13 +133,14 @@ For inspection or launch planning, output:
 - M1: <command/session/worktree summary>
 
 ## Gates
+- Stack verdict: <GO/NO-GO/missing>
 - PR bases: <pass/fail/pending>
 - CI: <pass/fail/pending>
 - Verification: <pass/fail/pending>
 - Review: <pass/fail/pending>
 
 ## Stop/Continue Decision
-<Continue to next ready milestone | Stop for human review | Stop on failure | Merge requested and complete>
+<Continue to next ready milestone | Merge complete and continue | Stop for human review | Stop on NO-GO | Stop on failed gate>
 ```
 
 For merge-and-clean requests, output:
@@ -167,15 +170,15 @@ For merge-and-clean requests, output:
 | A milestone fails | Stop all downstream work, report failed gate, leave worktrees/branches intact for debugging. |
 | CI pending | Treat as not complete; wait or stop with pending status. |
 | Merge conflict | Stop and invoke stack conflict resolution; do not continue to downstream milestones. |
-| User asks to merge without green checks | Refuse the merge and report failing checks. |
+| Missing or `NO-GO` verdict | Refuse the merge and report the failed, pending, or ambiguous gates. |
 
 ## Safety checklist
 
 Before yielding:
 
-- Every launched milestone has an observed state: pending, running, ready for review, merged, or failed.
+- Every launched milestone has an observed state: pending, running, `GO`, `NO-GO`, merged, or failed.
 - No downstream milestone launched before its dependencies were externally observed as merged.
 - Parallel milestones used isolated worktrees/sessions.
-- Merge happened only after explicit user request.
+- Merge happened only after a `GO` verdict and green external gates, or after an explicit merge-and-clean request whose gates passed.
 - CI and verification evidence is reported exactly, not inferred from agent self-report.
 - Local/remote cleanup only removed branches verified as merged.

--- a/skills/milestone-runner/evals/cases.yaml
+++ b/skills/milestone-runner/evals/cases.yaml
@@ -1,12 +1,13 @@
 cases:
   - id: sequential_milestone_execution
     prompt: >
-      Run the milestone prompts in .docs/EXECUTION_PROMPTS.md one after another. Stop after each milestone stack is open, reviewed, and green so I can decide whether to merge before continuing.
+      Run the milestone prompts in .docs/EXECUTION_PROMPTS.md one after another. For each milestone, after the stack reports GO and external gates pass, merge the stack root-to-leaf and clean merged branches before continuing.
     fixtures: []
     rubric:
       - "parses EXECUTION_PROMPTS.md and identifies milestone /goal blocks"
       - "runs dependent milestones sequentially rather than launching the whole file blindly"
       - "uses external gates such as PR state, CI, verification commands, and review status before advancing"
+      - "merges automatically only after a GO verdict and external gates clear, then cleans verified merged branches"
     trigger_expected: true
     assertions:
       - type: matches_regex
@@ -19,7 +20,7 @@ cases:
         target: "(CI|checks|verification|PR state|review)"
         weight: 0.8
       - type: matches_regex
-        target: "(stop|halt|human review|merge before continuing)"
+        target: "(merge|root-to-leaf|GO|NO-GO|cleanup|merged branches)"
         weight: 0.7
 
   - id: parallel_independent_milestones
@@ -49,6 +50,7 @@ cases:
     rubric:
       - "routes merge-and-clean workflow through stacked PR discipline"
       - "requires green CI/checks before each merge"
+      - "treats explicit merge request as equivalent to a GO merge decision when gates are green"
       - "cleans only branches verified as merged"
     trigger_expected: true
     assertions:

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -120,7 +120,7 @@ Use this file structure:
 - No attribution of any kind: no `Co-authored-by`, no AI/tool mentions, no generated-by text, no emoji.
 - Each PR is one coherent, independently reviewable unit.
 - Review each PR individually, then review the full stack for cumulative coherence.
-- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, ready for human review.
+- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, and a final `GO`/`NO-GO` merge verdict with evidence. `GO` authorizes an autonomous runner to merge after it independently verifies the gates; `NO-GO` blocks merge and downstream milestones.
 
 ### M1 — <title>
 ```text
@@ -154,7 +154,12 @@ Whole stack:
 - CI/checks: checks green on every PR or pending provider checks are explicitly reported.
 - Rebase-clean: stack can be rebased from root to leaf without unresolved conflicts.
 - Human handoff: PR URLs, verification output, risks, and manual gates are reported.
-DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete. Report PR URLs and verification output.
+FINAL VERDICT:
+- Report exactly one verdict: `GO` or `NO-GO`.
+- `GO` only when every PR is open, correctly based, reviewed, green, locally verified, and the whole stack satisfies every milestone acceptance row.
+- `NO-GO` when any check is failing or pending, review is incomplete, branch topology is wrong, verification is missing, scope leaked, a human/manual gate remains, or merge readiness is ambiguous.
+- Evidence: list PR URLs, branch bases, CI/check status per PR, verification command output, review completion, residual risks, and any manual gate.
+DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete, final `GO`/`NO-GO` verdict reported with evidence.
 ```
 ```
 
@@ -173,7 +178,7 @@ Before yielding, check and fix:
 - Every milestone has binary acceptance and command-backed verification.
 - No milestone exceeds `STACK_DEPTH_HINT` PRs.
 - Every `/goal` block traces to one milestone's deliverables and verification.
-- Every `/goal` block contains no-attribution rules, per-PR review, and whole-stack review.
+- Every `/goal` block contains no-attribution rules, per-PR review, whole-stack review, and final `GO`/`NO-GO` verdict requirements.
 - Assumptions and gaps are visible, not buried in prose.
 - Mermaid diagrams parse when Mermaid validation tooling is available.
 - The only files written are `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` unless the user explicitly requests otherwise.

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -2,12 +2,13 @@ cases:
   - id: docs_folder_to_plan_and_prompts
     prompt: >
       Use the system docs in docs/ to create a source-faithful development plan and execution prompts.
-      Save the outputs as .docs/DEVELOPMENT_PLAN.md and .docs/EXECUTION_PROMPTS.md. Make the review process in each execution prompt robust enough for per-PR and whole-stack review.
+      Save the outputs as .docs/DEVELOPMENT_PLAN.md and .docs/EXECUTION_PROMPTS.md. Make the review process in each execution prompt robust enough for per-PR and whole-stack review, and make every milestone end with a structured GO/NO-GO merge decision.
     fixtures: []
     rubric:
       - "creates exactly DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md under .docs"
       - "includes source map, assumptions/gaps, dependency graph, milestones, acceptance, and verification"
       - "includes one /goal block per milestone with detailed per-PR and whole-stack review criteria"
+      - "requires every milestone run to report GO/NO-GO with evidence for merge readiness"
     trigger_expected: true
     assertions:
       - type: contains
@@ -20,7 +21,7 @@ cases:
         target: "(Source Map|Assumptions|Gaps|Dependency Graph|Milestones)"
         weight: 0.8
       - type: matches_regex
-        target: "(/goal|PLANNED STACK|Per PR|Whole stack|whole-stack)"
+        target: "(/goal|PLANNED STACK|Per PR|Whole stack|whole-stack|GO/NO-GO)"
         weight: 0.8
       - type: output_format
         target: markdown_table


### PR DESCRIPTION
## Summary

This PR updates the `plan-prompts` and `milestone-runner` skills so milestone execution can run autonomously through merge when all gates are clear.

The prior contract stopped milestone runs at "PR stack open, checks green, reviewed, ready for human review" unless the user separately authorized a merge. That made the runner safe, but it prevented the intended unattended flow where each milestone stack reaches a clear merge decision and the orchestrator continues after verifying the result.

This branch changes the contract to a structured `GO`/`NO-GO` handoff:

- `plan-prompts` now requires every generated milestone `/goal` block to end with a final `GO` or `NO-GO` verdict plus evidence.
- `milestone-runner` now treats that verdict as a required gate before advancing.
- A `GO` verdict plus independently verified external gates authorizes automatic root-to-leaf stack merge and branch cleanup.
- `NO-GO`, missing/ambiguous verdicts, pending/failing checks, failed verification, wrong branch topology, explicit no-merge requests, or a `HUMAN REVIEW GATE` stop the sequence.

## Scope

### `skills/milestone-runner`

- Replaces the default human-review stop point with autonomous merge-and-continue after `GO` plus external gate verification.
- Adds a required `Stack verdict` gate: the final milestone output must contain `GO` with evidence before merge, while `NO-GO`, missing verdicts, or ambiguous verdicts stop the sequence.
- Keeps external verification authoritative. The runner still verifies PR existence, PR bases, CI/check status, milestone verification commands, review completion, and clean worktree state before any merge.
- Routes merge execution through stacked-PR discipline: merge root-to-leaf, update local state, retarget/rebase children, re-run checks before each child merge, clean only merged branches, and re-run milestone verification on merged `main`.
- Preserves safety stops for explicit no-merge instructions and `HUMAN REVIEW GATE` milestones.
- Updates milestone-runner eval coverage so the sequential execution case expects automatic merge-and-clean after `GO`, and explicit merge requests are treated as `GO` candidates only when gates are green.

### `skills/plan-prompts`

- Updates the generated global execution rules so `DONE` includes a final `GO`/`NO-GO` merge verdict with evidence.
- Adds a `FINAL VERDICT` section to every generated milestone `/goal` template.
- Defines `GO` narrowly: every PR open, correctly based, reviewed, green, locally verified, and the whole stack satisfies every milestone acceptance row.
- Defines `NO-GO` for failing/pending checks, incomplete review, wrong topology, missing verification, scope leakage, remaining human/manual gates, or ambiguous merge readiness.
- Requires evidence for the verdict: PR URLs, branch bases, CI/check status per PR, verification command output, review completion, residual risks, and manual gates.
- Updates plan-prompts eval coverage to require generated execution prompts to include `GO/NO-GO` merge-readiness language.

## Skill Evaluator Results

```text
Package: milestone-runner (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        16/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          92/100 (92%)
  Status: PASS

Package: plan-prompts (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        16/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          92/100 (92%)
  Status: PASS
```

## Verification

```text
uv run python scripts/validate_evals.py
uv run python scripts/validate_frontmatter.py
uv run python scripts/validate_references.py
uv run python scripts/generate_manifest.py
uv run python scripts/evaluate_package.py --path skills/milestone-runner
uv run python scripts/evaluate_package.py --path skills/plan-prompts
git diff --check
```

Observed results:

```text
Validated 72 skills, 17 agents, 9 hooks, 6 rules, 7 commands, 3 utilities, 11 presets — all passed
Validated 135 packages across 7 types — all passed
Validated 135 packages — all references intact
Generated manifest.yaml with 80 skills, 17 agents, 9 hooks, 6 rules, 7 commands, 3 utilities, 13 presets
milestone-runner evaluator: 92/100 PASS
plan-prompts evaluator: 92/100 PASS
git diff --check: no output
```

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter with `name` and `description`
- [x] Skill name is kebab-case, under 64 characters
- [x] Description is 200-1024 characters with trigger phrases and "Use when" clause
- [x] No angle brackets or pushy language in description
- [x] No secrets, credentials, or internal URLs in any file
- [x] Tested locally with Claude Code
- [x] All file references in `SKILL.md` resolve to existing files
- [x] Skill evaluator score is 70% or above
- [x] No CRITICAL or HIGH findings from skill evaluator
