### PR TITLE
feat(skills): add shared release-train workflow

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -777,7 +777,7 @@ packages:
     difficulty: advanced
     phase: review
   - name: milestone-runner
-    version: 1.0.0
+    version: 1.1.0
     description: Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel
       when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run
       the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue
@@ -794,6 +794,7 @@ packages:
     - orchestration
     - stacked-prs
     - ci
+    - release-management
     - execution-prompts
     category: development
     difficulty: advanced
@@ -862,7 +863,7 @@ packages:
     difficulty: advanced
     phase: build
   - name: plan-prompts
-    version: 1.0.0
+    version: 1.1.0
     description: Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture,
       or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate
       execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md",
@@ -881,6 +882,7 @@ packages:
     - execution-prompts
     - milestones
     - stacked-prs
+    - release-management
     - docs
     category: development
     difficulty: advanced

--- a/skills/milestone-runner/SKILL.md
+++ b/skills/milestone-runner/SKILL.md
@@ -2,9 +2,9 @@
 name: milestone-runner
 description: 'Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue the milestone sequence", "merge the stack", or "ensure CI is green and clean branches". NOT for generating plan files; use plan-prompts. NOT for repairing one existing stack; use stacked-prs.'
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   category: development
-  tags: [milestones, orchestration, stacked-prs, ci, execution-prompts]
+  tags: [milestones, orchestration, stacked-prs, ci, release-management, execution-prompts]
   difficulty: advanced
   phase: ship
   complements:
@@ -15,53 +15,55 @@ metadata:
 
 # Milestone Runner
 
-Run milestone prompts produced by `plan-prompts` from `.docs/EXECUTION_PROMPTS.md`. The skill coordinates execution order, isolation, verification, CI checks, review gates, and optional stack merge/cleanup.
+Run milestone prompts produced by `plan-prompts` from `.docs/EXECUTION_PROMPTS.md`. The skill coordinates execution order, isolation, verification, CI checks, review gates, stack merge/cleanup, and release preparation.
 
-This skill executes existing milestone prompts. It does not generate `DEVELOPMENT_PLAN.md` or `EXECUTION_PROMPTS.md`; use `plan-prompts` for that. It does not replace `stacked-prs`; it invokes that workflow when a stack must be validated, merged, retargeted, or cleaned.
+This skill executes existing milestone prompts. It does not generate `DEVELOPMENT_PLAN.md` or `EXECUTION_PROMPTS.md`; use `plan-prompts` for that. It does not replace `stacked-prs`; it invokes that workflow when a stack must be validated, merged, retargeted, or cleaned. It invokes `ship-workflow` only after a complete shared release train requires release preparation.
 
 ## Core model
 
-Milestone prompts are designed to end with a structured `GO`/`NO-GO` merge verdict. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when the milestone reports `GO` and external state proves every gate.
+Milestone prompts end with a structured, release-aware `GO`/`NO-GO` merge verdict. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when the milestone reports `GO` and external state proves every gate. A stack-level `GO` does not complete its release train: release preparation begins only after every milestone assigned to that train is externally merged.
 
 | Evidence | Use |
 | --- | --- |
-| `.docs/DEVELOPMENT_PLAN.md` dependency rows | Build the milestone DAG. |
-| `.docs/EXECUTION_PROMPTS.md` `/goal` blocks | Exact executable prompt text. |
+| `.docs/DEVELOPMENT_PLAN.md` dependency rows and release-train table | Build the milestone DAG and determine release-train completion. |
+| `.docs/EXECUTION_PROMPTS.md` `/goal` blocks and `RELEASE TRAIN` fields | Extract exact executable prompt text, target release, required artifacts, release verification, and publication requirement. |
 | Git branch/worktree state | Ensure isolated runs do not share an index or branch. |
 | Provider PR metadata | Confirm PRs exist and are based correctly. |
 | CI/check provider state | Confirm each PR is green before merge or handoff. |
-| Milestone `GO`/`NO-GO` verdict | Confirm the implementation session reached an explicit merge-readiness decision. |
+| Milestone `GO`/`NO-GO` verdict | Confirm the implementation session reached an explicit merge-readiness decision and reports the correct release target. |
 | Milestone verification commands | Confirm behavior after the stack is built and again after merge when continuing. |
+| Version source, `CHANGELOG.md`, release workflow, and release-preparation PR | Prepare and verify the declared release exactly once after its train completes. |
 
 ## Modes
 
 | Mode | Trigger | Behavior |
 | --- | --- | --- |
-| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, merge automatically after `GO` plus external gates, clean merged branches, then continue to the next dependency-ready milestone. |
-| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any `NO-GO` or failed external gate. Merge only stacks whose lane reports `GO` and whose external gates pass. |
-| Resume | "continue the milestone sequence" | Read prior state, observe which milestone stacks are merged, then launch the next dependency-ready milestone or wave. |
-| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Treat the request as an explicit `GO` candidate for the current stack, then use stacked-PR discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches. |
+| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, merge automatically after `GO` plus external gates, clean merged branches, prepare a completed release train when required, then continue to the next dependency-ready milestone. |
+| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any `NO-GO` or failed external gate. Merge only stacks whose lane reports `GO` and whose external gates pass; prepare a release only after all of its train members merge. |
+| Resume | "continue the milestone sequence" | Read prior state, observe which milestone stacks and release-preparation PRs are merged, then launch the next dependency-ready milestone, release preparation, or wave. |
+| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Treat the request as an explicit `GO` candidate for the current stack, then use stacked-PR discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches, and evaluate whether the train is ready for release preparation. |
 
-Default to sequential build when the user does not explicitly request parallel execution. Default to autonomous merge-and-continue after a milestone reports `GO` and all external gates pass. Stop instead when the user explicitly requests human-review stop points, the milestone reports `NO-GO`, a required gate fails or is pending, or the milestone contains a `HUMAN REVIEW GATE`.
+Default to sequential build when the user does not explicitly request parallel execution. Default to autonomous merge-and-continue after a milestone reports `GO` and all external gates pass. Stop instead when the user explicitly requests human-review stop points, the milestone reports `NO-GO`, a required gate fails or is pending, a release target is unresolved, a required release-preparation gate fails, or the milestone contains a `HUMAN REVIEW GATE`.
 
 ## Workflow
 
 ### 1. Inspect inputs
 
 1. Read `.docs/EXECUTION_PROMPTS.md` and extract each milestone heading plus the fenced `/goal` block that follows it.
-2. Read `.docs/DEVELOPMENT_PLAN.md` when present and extract `Depends on` rows. Use these dependencies to build the DAG.
-3. If the plan is missing or dependency rows are ambiguous, fall back to file order and treat milestones as sequential unless the prompt text explicitly says they are independent.
-4. Confirm the worktree is clean before launching, merging, rebasing, or cleanup. Stop on dirty state unless the user only asked for inspection.
-5. Confirm the current branch/base context. Do not run milestone work on an unrelated dirty branch.
+2. Read `.docs/DEVELOPMENT_PLAN.md` when present and extract `Depends on` rows and the release-train table. Use dependencies to build the DAG and release-train memberships to determine when preparation may start.
+3. For every milestone, reconcile its `RELEASE TRAIN` field with the plan. Record target release, included milestones, preparation trigger, required artifacts, release verification, and publication requirement. Stop on contradictions or unresolved `> GAP:` values.
+4. If the plan is missing or dependency rows are ambiguous, fall back to file order and treat milestones as sequential unless the prompt text explicitly says they are independent. Do not infer a release target or version.
+5. Confirm the worktree is clean before launching, merging, rebasing, cleanup, or release preparation. Stop on dirty state unless the user only asked for inspection.
+6. Confirm the current branch/base context. Do not run milestone work on an unrelated dirty branch.
 
 ### 2. Build the execution DAG
 
 Create a table before launching work:
 
-| Milestone | Depends on | Status | Runnable now | Execution lane |
-| --- | --- | --- | --- | --- |
-| M1 | none | pending | yes | wave-1 |
-| M2 | M1 | blocked | no | wave-2 |
+| Milestone | Depends on | Target release | Status | Runnable now | Execution lane |
+| --- | --- | --- | --- | --- | --- |
+| M1 | none | v2.4.0 | pending | yes | wave-1 |
+| M2 | M1 | v2.4.0 | blocked | no | wave-2 |
 
 Rules:
 
@@ -69,6 +71,7 @@ Rules:
 - Milestones with no dependencies between them can share a wave.
 - Parallel wave members must run in separate git worktrees and separate headless sessions.
 - If two independent milestones touch the same files, prefer sequential execution unless the user accepts conflict risk.
+- A release train becomes eligible for preparation only when every included milestone is externally observed as merged. A train with target `none` has no release-preparation work.
 
 ### 3. Launch milestone work
 
@@ -93,17 +96,20 @@ Treat runner output as a hint. Verify with external state:
 
 | Gate | Requirement |
 | --- | --- |
-| Stack verdict | Milestone final output contains `GO` with evidence; `NO-GO`, missing verdict, or ambiguous verdict stops the sequence. |
+| Stack verdict | Milestone final output contains `GO — RELEASE: <target>` with evidence; `NO-GO`, missing verdict, ambiguous verdict, or target mismatch stops the sequence. |
 | PR existence | Expected PR stack exists. |
 | PR bases | Root PR targets the intended base; child PRs target the previous PR branch. |
 | Checks | CI/checks are green or pending state is explicitly reported and treated as not done. |
 | Verification | Milestone `VERIFICATION` commands pass with expected output. |
 | Review | Generated prompt's per-PR and whole-stack review criteria are complete. |
 | Cleanliness | No accidental dirty files remain in the worktree. |
+| Release target | The target agrees between plan, prompt, and verdict; it is neither unresolved nor invented. |
+| Release readiness | Before train completion, release preparation remains pending and no version or changelog update starts. After completion, every train member is externally merged. |
+| Release preparation | Applies only after train completion when artifacts are required: version source and/or `CHANGELOG.md` changes are present, reviewed, green, merged, and pass the train's release verification. |
 
 If any gate fails, stop the sequence. Report the failure, the last safe state, and the next required human/agent action. Do not launch downstream milestones on a broken base.
 
-### 5. Merge and continue
+### 5. Merge, prepare release, and continue
 
 After a milestone reports `GO` and every external gate passes, merge the stack automatically unless the user explicitly requested no merge or the milestone contains a `HUMAN REVIEW GATE`. Use the `stacked-prs` skill for stack topology and merge discipline.
 
@@ -115,9 +121,14 @@ Safe merge loop:
 4. Rebase or retarget the child PR onto the new base according to the stack workflow.
 5. Re-run checks before merging the next PR.
 6. After the final PR merges, clean merged local and remote branches.
-7. Re-run the milestone verification commands on the merged base before launching dependent milestones.
+7. Re-run the milestone verification commands on the merged base.
+8. Recompute the release train from external merge state. If another included milestone remains unmerged, report `Continue within release train` and launch only dependency-ready work.
+9. If the completed train's target is `none` or its required artifacts are `none`, record `RELEASE PREP: not-required`; do not invoke `ship-workflow`.
+10. If the completed train requires release preparation, launch a fresh isolated release-preparation session from the clean merged base. Invoke `ship-workflow` on a dedicated release-preparation branch and preserve its pre-flight, test, review, version-bump, changelog, atomic-commit, PR, and CI gates.
+11. Detect the version source and changelog from the plan and repository rather than assuming either exists. Update the version to the declared target only when the train requires a version update; update `CHANGELOG.md` only when the train requires it. Do not tag, publish, or create a hosted release unless the train explicitly requires that action.
+12. Verify the release-preparation PR is reviewed, green, and merged; then run the train's release verification on the merged base. Report `RELEASE PREP: ready` only after the required artifacts and verification pass.
 
-If the user wants to preserve the human review gate, stop after reporting the stack as ready and wait for observed merge before continuing. If the milestone reports `NO-GO`, do not merge; report the failed or pending gates.
+If the user wants to preserve the human review gate, stop after reporting the stack or release-preparation PR as ready and wait for observed merge before continuing. If the milestone or release preparation reports `NO-GO`, do not merge or advance; report the failed or pending gates.
 
 ## Output Format
 
@@ -126,8 +137,8 @@ For inspection or launch planning, output:
 ```text
 ## Milestone Runner Plan
 
-| Milestone | Depends on | Mode | Worktree/Profile | Status |
-| --- | --- | --- | --- | --- |
+| Milestone | Depends on | Target release | Mode | Worktree/Profile | Status |
+| --- | --- | --- | --- | --- | --- |
 
 ## Launches
 - M1: <command/session/worktree summary>
@@ -138,9 +149,11 @@ For inspection or launch planning, output:
 - CI: <pass/fail/pending>
 - Verification: <pass/fail/pending>
 - Review: <pass/fail/pending>
+- Release train: <target, included/merged milestones, pending members>
+- Release preparation: <not-required/pending/ready/NO-GO>
 
 ## Stop/Continue Decision
-<Continue to next ready milestone | Merge complete and continue | Stop for human review | Stop on NO-GO | Stop on failed gate>
+<Continue within release train | Prepare release | RELEASE PREP: ready and continue | Stop for human review | Stop on NO-GO | Stop on failed gate>
 ```
 
 For merge-and-clean requests, output:
@@ -150,6 +163,17 @@ For merge-and-clean requests, output:
 
 | PR | Branch | Base | CI before merge | Merge result | Cleanup |
 | --- | --- | --- | --- | --- | --- |
+
+## Release Train
+- Target:
+- Included milestones:
+- Externally merged milestones:
+- Required artifacts:
+- Release-preparation PR:
+- Version transition:
+- CHANGELOG.md status:
+- Publication status:
+- Verification after release preparation:
 
 ## Remaining State
 - Open PRs:
@@ -164,13 +188,16 @@ For merge-and-clean requests, output:
 | --- | --- |
 | Missing `.docs/EXECUTION_PROMPTS.md` | Stop; ask for the prompt file or run `plan-prompts` first. |
 | Ambiguous dependency graph | Use sequential execution unless the user explicitly authorizes parallel conflict risk. |
-| Dirty worktree | Stop before launching, merging, rebasing, or cleanup. |
+| Dirty worktree | Stop before launching, merging, rebasing, cleanup, or release preparation. |
 | Parallel run file overlap | Prefer sequential execution; parallel only with explicit approval. |
 | Headless command unavailable | Fall back to manual copy/paste execution guidance and preserve the same gates. |
 | A milestone fails | Stop all downstream work, report failed gate, leave worktrees/branches intact for debugging. |
 | CI pending | Treat as not complete; wait or stop with pending status. |
 | Merge conflict | Stop and invoke stack conflict resolution; do not continue to downstream milestones. |
 | Missing or `NO-GO` verdict | Refuse the merge and report the failed, pending, or ambiguous gates. |
+| Release target is missing, contradictory, or unresolved | Stop the affected release train. Do not infer a semantic version or create a version/changelog update. |
+| Release train is incomplete | Continue only with its remaining dependency-ready milestones. Do not start release preparation. |
+| Required release preparation fails or is pending | Stop the affected train and only milestones whose declared dependency closure includes it. Independent trains may continue in isolated lanes. Leave the release-preparation branch and PR intact for remediation. |
 
 ## Safety checklist
 
@@ -180,5 +207,7 @@ Before yielding:
 - No downstream milestone launched before its dependencies were externally observed as merged.
 - Parallel milestones used isolated worktrees/sessions.
 - Merge happened only after a `GO` verdict and green external gates, or after an explicit merge-and-clean request whose gates passed.
+- Every completed release train has an observed `RELEASE PREP` state: `not-required`, `pending`, `ready`, or `NO-GO`; no version/changelog preparation began before all train milestones merged.
+- Required version and changelog changes match the declared release target, are merged through a reviewed green release-preparation PR, and pass release verification.
 - CI and verification evidence is reported exactly, not inferred from agent self-report.
 - Local/remote cleanup only removed branches verified as merged.

--- a/skills/milestone-runner/evals/cases.yaml
+++ b/skills/milestone-runner/evals/cases.yaml
@@ -64,6 +64,62 @@ cases:
         target: "(clean|cleanup|local.*remote|merged branches)"
         weight: 0.7
 
+  - id: shared_release_train_preparation
+    prompt: >
+      M1 and M2 both target release v2.4.0. M1 is merged, but M2 is still open; do not update release artifacts yet.
+      After M2 merges, prepare the release using the repository's VERSION file and CHANGELOG.md, create a reviewed green
+      release-preparation PR, and do not tag or publish because the plan does not require it.
+    fixtures: []
+    rubric:
+      - "defers release preparation while M2 remains unmerged"
+      - "recomputes release-train completion from external merge state"
+      - "runs ship-workflow release preparation after the train completes"
+      - "updates and verifies VERSION and CHANGELOG.md through a reviewed green release-preparation PR"
+      - "does not tag or publish without an explicit release-train requirement"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(release train|v2\\.4\\.0|M1|M2)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(unmerged|incomplete|defer|Continue within release train)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(ship-workflow|release preparation|release-preparation PR)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(VERSION|CHANGELOG\\.md)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(do not tag|do not publish|not.*publish)"
+        weight: 0.8
+
+  - id: failed_release_preparation_isolation
+    prompt: >
+      Release v2.4.0 has completed its train, but its release-preparation PR fails CI. Preserve that branch and PR for remediation,
+      stop v2.4.0 and only milestones whose declared dependency closure includes it, and continue the independent v2.5.0 train
+      in an isolated lane. Do not tag or publish either release without an explicit requirement.
+    fixtures: []
+    rubric:
+      - "marks v2.4.0 release preparation as NO-GO and preserves its branch and PR"
+      - "stops only the affected train and declared dependency-closure consumers"
+      - "permits the independent v2.5.0 train to continue in an isolated lane"
+      - "does not tag or publish without an explicit train requirement"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(v2\\.4\\.0|release preparation).*(NO-GO|fail|failed|pending)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(leave.*branch.*PR|preserve.*branch.*PR|intact for remediation)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(dependency closure|affected train|independent.*v2\\.5\\.0|isolated lane)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(do not tag|do not publish|not.*publish)"
+        weight: 0.8
+
   - id: negative_generate_plan_prompts
     prompt: >
       Create DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md from the documents in docs/ and save them in .docs.

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -2,9 +2,9 @@
 name: plan-prompts
 description: 'Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture, or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md", "plan implementation from .docs", "create milestone execution prompts", "convert architecture docs into stacked PR prompts", or when given DOCS_DIR / REPO_CONTEXT / GLOBAL_CONSTRAINTS / STACK_DEPTH_HINT placeholders. NOT for auditing an existing plan; use plan-review. NOT for executing the stack; use stacked-prs.'
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   category: development
-  tags: [planning, execution-prompts, milestones, stacked-prs, docs]
+  tags: [planning, execution-prompts, milestones, stacked-prs, release-management, docs]
   difficulty: advanced
   phase: plan
   complements:
@@ -35,8 +35,8 @@ Optional context:
 
 | Field | Meaning | Default |
 | --- | --- | --- |
-| `REPO_CONTEXT` | Target repo path or description; use actual repo structure, tooling, CI, and style when a path exists. | Greenfield planning if absent. |
-| `GLOBAL_CONSTRAINTS` | Cross-cutting constraints not present in source docs: compliance, dependency policy, deadlines, perf budgets. | None. |
+| `REPO_CONTEXT` | Target repo path or description; use actual repo structure, tooling, CI, style, and release conventions when a path exists. | Greenfield planning if absent. |
+| `GLOBAL_CONSTRAINTS` | Cross-cutting constraints not present in source docs: compliance, dependency policy, deadlines, perf budgets, release policy. | None. |
 | `STACK_DEPTH_HINT` | Maximum PRs per milestone stack. | 6. |
 
 ## Workflow
@@ -49,8 +49,9 @@ Optional context:
 4. Record `> ASSUMPTION:` for defensible defaults where docs are silent.
 5. Record `> GAP:` for missing, ambiguous, or contradictory requirements. Contradictions that change architecture, data semantics, security posture, or acceptance block file creation until resolved.
 6. Map dependencies between capabilities. Dependencies must be implementation-relevant, not topical adjacency.
-7. Inspect the target repo when available: CI workflows, package manager, test runner, type checker, linter, existing test naming, existing partial implementations, and repository conventions. Copy exact verification commands from the repo's own config or CI when possible.
-8. If the repo is greenfield, make M1 establish the minimal skeleton and verification surface needed for later milestones to be testable.
+7. Inspect the target repo when available: CI workflows, package manager, test runner, type checker, linter, existing test naming, existing partial implementations, repository conventions, version source, `CHANGELOG.md`, tags, release branches, and documented release commands. Copy exact verification and release commands from the repo's own config or CI when possible.
+8. Identify source-traceable release targets and group milestones into shared release trains. Every milestone must explicitly target a named release, an unversioned release train, `none`, or a visible `> GAP:`. Never infer a semantic version from feature scope.
+9. If the repo is greenfield, make M1 establish the minimal skeleton and verification surface needed for later milestones to be testable.
 
 Summarize Phase 0 in the chat response only. Do not duplicate the full ingest inventory inside the generated files.
 
@@ -73,7 +74,12 @@ graph TD
   M1 --> M2
 ```
 
-## 4. Sections & Milestones
+## 4. Release Trains
+| Target release | Included milestones | Preparation trigger | Required artifacts | Verification | Publication |
+| --- | --- | --- | --- | --- | --- |
+| `<version | unversioned | none>` | `<M1, M2>` | All included milestones are externally merged. | `<version update | CHANGELOG.md | both | none>` | `<exact command or binary manual check>` | `<required command/workflow | not requested>` |
+
+## 5. Sections & Milestones
 ### Section A — <name>
 #### M1 — <title>
 | Field | Value |
@@ -81,17 +87,18 @@ graph TD
 | Objective | Observable outcome, 1–2 sentences. |
 | In / Out of scope | Explicit boundaries. |
 | Depends on | `none` or milestone IDs. |
+| Target release | Named release train, `unversioned`, `none`, or `> GAP:`. |
 | Deliverables | Concrete artifacts or behavior. |
 | Acceptance | Binary, testable statements. |
 | Verification | Exact command(s) and expected result. |
 | Risks & rollback | Failure modes; stack is the rollback unit unless a finer rollback is doc-traceable. |
 | Est. PRs | Integer ≤ `STACK_DEPTH_HINT`. |
 
-## 5. Cross-Cutting Concerns
-<Security, privacy, perf, observability, migrations, back-compat — only when source-traceable.>
+## 6. Cross-Cutting Concerns
+<Security, privacy, perf, observability, migrations, back-compat, release management — only when source-traceable.>
 
-## 6. Critical Path
-<Ordered table or Mermaid diagram through the DAG.>
+## 7. Critical Path
+<Ordered table or Mermaid diagram through the DAG and release-train completion.>
 ```
 
 Planning rules:
@@ -102,6 +109,8 @@ Planning rules:
 - Order foundations before consumers.
 - Keep shared context in the preamble; do not repeat it in every milestone.
 - Every acceptance row must be checkable by a command, asserted script output, CI signal, or clearly flagged minimal manual check.
+- Assign release preparation once per shared release train, after all included milestones merge. Do not create a version bump or changelog entry per feature milestone.
+- Derive version and changelog requirements from source documents and repository conventions. Use `none` only when evidence shows that no release artifact is required; use `> GAP:` rather than inventing a release target or versioning policy.
 - Use Mermaid and Markdown tables only for visuals.
 - Validate the Mermaid DAG before final output when Mermaid validation tooling is available.
 
@@ -120,20 +129,22 @@ Use this file structure:
 - No attribution of any kind: no `Co-authored-by`, no AI/tool mentions, no generated-by text, no emoji.
 - Each PR is one coherent, independently reviewable unit.
 - Review each PR individually, then review the full stack for cumulative coherence.
-- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, and a final `GO`/`NO-GO` merge verdict with evidence. `GO` authorizes an autonomous runner to merge after it independently verifies the gates; `NO-GO` blocks merge and downstream milestones.
+- A `GO` makes only the milestone stack eligible for merge. Release preparation is deferred until every milestone in its shared release train is externally merged; the runner owns that release workflow.
+- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, and a final release-aware `GO`/`NO-GO` merge verdict with evidence. `GO` authorizes an autonomous runner to merge after it independently verifies the gates; `NO-GO` blocks merge and downstream milestones.
 
 ### M1 — <title>
 ```text
 /goal Deliver milestone M1 (<title>) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
 
-CONTEXT: DEVELOPMENT_PLAN.md §4 M1 + source docs. Preconditions: <none | Mx merged>. Repo: <language, package manager, test runner, type/lint/CI surface>.
+CONTEXT: DEVELOPMENT_PLAN.md §5 M1 + source docs. Preconditions: <none | Mx merged>. Repo: <language, package manager, test runner, type/lint/CI surface>.
 OBJECTIVE: <objective and acceptance criteria as the success contract>.
+RELEASE TRAIN: target=<named version | unversioned | none | > GAP: unresolved>; included milestones=<Mx>; preparation trigger=<all included milestones externally merged>; required artifacts=<version update | CHANGELOG.md | both | none>; release verification=<exact command or binary manual check>; publication=<required command/workflow | not requested>.
 
 PLANNED STACK (stacked-prs skill; refine only to keep PRs reviewable):
 1. PR-1 <purpose> — scope: <areas>; commits: <c1>, <c2>; verification: <PR-specific command if narrower than milestone command>
 2. PR-2 <purpose, on PR-1> — scope: <areas>; commits: <c1>, <c2>
 
-CONSTRAINTS: Conventional Commits, atomic commits, multi-commit PRs, no attribution, no scope leakage across PRs, minimal dependencies, respect repo style.
+CONSTRAINTS: Conventional Commits, atomic commits, multi-commit PRs, no attribution, no scope leakage across PRs, minimal dependencies, respect repo style. Do not update version or changelog artifacts before the release-train trigger unless the milestone itself is the source-traceable release-preparation unit.
 VERIFICATION (must pass): <exact command(s) + expected result from M1>.
 REVIEW:
 Per PR:
@@ -155,11 +166,11 @@ Whole stack:
 - Rebase-clean: stack can be rebased from root to leaf without unresolved conflicts.
 - Human handoff: PR URLs, verification output, risks, and manual gates are reported.
 FINAL VERDICT:
-- Report exactly one verdict: `GO` or `NO-GO`.
-- `GO` only when every PR is open, correctly based, reviewed, green, locally verified, and the whole stack satisfies every milestone acceptance row.
-- `NO-GO` when any check is failing or pending, review is incomplete, branch topology is wrong, verification is missing, scope leaked, a human/manual gate remains, or merge readiness is ambiguous.
-- Evidence: list PR URLs, branch bases, CI/check status per PR, verification command output, review completion, residual risks, and any manual gate.
-DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete, final `GO`/`NO-GO` verdict reported with evidence.
+- Report exactly one verdict: `GO — RELEASE: <target> — RELEASE PREP: <pending | not-required>` or `NO-GO — RELEASE: <target> — REASON: <blocking gate>`.
+- `GO` only when every PR is open, correctly based, reviewed, green, locally verified, and the whole stack satisfies every milestone acceptance row. Use `pending` whenever release preparation has not started; only use `not-required` when the release train requires no release artifacts.
+- `NO-GO` when any check is failing or pending, review is incomplete, branch topology is wrong, verification is missing, scope leaked, a human/manual gate remains, merge readiness is ambiguous, or the target release is unresolved.
+- Evidence: list target release, included and remaining train milestones, PR URLs, branch bases, CI/check status per PR, verification command output, review completion, residual risks, and any manual gate.
+DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete, final release-aware `GO`/`NO-GO` verdict reported with evidence.
 ```
 ```
 
@@ -176,9 +187,11 @@ Before yielding, check and fix:
 - Every inventoried capability maps to at least one milestone.
 - The dependency graph is acyclic.
 - Every milestone has binary acceptance and command-backed verification.
+- Every milestone has an explicit named target, `unversioned`, `none`, or a visible `> GAP:`.
+- Each shared release train lists included milestones, trigger, required artifacts, and verification; version or changelog work is assigned only once per train.
 - No milestone exceeds `STACK_DEPTH_HINT` PRs.
-- Every `/goal` block traces to one milestone's deliverables and verification.
-- Every `/goal` block contains no-attribution rules, per-PR review, whole-stack review, and final `GO`/`NO-GO` verdict requirements.
+- Every `/goal` block traces to one milestone's deliverables, verification, and release train.
+- Every `/goal` block contains no-attribution rules, per-PR review, whole-stack review, and final release-aware `GO`/`NO-GO` verdict requirements.
 - Assumptions and gaps are visible, not buried in prose.
 - Mermaid diagrams parse when Mermaid validation tooling is available.
 - The only files written are `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` unless the user explicitly requests otherwise.
@@ -192,15 +205,15 @@ Before yielding, check and fix:
 | Source docs contradict each other | Emit blocking `> GAP:` items in chat; proceed only if a defensible default does not change architecture, data semantics, security posture, or acceptance. |
 | Repo tooling is absent | Treat as greenfield and make M1 establish verification. |
 | Verification cannot be fully automated | Use the smallest manual binary check, flag it in the milestone, and explain why automation is unavailable. |
+| Release target or policy is absent | Emit a visible `> GAP:`. Do not invent a semantic version, version bump, changelog entry, tag, or publication step. |
 | Existing `.docs/DEVELOPMENT_PLAN.md` or `.docs/EXECUTION_PROMPTS.md` exists | Read it first, then overwrite only when the user requested regeneration. Preserve no stale milestones. |
 
 ## Output Format and Chat Response
 
-After writing files, respond with:
-
-1. Phase 0 ingest summary: capabilities, dependencies, assumptions, gaps, and verification surface.
+1. Phase 0 ingest summary: capabilities, dependencies, release trains, assumptions, gaps, verification surface, and release conventions.
 2. Paths written.
 3. Quality-gate result.
 4. Any destructive milestones requiring human review.
+5. Release trains blocked by unresolved targets or manual release gates.
 
 Do not paste the full generated files into chat unless requested.

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -72,6 +72,54 @@ cases:
         target: "DEVELOPMENT_PLAN.md"
         weight: 0.6
 
+  - id: shared_release_train_planning
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md for a repository where M1 and M2 both ship in v2.4.0.
+      The repository stores its version in VERSION, maintains CHANGELOG.md, and does not publish tags automatically.
+      Keep version and changelog preparation deferred until both milestones merge; do not create one release entry per milestone.
+    fixtures: []
+    rubric:
+      - "assigns M1 and M2 to the shared v2.4.0 release train"
+      - "records VERSION and CHANGELOG.md as release artifacts, with no publication step"
+      - "requires release preparation only after every train milestone merges"
+      - "emits release-aware GO/NO-GO verdicts that name the target release"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(Release Trains|release train|Target release|v2\\.4\\.0)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(VERSION|CHANGELOG\\.md)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(all.*milestones.*merge|all included milestones.*merged|deferred|release preparation)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(GO.*RELEASE|NO-GO.*RELEASE|RELEASE PREP)"
+        weight: 0.9
+
+  - id: unresolved_release_target
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md for source docs that do not identify a release target.
+      The repository has VERSION and CHANGELOG.md, but no documented release policy. Do not infer a version, changelog entry,
+      tag, or publication action.
+    fixtures: []
+    rubric:
+      - "emits a visible release-target GAP rather than inventing a semantic version"
+      - "propagates the unresolved release target into the release-aware NO-GO path"
+      - "does not prescribe a version bump, changelog entry, tag, or publication action without source evidence"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(> GAP:|GAP:|unresolved release target|release target.*unresolved)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(NO-GO.*RELEASE|RELEASE.*NO-GO|REASON.*blocking)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(do not infer|do not invent|not requested|without source evidence)"
+        weight: 0.8
+
   - id: negative_existing_plan_review
     prompt: >
       Review this existing DEVELOPMENT_PLAN.md and stress-test its assumptions, scope, risk, and failure modes before we implement it.


### PR DESCRIPTION
## Summary

This PR adds a shared release-train contract to `plan-prompts` and `milestone-runner`.

- `plan-prompts` now inspects repository release conventions, groups milestones by explicit release target, and emits a Release Trains table in generated development plans.
- Each generated milestone prompt now carries its target release, included milestones, release-artifact requirements, release verification, and explicit publication requirement.
- Release-aware verdicts distinguish stack merge readiness from release completion. Milestone stacks report a GO verdict naming the target release with release preparation pending or not-required, or a target-specific NO-GO.
- `milestone-runner` now defers release preparation until every milestone in a train is externally merged, then creates a dedicated release-preparation branch and applies the repository’s version and changelog conventions.
- Required release artifacts must pass review, CI, merge, and release verification before the train becomes ready. Tags, publication, and hosted releases remain disabled unless the train explicitly requires them.
- Failed release preparation blocks the affected train and its declared dependency closure while allowing independent release trains to continue in isolated lanes.
- Both skills are versioned `1.1.0`; `manifest.yaml` is regenerated.
- New scenarios cover shared-train completion, unresolved release targets, deferred preparation, release-preparation failures, and independent-train isolation.

## Skill Evaluator Results

Not run. This PR updates existing skills and is covered by focused repository validation and release-train scenario review.

## Validation

- `uv run pytest tests/test_generate_manifest.py tests/test_install_skills.py` — 81 passed
- `uv run python scripts/validate_evals.py` — all package eval schemas passed
- `uv run python scripts/generate_manifest.py` — manifest regenerated successfully
- Eval-package dry runs discovered seven cases for each updated skill; dry-run mode intentionally skips live execution.

## Checklist

- [x] Updated `SKILL.md` files have valid YAML frontmatter with existing kebab-case names.
- [x] Updated descriptions retain trigger phrases and a `Use when` clause.
- [x] No secrets, credentials, or internal URLs were added.
- [x] All skill references resolve to existing packages.
- [x] No critical or high-severity findings remain after focused review.
- [x] Generated manifest matches the updated skill metadata.

## Breaking Changes

None.