### PR TITLE
feat(planning): add adaptive milestone design gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [debug-investigator](skills/debug-investigator/) | Systematic debugging framework — hypothesis-driven investigation with bisection, log analysis, instrumentation, and minimal reproduction                    |
 | [project-context-setup](skills/project-context-setup/) | Scaffold repo-local agent context — issue tracker rules, triage labels, domain glossary layout, ADR lookup, agent brief conventions                  |
 | [stacked-prs](skills/stacked-prs/)               | Manage dependent branch stacks and stacked pull requests — inspect, split, publish, sync, validate, merge, and clean up stack topology                      |
-| [plan-prompts](skills/plan-prompts/)             | Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from source docs, with reviewed stacked-PR prompts |
-| [milestone-runner](skills/milestone-runner/)     | Run `.docs/EXECUTION_PROMPTS.md` milestone stacks sequentially or in dependency-safe parallel waves, with CI/review gates and cleanup |
+| [plan-prompts](skills/plan-prompts/)             | Generate adaptive development plans, execution prompts, and an ignored local design-evidence ledger from source docs |
+| [milestone-runner](skills/milestone-runner/)     | Run milestones through serialized design reconciliation, reviewed PR gates, CI, cleanup, and release preparation |
 | [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub                        |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
 | [lightpanda-browser](skills/lightpanda-browser/) | Lightweight headless browser automation via Lightpanda + agent-browser CDP — 9x lower memory, 11x faster, for scraping, DOM extraction, and form automation |

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -777,12 +777,10 @@ packages:
     difficulty: advanced
     phase: review
   - name: milestone-runner
-    version: 1.1.0
-    description: Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel
-      when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run
-      the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue
-      the milestone sequence", "merge the stack", or "ensure CI is green and clean branches". NOT for generating plan files;
-      use plan-prompts. NOT for repairing one existing stack; use stacked-prs.
+    version: 1.2.0
+    description: Use when asked to "run milestones", "execute EXECUTION_PROMPTS.md", "continue the milestone sequence", "run
+      independent milestones in parallel", "merge the stack", or "reconcile M5" after prior work changes the current design.
+      Not for generating plan files; use plan-prompts. Not for repairing one stack; use stacked-prs.
     path: skills/milestone-runner
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/milestone-runner/SKILL.md
     complements:
@@ -792,6 +790,7 @@ packages:
     tags:
     - milestones
     - orchestration
+    - adaptive-planning
     - stacked-prs
     - ci
     - release-management
@@ -863,24 +862,22 @@ packages:
     difficulty: advanced
     phase: build
   - name: plan-prompts
-    version: 1.1.0
-    description: Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture,
-      or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate
-      execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md",
-      "plan implementation from .docs", "create milestone execution prompts", "convert architecture docs into stacked PR prompts",
-      or when given DOCS_DIR / REPO_CONTEXT / GLOBAL_CONSTRAINTS / STACK_DEPTH_HINT placeholders. NOT for auditing an existing
-      plan; use plan-review. NOT for executing the stack; use stacked-prs.
+    version: 1.2.0
+    description: Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update
+      DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository
+      design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.
     path: skills/plan-prompts
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/plan-prompts/SKILL.md
     complements:
+    - milestone-runner
     - stacked-prs
     - plan-review
     - task-decomposer
-    - milestone-runner
     tags:
     - planning
     - execution-prompts
     - milestones
+    - adaptive-planning
     - stacked-prs
     - release-management
     - docs

--- a/skills/milestone-runner/SKILL.md
+++ b/skills/milestone-runner/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: milestone-runner
-description: 'Run milestone `/goal` blocks from `.docs/EXECUTION_PROMPTS.md` in dependency order, sequentially or in parallel when milestones are independent. Use when asked "run these milestone prompts", "execute EXECUTION_PROMPTS.md", "run the milestones sequentially", "run independent milestones in parallel", "orchestrate plan-prompts output", "continue the milestone sequence", "merge the stack", or "ensure CI is green and clean branches". NOT for generating plan files; use plan-prompts. NOT for repairing one existing stack; use stacked-prs.'
+description: 'Use when asked to "run milestones", "execute EXECUTION_PROMPTS.md", "continue the milestone sequence", "run independent milestones in parallel", "merge the stack", or "reconcile M5" after prior work changes the current design. Not for generating plan files; use plan-prompts. Not for repairing one stack; use stacked-prs.'
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   category: development
-  tags: [milestones, orchestration, stacked-prs, ci, release-management, execution-prompts]
+  tags: [milestones, orchestration, adaptive-planning, stacked-prs, ci, release-management, execution-prompts]
   difficulty: advanced
   phase: ship
   complements:
@@ -15,199 +15,184 @@ metadata:
 
 # Milestone Runner
 
-Run milestone prompts produced by `plan-prompts` from `.docs/EXECUTION_PROMPTS.md`. The skill coordinates execution order, isolation, verification, CI checks, review gates, stack merge/cleanup, and release preparation.
+Run milestone prompts produced by `plan-prompts`. The runner coordinates mandatory design reconciliation, dependency-safe execution, verification, CI, review, merge/cleanup, and release preparation.
 
-This skill executes existing milestone prompts. It does not generate `DEVELOPMENT_PLAN.md` or `EXECUTION_PROMPTS.md`; use `plan-prompts` for that. It does not replace `stacked-prs`; it invokes that workflow when a stack must be validated, merged, retargeted, or cleaned. It invokes `ship-workflow` only after a complete shared release train requires release preparation.
+The runner executes existing prompts; it does not author a new product plan. It may require a docs-only reconciliation PR when the current plan no longer matches repository evidence. It invokes `stacked-prs` for stack topology and `ship-workflow` only after a complete release train requires preparation.
 
 ## Core model
 
-Milestone prompts end with a structured, release-aware `GO`/`NO-GO` merge verdict. A milestone process exiting successfully or reporting `DONE` is not proof that the milestone is safe to advance from. Advance only when the milestone reports `GO` and external state proves every gate. A stack-level `GO` does not complete its release train: release preparation begins only after every milestone assigned to that train is externally merged.
+A milestone has two independent gates:
+
+1. **Design gate.** Before implementation, inspect the authoritative plan/prompt, current codebase, merged predecessor diffs, predecessor verification, CI, and local history. Require `DESIGN GO` or stop on `DESIGN NO-GO`.
+2. **Merge gate.** After implementation, require release-aware `GO` plus external PR, CI, verification, and review evidence.
+
+An ignored history ledger is reconstructible local evidence, not authoritative state. `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md`, merged PRs, CI, and current code remain authoritative.
 
 | Evidence | Use |
 | --- | --- |
-| `.docs/DEVELOPMENT_PLAN.md` dependency rows and release-train table | Build the milestone DAG and determine release-train completion. |
-| `.docs/EXECUTION_PROMPTS.md` `/goal` blocks and `RELEASE TRAIN` fields | Extract exact executable prompt text, target release, required artifacts, release verification, and publication requirement. |
-| Git branch/worktree state | Ensure isolated runs do not share an index or branch. |
-| Provider PR metadata | Confirm PRs exist and are based correctly. |
-| CI/check provider state | Confirm each PR is green before merge or handoff. |
-| Milestone `GO`/`NO-GO` verdict | Confirm the implementation session reached an explicit merge-readiness decision and reports the correct release target. |
-| Milestone verification commands | Confirm behavior after the stack is built and again after merge when continuing. |
-| Version source, `CHANGELOG.md`, release workflow, and release-preparation PR | Prepare and verify the declared release exactly once after its train completes. |
+| Authoritative plan and prompts | Build the DAG, release trains, milestone contract, and design-gate scope. |
+| Local history ledger | Carry prior gate decisions and verified outcomes; rebuild it when absent. |
+| Current code plus merged predecessor diffs and PR evidence | Validate the plan’s assumptions, interfaces, dependencies, and acceptance. |
+| CI/check state and verification commands | Confirm predecessor outcomes, reconciliation PRs, and implementation stacks. |
+| Provider PR metadata | Confirm bases, reviewed reconciliation, stack topology, and merge state. |
 
 ## Modes
 
 | Mode | Trigger | Behavior |
 | --- | --- | --- |
-| Sequential build | "run milestones", "run them one after another" | Run the next ready milestone, verify its stack, merge automatically after `GO` plus external gates, clean merged branches, prepare a completed release train when required, then continue to the next dependency-ready milestone. |
-| Parallel build | "run independent milestones in parallel" | Run a wave of dependency-ready milestones concurrently, one isolated worktree/session per milestone. Halt the wave on any `NO-GO` or failed external gate. Merge only stacks whose lane reports `GO` and whose external gates pass; prepare a release only after all of its train members merge. |
-| Resume | "continue the milestone sequence" | Read prior state, observe which milestone stacks and release-preparation PRs are merged, then launch the next dependency-ready milestone, release preparation, or wave. |
-| Merge and clean | "merge the stack", "ensure CI is green", "clean branches" | Treat the request as an explicit `GO` candidate for the current stack, then use stacked-PR discipline: verify order and CI, merge root-to-leaf, retarget children, clean merged local and remote branches, and evaluate whether the train is ready for release preparation. |
+| Sequential build | "run milestones", "one after another" | Reconcile the next ready milestone, run it only after `DESIGN GO`, merge after external gates, then continue. |
+| Parallel build | "run independent milestones in parallel" | Reconcile every candidate serially on the latest base; launch only the stable `DESIGN GO` wave in isolated worktrees. |
+| Resume | "continue the milestone sequence" | Reconstruct state from authoritative artifacts and external evidence, then reconcile the next ready milestone or release train. |
+| Merge and clean | "merge the stack", "ensure CI is green" | Verify design and merge gates, use stacked-PR discipline, clean verified merged branches, and evaluate release preparation. |
 
-Default to sequential build when the user does not explicitly request parallel execution. Default to autonomous merge-and-continue after a milestone reports `GO` and all external gates pass. Stop instead when the user explicitly requests human-review stop points, the milestone reports `NO-GO`, a required gate fails or is pending, a release target is unresolved, a required release-preparation gate fails, or the milestone contains a `HUMAN REVIEW GATE`.
+Default to sequential. Never launch code after `DESIGN NO-GO`, a failed or pending gate, an unresolved release target, or a required human gate.
 
 ## Workflow
 
-### 1. Inspect inputs
+### 1. Inspect inputs and local evidence
 
-1. Read `.docs/EXECUTION_PROMPTS.md` and extract each milestone heading plus the fenced `/goal` block that follows it.
-2. Read `.docs/DEVELOPMENT_PLAN.md` when present and extract `Depends on` rows and the release-train table. Use dependencies to build the DAG and release-train memberships to determine when preparation may start.
-3. For every milestone, reconcile its `RELEASE TRAIN` field with the plan. Record target release, included milestones, preparation trigger, required artifacts, release verification, and publication requirement. Stop on contradictions or unresolved `> GAP:` values.
-4. If the plan is missing or dependency rows are ambiguous, fall back to file order and treat milestones as sequential unless the prompt text explicitly says they are independent. Do not infer a release target or version.
-5. Confirm the worktree is clean before launching, merging, rebasing, cleanup, or release preparation. Stop on dirty state unless the user only asked for inspection.
-6. Confirm the current branch/base context. Do not run milestone work on an unrelated dirty branch.
+1. Read `.docs/DEVELOPMENT_PLAN.md`, `.docs/EXECUTION_PROMPTS.md`, and every `/goal` block. Extract dependencies, release-train fields, design-reevaluation rows, and exact verification commands.
+2. Read `.docs/DEVELOPMENT_PLAN_HISTORY.md` when it exists. Verify it is ignored. Maintain this single ledger only in the canonical runner workspace.
+3. When the ledger is absent, reconstruct the gate context from committed plan/prompt history, merged predecessor PRs and diffs, CI/check results, verification output, and current code. Create a local ledger header and append the reconstruction evidence; do not claim unavailable history.
+4. Reconcile each prompt release-train field with the plan. Stop on contradictions or unresolved `> GAP:`.
+5. Confirm a clean canonical workspace before reconciliation, launches, merges, rebases, cleanup, or release preparation. Stop on unrelated dirty state.
 
-### 2. Build the execution DAG
+### 2. Build the provisional DAG
 
-Create a table before launching work:
+Before any launch, report:
 
-| Milestone | Depends on | Target release | Status | Runnable now | Execution lane |
-| --- | --- | --- | --- | --- | --- |
-| M1 | none | v2.4.0 | pending | yes | wave-1 |
-| M2 | M1 | v2.4.0 | blocked | no | wave-2 |
+| Milestone | Depends on | Target release | Design status | Implementation status | Runnable now | Lane |
+| --- | --- | --- | --- | --- | --- | --- |
+| M1 | none | v2.4.0 | awaiting design | pending | no | design-1 |
+| M2 | M1 | v2.4.0 | blocked | blocked | no | design-2 |
 
 Rules:
 
-- A milestone with unmerged dependencies is blocked.
-- Milestones with no dependencies between them can share a wave.
-- Parallel wave members must run in separate git worktrees and separate headless sessions.
-- If two independent milestones touch the same files, prefer sequential execution unless the user accepts conflict risk.
-- A release train becomes eligible for preparation only when every included milestone is externally observed as merged. A train with target `none` has no release-preparation work.
+- An unmerged dependency blocks both design and implementation.
+- Release preparation begins only after every train member is externally merged.
+- A `DESIGN GO` applies only to the exact authoritative plan/prompt revision that was inspected.
+- A material reconciliation invalidates every provisional design result for affected milestones. Re-read the artifacts and rebuild the DAG before any implementation launch.
 
-### 3. Launch milestone work
+### 3. Reconcile milestone design
 
-Use a fresh top-level session per milestone. Do not use same-context subagents for milestone implementation; shared context and a shared checkout can hide ordering bugs.
+Run design gates serially in fresh top-level sessions from the canonical clean base. A design session must do only the prompt’s `PRE-IMPLEMENTATION DESIGN GATE`; it must not create product-code branches, write product code, or launch implementation PRs.
 
-Preferred headless shape for omp environments:
+For each dependency-ready milestone:
+
+1. Supply the current authoritative plan/prompt and local history context.
+2. Inspect the milestone’s source-map rows, current code, merged predecessor diffs, predecessor PR outcomes, CI/check evidence, verification output, release fields, and every declared dependent milestone.
+3. Require one exact outcome:
+   - `DESIGN GO — PLAN REVISION: none`
+   - `DESIGN GO — PLAN REVISION: <entry IDs>`
+   - `DESIGN NO-GO — REASON: <blocking evidence>`
+4. Append the evidence, decision, changed sections, downstream impact, and authorization to the canonical ignored ledger.
+5. On `DESIGN NO-GO`, stop the affected dependency closure. Leave no product-code branch or PR.
+6. On a material revision, require a docs-only reconciliation PR containing all affected plan/prompt updates and no product code. Require that PR to be reviewed, green, and externally merged. Then update the canonical base, reload both authoritative artifacts, rebuild the DAG/release trains/waves, and rerun invalidated design gates.
+7. On `DESIGN GO — PLAN REVISION: none`, retain the result only until the next authoritative artifact revision or predecessor merge.
+
+Do not run design gates concurrently. The ignored ledger has one canonical writer. A parallel implementation wave is eligible only after each member has a current `DESIGN GO`.
+
+HARD STOP FOR SHARED DRIFT: A shared invalidated assumption blocks every affected implementation lane. A request to keep lanes running does not authorize scaffolding, partial code, or work on allegedly unaffected surfaces. Stop or leave those implementation sessions unlaunched; only the serialized canonical design-reconciliation session may continue. Never let an isolated worktree write the history ledger.
+
+### 4. Launch implementation
+
+Use a fresh top-level session per milestone. Provide the exact prompt plus the already-verified design evidence and authoritative artifact revision. The implementation session must confirm that revision before changing code; any newly discovered design mismatch returns to Step 3.
+
+Preferred headless shape for omp:
 
 ```bash
 omp -p --profile <run-name> --auto-approve --mode json --max-time <seconds> "<milestone /goal block>"
 ```
 
-Isolation rules:
+Rules:
 
-1. Sequential mode can use the main checkout when the tree is clean.
-2. Parallel mode must create one worktree per milestone from the correct base.
-3. Name worktrees and temporary run branches with milestone IDs and a short slug; avoid branch names that imply chronology beyond the dependency DAG.
-4. Capture each run's final output, PR URLs, branch names, and verification output.
+1. Sequential mode may use the canonical checkout only when clean.
+2. Parallel mode uses separate worktrees and sessions from the same reconciled base.
+3. If independent milestones overlap files after reconciliation, run them sequentially unless the user explicitly accepts conflict risk.
+4. Capture final verdicts, PR URLs, bases, verification output, review evidence, and material learnings.
 
-### 4. Verify before advancing
+### 5. Verify before merging
 
-Treat runner output as a hint. Verify with external state:
+Treat runner output as a hint. Verify externally:
 
 | Gate | Requirement |
 | --- | --- |
-| Stack verdict | Milestone final output contains `GO — RELEASE: <target>` with evidence; `NO-GO`, missing verdict, ambiguous verdict, or target mismatch stops the sequence. |
-| PR existence | Expected PR stack exists. |
-| PR bases | Root PR targets the intended base; child PRs target the previous PR branch. |
-| Checks | CI/checks are green or pending state is explicitly reported and treated as not done. |
-| Verification | Milestone `VERIFICATION` commands pass with expected output. |
-| Review | Generated prompt's per-PR and whole-stack review criteria are complete. |
-| Cleanliness | No accidental dirty files remain in the worktree. |
-| Release target | The target agrees between plan, prompt, and verdict; it is neither unresolved nor invented. |
-| Release readiness | Before train completion, release preparation remains pending and no version or changelog update starts. After completion, every train member is externally merged. |
-| Release preparation | Applies only after train completion when artifacts are required: version source and/or `CHANGELOG.md` changes are present, reviewed, green, merged, and pass the train's release verification. |
+| Design verdict | A current `DESIGN GO` matches the authoritative artifact revision used by the implementation. |
+| Reconciliation | When revised, the docs-only PR is scope-clean, reviewed, green, and merged before code starts. |
+| Stack verdict | Final output contains `GO — RELEASE: <target>` with evidence. Missing, ambiguous, or `NO-GO` stops. |
+| PR topology | Root targets the intended base and children target the preceding branch. |
+| Checks and verification | CI is green and every milestone command passes with expected output. Pending is not done. |
+| Review | Per-PR and whole-stack criteria are complete. |
+| Release target | Plan, prompt, and verdict agree; no unresolved or invented target exists. |
+| Cleanliness | No accidental non-ignored worktree files remain. |
 
-If any gate fails, stop the sequence. Report the failure, the last safe state, and the next required human/agent action. Do not launch downstream milestones on a broken base.
+Any failed gate stops the affected dependency closure. Report the last safe state and required remediation; independent release trains may continue only in isolated lanes.
 
-### 5. Merge, prepare release, and continue
+### 6. Merge, record outcomes, and prepare release
 
-After a milestone reports `GO` and every external gate passes, merge the stack automatically unless the user explicitly requested no merge or the milestone contains a `HUMAN REVIEW GATE`. Use the `stacked-prs` skill for stack topology and merge discipline.
+After all gates pass, merge with `stacked-prs` root-to-leaf. Recheck CI after each retarget or rebase. After the leaf merges:
 
-Safe merge loop:
+1. Clean only verified merged branches.
+2. Re-run milestone verification on the merged base.
+3. Append verified material learnings and downstream milestones requiring renewed design review to the canonical local ledger.
+4. Recompute the DAG and release train from external merge state. Treat all downstream design results as stale after a predecessor merge.
+5. If the train is incomplete, continue only with dependency-ready design gates.
+6. If target or required artifacts are `none`, record `RELEASE PREP: not-required`.
+7. If required, run `ship-workflow` in an isolated release-preparation branch only after all train milestones merge. Update only source-traceable version/changelog artifacts; require reviewed green merged release-preparation PR and post-merge release verification. Do not tag, publish, or create a hosted release without explicit plan evidence.
 
-1. Verify PR order, branch bases, and CI/check state.
-2. Merge root PR first.
-3. Fetch and update local state.
-4. Rebase or retarget the child PR onto the new base according to the stack workflow.
-5. Re-run checks before merging the next PR.
-6. After the final PR merges, clean merged local and remote branches.
-7. Re-run the milestone verification commands on the merged base.
-8. Recompute the release train from external merge state. If another included milestone remains unmerged, report `Continue within release train` and launch only dependency-ready work.
-9. If the completed train's target is `none` or its required artifacts are `none`, record `RELEASE PREP: not-required`; do not invoke `ship-workflow`.
-10. If the completed train requires release preparation, launch a fresh isolated release-preparation session from the clean merged base. Invoke `ship-workflow` on a dedicated release-preparation branch and preserve its pre-flight, test, review, version-bump, changelog, atomic-commit, PR, and CI gates.
-11. Detect the version source and changelog from the plan and repository rather than assuming either exists. Update the version to the declared target only when the train requires a version update; update `CHANGELOG.md` only when the train requires it. Do not tag, publish, or create a hosted release unless the train explicitly requires that action.
-12. Verify the release-preparation PR is reviewed, green, and merged; then run the train's release verification on the merged base. Report `RELEASE PREP: ready` only after the required artifacts and verification pass.
-
-If the user wants to preserve the human review gate, stop after reporting the stack or release-preparation PR as ready and wait for observed merge before continuing. If the milestone or release preparation reports `NO-GO`, do not merge or advance; report the failed or pending gates.
-
-## Output Format
-
-For inspection or launch planning, output:
+## Output format
 
 ```text
 ## Milestone Runner Plan
 
-| Milestone | Depends on | Target release | Mode | Worktree/Profile | Status |
-| --- | --- | --- | --- | --- | --- |
+| Milestone | Depends on | Target release | Design status | Mode | Worktree/Profile | Status |
+| --- | --- | --- | --- | --- | --- | --- |
 
-## Launches
-- M1: <command/session/worktree summary>
+## Design evidence
+- Authoritative plan/prompt revision:
+- Local history: present | reconstructed
+- Reconciliation PR:
+- Affected downstream milestones:
 
 ## Gates
-- Stack verdict: <GO/NO-GO/missing>
-- PR bases: <pass/fail/pending>
-- CI: <pass/fail/pending>
-- Verification: <pass/fail/pending>
-- Review: <pass/fail/pending>
-- Release train: <target, included/merged milestones, pending members>
-- Release preparation: <not-required/pending/ready/NO-GO>
+- Design verdict:
+- Reconciliation:
+- PR bases:
+- CI:
+- Verification:
+- Review:
+- Release train:
+- Release preparation:
 
 ## Stop/Continue Decision
-<Continue within release train | Prepare release | RELEASE PREP: ready and continue | Stop for human review | Stop on NO-GO | Stop on failed gate>
+<Run design gate | Reconcile plan | Launch implementation wave | Continue within release train | Prepare release | Stop on DESIGN NO-GO | Stop on failed gate>
 ```
 
-For merge-and-clean requests, output:
-
-```text
-## Merge Result
-
-| PR | Branch | Base | CI before merge | Merge result | Cleanup |
-| --- | --- | --- | --- | --- | --- |
-
-## Release Train
-- Target:
-- Included milestones:
-- Externally merged milestones:
-- Required artifacts:
-- Release-preparation PR:
-- Version transition:
-- CHANGELOG.md status:
-- Publication status:
-- Verification after release preparation:
-
-## Remaining State
-- Open PRs:
-- Local branches:
-- Remote branches:
-- Verification after merge:
-```
+For merge-and-clean requests, also report each PR’s base, pre-merge CI, merge result, cleanup, post-merge verification, release-train state, and downstream milestones marked for renewed design review.
 
 ## Error handling
 
 | Problem | Resolution |
 | --- | --- |
-| Missing `.docs/EXECUTION_PROMPTS.md` | Stop; ask for the prompt file or run `plan-prompts` first. |
-| Ambiguous dependency graph | Use sequential execution unless the user explicitly authorizes parallel conflict risk. |
-| Dirty worktree | Stop before launching, merging, rebasing, cleanup, or release preparation. |
-| Parallel run file overlap | Prefer sequential execution; parallel only with explicit approval. |
-| Headless command unavailable | Fall back to manual copy/paste execution guidance and preserve the same gates. |
-| A milestone fails | Stop all downstream work, report failed gate, leave worktrees/branches intact for debugging. |
-| CI pending | Treat as not complete; wait or stop with pending status. |
-| Merge conflict | Stop and invoke stack conflict resolution; do not continue to downstream milestones. |
-| Missing or `NO-GO` verdict | Refuse the merge and report the failed, pending, or ambiguous gates. |
-| Release target is missing, contradictory, or unresolved | Stop the affected release train. Do not infer a semantic version or create a version/changelog update. |
-| Release train is incomplete | Continue only with its remaining dependency-ready milestones. Do not start release preparation. |
-| Required release preparation fails or is pending | Stop the affected train and only milestones whose declared dependency closure includes it. Independent trains may continue in isolated lanes. Leave the release-preparation branch and PR intact for remediation. |
+| Missing plan or prompt file | Stop; run `plan-prompts` first. |
+| Missing ignored history ledger | Reconstruct from authoritative artifacts, merged PRs, CI, and current code; recreate it locally. |
+| History path is not ignored | Stop before writing it; add or verify the exact ignore rule. |
+| Ambiguous dependency graph | Use sequential design gates; do not infer parallel safety. |
+| `DESIGN NO-GO` or missing design verdict | Stop the affected dependency closure before code work. |
+| Reconciliation changes plan/prompt | Merge the reviewed green docs-only PR, reload artifacts, rebuild the DAG, and rerun invalidated gates. |
+| Dirty workspace | Stop before state-changing operations. |
+| CI pending or failed | Treat as incomplete; do not merge or advance. |
+| Merge conflict | Stop and use stack conflict resolution; do not launch downstream work. |
+| Release target missing, contradictory, or unresolved | Stop the affected train; do not infer versioning or release artifacts. |
 
 ## Safety checklist
 
 Before yielding:
 
-- Every launched milestone has an observed state: pending, running, `GO`, `NO-GO`, merged, or failed.
-- No downstream milestone launched before its dependencies were externally observed as merged.
-- Parallel milestones used isolated worktrees/sessions.
-- Merge happened only after a `GO` verdict and green external gates, or after an explicit merge-and-clean request whose gates passed.
-- Every completed release train has an observed `RELEASE PREP` state: `not-required`, `pending`, `ready`, or `NO-GO`; no version/changelog preparation began before all train milestones merged.
-- Required version and changelog changes match the declared release target, are merged through a reviewed green release-preparation PR, and pass release verification.
-- CI and verification evidence is reported exactly, not inferred from agent self-report.
-- Local/remote cleanup only removed branches verified as merged.
+- Every considered milestone has an observed design state: awaiting, `DESIGN GO`, `DESIGN NO-GO`, invalidated, or blocked.
+- No product code or code PR began before a current `DESIGN GO`.
+- Every material revision merged through a reviewed green docs-only reconciliation PR before implementation.
+- Parallel work used isolated worktrees only after serialized design gates and a stable artifact revision.
+- Every merged milestone has verified post-merge behavior and recorded downstream reevaluation requirements.
+- Every completed release train has observed `RELEASE PREP` state and no early version/changelog work.
+- Cleanup removed only branches verified as merged.

--- a/skills/milestone-runner/evals/cases.yaml
+++ b/skills/milestone-runner/evals/cases.yaml
@@ -135,3 +135,83 @@ cases:
     rubric:
       - "repairing one existing stack is stacked-prs territory, not milestone orchestration"
     trigger_expected: false
+
+  - id: design_reconciliation_before_parallel_wave
+    prompt: >
+      M5 and M6 are currently independent and ready for a parallel implementation wave. Before
+      launch, M5's design gate finds that a shared authentication assumption invalidates both
+      milestones. Reconcile the plan and prompts, preserve the gitignored local history, and
+      only then decide whether either implementation lane may run.
+    fixtures: []
+    rubric:
+      - "serializes design reconciliation before launching or continuing parallel implementation"
+      - "updates the current and every affected downstream milestone, then rebuilds the DAG and waves"
+      - "requires a reviewed green merged docs-only reconciliation PR before dependent code PRs"
+      - "preserves one canonical ignored history ledger without concurrent writes"
+      - "halts every affected implementation lane and rejects continued scaffolding or partial code work"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(design gate|design reconciliation|DESIGN GO|DESIGN NO-GO)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(serial|sequential|before.*parallel|rebuild.*DAG|reload.*plan)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(docs-only|reconciliation.*PR|reviewed.*green)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(history.*canonical|single.*history|concurrent.*write)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(halt all|stop all|no.*scaffolding|do not.*continue.*code)"
+        weight: 0.9
+
+  - id: missing_ignored_history_reconstruction
+    prompt: >
+      Start M5 in a fresh worktree where the gitignored
+      .docs/DEVELOPMENT_PLAN_HISTORY.md is absent. The committed plan and prompts, merged
+      predecessor PRs, CI evidence, and current codebase are available. Reconstruct the required
+      design context and decide whether implementation may begin.
+    fixtures: []
+    rubric:
+      - "does not treat a missing ignored ledger as authoritative plan loss"
+      - "reconstructs design evidence from committed artifacts, merged predecessors, CI, and current code"
+      - "restores the local ledger after evidence is verified"
+      - "blocks implementation when reconciliation finds plan drift"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: ".docs/DEVELOPMENT_PLAN_HISTORY.md"
+        weight: 1.0
+      - type: matches_regex
+        target: "(merged PR|CI|current codebase|committed plan)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(reconstruct|restore|regenerate)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(block|DESIGN NO-GO|drift)"
+        weight: 0.8
+
+  - id: overlapping_parallel_milestones
+    prompt: >
+      M5 and M6 have no dependency edge and both report DESIGN GO, but their reconciled plans
+      modify the same authentication files. Run them in parallel anyway unless an explicit
+      exception is required.
+    fixtures: []
+    rubric:
+      - "detects file overlap after reconciliation before launching the implementation wave"
+      - "runs overlapping milestones sequentially unless the user explicitly accepts conflict risk"
+      - "does not treat dependency independence as sufficient parallel-safety evidence"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(overlap|same files|shared files|file conflict)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(sequential|serialize|one at a time)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(explicit.*accept|user.*accept|conflict risk)"
+        weight: 0.8

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: plan-prompts
-description: 'Generate `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` from system, design, architecture, or enhancement docs in a folder or explicit file list. Use when asked "create a development plan from docs", "generate execution prompts", "turn these design docs into milestones", "write DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md", "plan implementation from .docs", "create milestone execution prompts", "convert architecture docs into stacked PR prompts", or when given DOCS_DIR / REPO_CONTEXT / GLOBAL_CONSTRAINTS / STACK_DEPTH_HINT placeholders. NOT for auditing an existing plan; use plan-review. NOT for executing the stack; use stacked-prs.'
+description: 'Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.'
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   category: development
-  tags: [planning, execution-prompts, milestones, stacked-prs, release-management, docs]
+  tags: [planning, execution-prompts, milestones, adaptive-planning, stacked-prs, release-management, docs]
   difficulty: advanced
   phase: plan
   complements:
+    - milestone-runner
     - stacked-prs
     - plan-review
     - task-decomposer
@@ -15,10 +16,11 @@ metadata:
 
 # Development Plan and Execution Prompts
 
-Convert source documents into two standalone Markdown files:
+Convert source documents into a plan that remains valid as milestones merge:
 
-- `.docs/DEVELOPMENT_PLAN.md` — milestone plan with source traceability, dependencies, acceptance, verification, risks, and rollback notes.
-- `.docs/EXECUTION_PROMPTS.md` — one copy-paste `/goal` block per milestone that drives a reviewed stacked-PR implementation.
+- `.docs/DEVELOPMENT_PLAN.md` — the committed, authoritative milestone plan.
+- `.docs/EXECUTION_PROMPTS.md` — the committed, authoritative `/goal` contract for each milestone.
+- `.docs/DEVELOPMENT_PLAN_HISTORY.md` — the single local, append-only design-evidence ledger. It must be gitignored.
 
 This skill plans from documents only. Do not implement product code, create branches, open PRs, or execute the generated prompts.
 
@@ -35,8 +37,8 @@ Optional context:
 
 | Field | Meaning | Default |
 | --- | --- | --- |
-| `REPO_CONTEXT` | Target repo path or description; use actual repo structure, tooling, CI, style, and release conventions when a path exists. | Greenfield planning if absent. |
-| `GLOBAL_CONSTRAINTS` | Cross-cutting constraints not present in source docs: compliance, dependency policy, deadlines, perf budgets, release policy. | None. |
+| `REPO_CONTEXT` | Target repo path or description; inspect its current structure, tooling, CI, style, release conventions, and partial implementation. | Greenfield planning if absent. |
+| `GLOBAL_CONSTRAINTS` | Cross-cutting constraints absent from source docs. | None. |
 | `STACK_DEPTH_HINT` | Maximum PRs per milestone stack. | 6. |
 
 ## Workflow
@@ -44,26 +46,27 @@ Optional context:
 ### Phase 0 — Ingest and ground the plan
 
 1. Inventory every capability, contract, data model, integration, workflow, and non-functional requirement in the source docs.
-2. Preserve source order, but resolve authority by input shape: explicit file list order wins; otherwise newer or more specific design docs refine broader overview docs.
+2. Preserve source order, but resolve authority by input shape: explicit file-list order wins; otherwise newer or more-specific design docs refine broader overview docs.
 3. Build a traceability table from source references to planned capabilities. Use document paths plus section names or line ranges when available.
-4. Record `> ASSUMPTION:` for defensible defaults where docs are silent.
-5. Record `> GAP:` for missing, ambiguous, or contradictory requirements. Contradictions that change architecture, data semantics, security posture, or acceptance block file creation until resolved.
-6. Map dependencies between capabilities. Dependencies must be implementation-relevant, not topical adjacency.
-7. Inspect the target repo when available: CI workflows, package manager, test runner, type checker, linter, existing test naming, existing partial implementations, repository conventions, version source, `CHANGELOG.md`, tags, release branches, and documented release commands. Copy exact verification and release commands from the repo's own config or CI when possible.
-8. Identify source-traceable release targets and group milestones into shared release trains. Every milestone must explicitly target a named release, an unversioned release train, `none`, or a visible `> GAP:`. Never infer a semantic version from feature scope.
-9. If the repo is greenfield, make M1 establish the minimal skeleton and verification surface needed for later milestones to be testable.
+4. Record `> ASSUMPTION:` for defensible defaults. Record `> GAP:` for missing, ambiguous, or contradictory requirements. A contradiction affecting architecture, data semantics, security posture, or acceptance blocks output until resolved.
+5. Map implementation-relevant dependencies. Inspect the target repo when available: CI, package manager, test/type/lint commands, naming conventions, partial implementations, version source, `CHANGELOG.md`, tags, branches, and release commands.
+6. Identify source-traceable release targets and group milestones into shared release trains. Every milestone must target a named release, `unversioned`, `none`, or visible `> GAP:`. Never infer a version.
+7. For a greenfield repo, make M1 establish the minimum verification surface required by later milestones.
+8. If existing plan/prompt artifacts are present, read them before regenerating. Treat them as the current committed contract, not as immutable truth.
 
-Summarize Phase 0 in the chat response only. Do not duplicate the full ingest inventory inside the generated files.
+Summarize the inventory, dependencies, release trains, assumptions, gaps, and verification surface in chat only.
 
-### Phase 1 — Write `.docs/DEVELOPMENT_PLAN.md`
+### Phase 1 — Write plan and local history
 
-Create `.docs` if it does not exist. Write a standalone plan with this structure:
+Create `.docs` when absent. Create `.docs/DEVELOPMENT_PLAN_HISTORY.md` with a header stating that it is local evidence only; `DEVELOPMENT_PLAN.md` and `EXECUTION_PROMPTS.md` are authoritative. Verify the exact history path is ignored with `git check-ignore`. When it is not ignored, add only `.docs/DEVELOPMENT_PLAN_HISTORY.md` to `.gitignore`; create `.gitignore` with that one rule only when it does not exist.
+
+Write `.docs/DEVELOPMENT_PLAN.md` with this structure:
 
 ```markdown
 # Development Plan — <System>
 
 ## 1. Context & Source Map
-<2–4 sentences, then a table mapping plan sections and milestone groups to source documents/sections.>
+<2–4 sentences and a table mapping plan sections and milestone groups to source documents/sections.>
 
 ## 2. Assumptions & Gaps
 <Visible `> ASSUMPTION:` and `> GAP:` entries, or "None.">
@@ -79,7 +82,14 @@ graph TD
 | --- | --- | --- | --- | --- | --- |
 | `<version | unversioned | none>` | `<M1, M2>` | All included milestones are externally merged. | `<version update | CHANGELOG.md | both | none>` | `<exact command or binary manual check>` | `<required command/workflow | not requested>` |
 
-## 5. Sections & Milestones
+## 5. Plan Evolution Protocol
+- The committed plan and prompt files are authoritative. The ignored history ledger is reconstructible local evidence.
+- Before each milestone, inspect its current plan/prompt, source map, current codebase, merged predecessor diffs, predecessor verification/CI evidence, and the local history when available.
+- Record exactly one `DESIGN GO — PLAN REVISION: none`, `DESIGN GO — PLAN REVISION: <entry IDs>`, or `DESIGN NO-GO — REASON: <blocking evidence>`.
+- A material mismatch updates the current milestone and every directly or transitively affected future milestone in both authoritative files. Recompute the dependency graph, critical path, and release-train membership when affected.
+- `DESIGN NO-GO` blocks code, branches, and implementation PRs. A material plan revision requires a docs-only reconciliation PR that is reviewed, green, and externally merged before implementation.
+
+## 6. Sections & Milestones
 ### Section A — <name>
 #### M1 — <title>
 | Field | Value |
@@ -91,90 +101,87 @@ graph TD
 | Deliverables | Concrete artifacts or behavior. |
 | Acceptance | Binary, testable statements. |
 | Verification | Exact command(s) and expected result. |
-| Risks & rollback | Failure modes; stack is the rollback unit unless a finer rollback is doc-traceable. |
-| Est. PRs | Integer ≤ `STACK_DEPTH_HINT`. |
+| Design reevaluation | Evidence to inspect before implementation; list direct/transitive dependent milestone IDs that require review if this design changes. |
+| Risks & rollback | Failure modes; stack is the rollback unit unless a finer rollback is source-traceable. |
+| Est. PRs | Integer ≤ `STACK_DEPTH_HINT`; exclude a conditional docs-only reconciliation root PR. |
 
-## 6. Cross-Cutting Concerns
+## 7. Cross-Cutting Concerns
 <Security, privacy, perf, observability, migrations, back-compat, release management — only when source-traceable.>
 
-## 7. Critical Path
+## 8. Critical Path
 <Ordered table or Mermaid diagram through the DAG and release-train completion.>
 ```
 
 Planning rules:
 
-- Decompose by capability or layer, not by file.
-- Each milestone must be standalone and self-verifiable.
-- Split any milestone estimated above `STACK_DEPTH_HINT` PRs.
-- Order foundations before consumers.
-- Keep shared context in the preamble; do not repeat it in every milestone.
-- Every acceptance row must be checkable by a command, asserted script output, CI signal, or clearly flagged minimal manual check.
-- Assign release preparation once per shared release train, after all included milestones merge. Do not create a version bump or changelog entry per feature milestone.
-- Derive version and changelog requirements from source documents and repository conventions. Use `none` only when evidence shows that no release artifact is required; use `> GAP:` rather than inventing a release target or versioning policy.
-- Use Mermaid and Markdown tables only for visuals.
-- Validate the Mermaid DAG before final output when Mermaid validation tooling is available.
+- Decompose by capability or layer, not by file. Keep milestones standalone and self-verifiable.
+- Every acceptance row needs a command, asserted output, CI signal, or clearly flagged minimum manual check.
+- Assign release preparation once per shared release train, after every included milestone merges.
+- Derive version/changelog requirements from source and repo evidence. Use `> GAP:` rather than inventing release policy.
+- Use Mermaid and Markdown tables only. Validate Mermaid when tooling is available.
 
-### Phase 2 — Write `.docs/EXECUTION_PROMPTS.md`
+### Phase 2 — Write execution prompts
 
-Create one `/goal` block per milestone. The prompt must trace directly to the matching milestone's objective, deliverables, acceptance, and verification rows. Do not invent scope that is not in the plan.
-
-Use this file structure:
+Create one `/goal` block per milestone. It must trace to that milestone’s objective, deliverables, acceptance, verification, design-reevaluation row, and release train. Do not invent scope.
 
 ```markdown
 # Execution Prompts — <System>
 
 ## Global execution rules (apply to every goal)
-- Use the `stacked-prs` skill: each PR is based on the previous PR's branch until that base merges.
-- Conventional Commits, atomic commits, multiple commits per PR grouped into a reviewable narrative.
-- No attribution of any kind: no `Co-authored-by`, no AI/tool mentions, no generated-by text, no emoji.
-- Each PR is one coherent, independently reviewable unit.
-- Review each PR individually, then review the full stack for cumulative coherence.
-- A `GO` makes only the milestone stack eligible for merge. Release preparation is deferred until every milestone in its shared release train is externally merged; the runner owns that release workflow.
-- Done = all PRs open and correctly based, checks green, individual and stack review complete, zero attribution, and a final release-aware `GO`/`NO-GO` merge verdict with evidence. `GO` authorizes an autonomous runner to merge after it independently verifies the gates; `NO-GO` blocks merge and downstream milestones.
+- Use `stacked-prs`; each implementation PR is based on the preceding stack branch until that base merges.
+- Use Conventional Commits, atomic commits, no attribution, and independently reviewable PRs.
+- Run the mandatory pre-implementation design gate before creating product-code branches or changing product code.
+- The committed plan/prompt files are authoritative. The local ignored history ledger is evidence; rebuild it from committed artifacts, merged PRs, CI, and current code when absent.
+- A material plan change must update the current milestone and every affected future milestone before implementation. Rebuild the DAG and release trains after the update.
+- A docs-only reconciliation PR is required for a material revision. It must be reviewed, green, and externally merged before code begins.
+- A shared mismatch in a proposed parallel wave blocks product-code work in every affected lane. Do not continue scaffolding, partial implementation, or isolated ledger writes while reconciliation is pending.
+- `GO` only makes the milestone stack merge-eligible. Release preparation remains deferred until every milestone in its train is externally merged.
 
 ### M1 — <title>
 ```text
 /goal Deliver milestone M1 (<title>) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
 
-CONTEXT: DEVELOPMENT_PLAN.md §5 M1 + source docs. Preconditions: <none | Mx merged>. Repo: <language, package manager, test runner, type/lint/CI surface>.
+CONTEXT: DEVELOPMENT_PLAN.md §6 M1 + source docs. Preconditions: <none | Mx merged>. Repo: <language, package manager, test runner, type/lint/CI surface>.
 OBJECTIVE: <objective and acceptance criteria as the success contract>.
 RELEASE TRAIN: target=<named version | unversioned | none | > GAP: unresolved>; included milestones=<Mx>; preparation trigger=<all included milestones externally merged>; required artifacts=<version update | CHANGELOG.md | both | none>; release verification=<exact command or binary manual check>; publication=<required command/workflow | not requested>.
 
-PLANNED STACK (stacked-prs skill; refine only to keep PRs reviewable):
+PRE-IMPLEMENTATION DESIGN GATE:
+1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
+2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
+3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone.
+4. Append one ledger entry: timestamp, milestone, decision, trigger, evidence, plan/prompt sections changed, downstream impact, and implementation authorization.
+5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
+6. If a mismatch exists, update both authoritative artifacts for M1 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`. This records a completed diagnosis but blocks product-code work until the reconciliation prerequisite merges.
+7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop. After a reconciliation PR merges, repeat this gate and require `DESIGN GO — PLAN REVISION: none` before implementation.
+
+RECONCILIATION RULE: A material revision opens `docs(plan): reconcile M1 design` as a docs-only prerequisite PR. It contains no product code, must be reviewed, green, and externally merged before any code PR, and must not be folded into an implementation PR.
+
+PLANNED STACK (refine only to keep PRs reviewable):
+0. Conditional prerequisite `docs(plan): reconcile M1 design` — scope: authoritative plan/prompt updates only; gate: reviewed, green, and merged before the implementation stack.
 1. PR-1 <purpose> — scope: <areas>; commits: <c1>, <c2>; verification: <PR-specific command if narrower than milestone command>
 2. PR-2 <purpose, on PR-1> — scope: <areas>; commits: <c1>, <c2>
 
-CONSTRAINTS: Conventional Commits, atomic commits, multi-commit PRs, no attribution, no scope leakage across PRs, minimal dependencies, respect repo style. Do not update version or changelog artifacts before the release-train trigger unless the milestone itself is the source-traceable release-preparation unit.
-VERIFICATION (must pass): <exact command(s) + expected result from M1>.
+CONSTRAINTS: no scope leakage, minimal dependencies, repo style, no version/changelog updates before the release-train trigger unless source-traceable.
+VERIFICATION (must pass): <exact command(s) and expected result>.
 REVIEW:
 Per PR:
-- Scope boundary: diff matches PR purpose; no milestone leakage; no grab-bag changes.
-- Contract integrity: public APIs, schemas, CLI flags, config keys, and data shapes match the plan.
-- Tests: changed behavior has meaningful unit/integration coverage; assertions test behavior and invariants, not implementation trivia.
-- Error handling: failures are loud, typed/classified where useful, and not hidden behind broad fallbacks.
-- Security/privacy: input validation, secret handling, auth/authz, and data exposure risks are addressed where relevant.
-- Data safety: migrations or destructive operations are dry-run or opt-in where applicable, reversible where possible, and covered by rollback notes.
-- Maintainability: follows repo conventions; no speculative abstractions; no duplicate source of truth.
-- History: Conventional Commits, atomic commits, no attribution, no unrelated formatting churn.
-- Local verification: PR-specific commands pass and output is captured.
+- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
+- Failures are loud; security, data safety, and rollback requirements are addressed where relevant.
+- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
+- PR-specific verification output is captured.
 Whole stack:
-- Topology: every PR is based on the previous PR branch; no orphan or duplicate commits.
-- Cumulative acceptance: the leaf stack satisfies every Mx acceptance row.
-- Integration: interfaces added lower in the stack are consumed consistently higher in the stack.
-- Regression surface: existing behavior remains covered; no test deletions without replacement.
-- CI/checks: checks green on every PR or pending provider checks are explicitly reported.
-- Rebase-clean: stack can be rebased from root to leaf without unresolved conflicts.
-- Human handoff: PR URLs, verification output, risks, and manual gates are reported.
-FINAL VERDICT:
-- Report exactly one verdict: `GO — RELEASE: <target> — RELEASE PREP: <pending | not-required>` or `NO-GO — RELEASE: <target> — REASON: <blocking gate>`.
-- `GO` only when every PR is open, correctly based, reviewed, green, locally verified, and the whole stack satisfies every milestone acceptance row. Use `pending` whenever release preparation has not started; only use `not-required` when the release train requires no release artifacts.
-- `NO-GO` when any check is failing or pending, review is incomplete, branch topology is wrong, verification is missing, scope leaked, a human/manual gate remains, merge readiness is ambiguous, or the target release is unresolved.
-- Evidence: list target release, included and remaining train milestones, PR URLs, branch bases, CI/check status per PR, verification command output, review completion, residual risks, and any manual gate.
-DONE: stack open and correctly based, checks green, per-PR and whole-stack reviews complete, final release-aware `GO`/`NO-GO` verdict reported with evidence.
+- Bases form one valid stack; cumulative acceptance and integration hold; CI is green; no regression coverage is removed without replacement.
+- The docs-only root, when present, is reviewed and green before dependent code PRs.
+- Report PR URLs, bases, verification, risks, manual gates, and review completion.
+FINAL VERDICTS:
+- Report the design verdict before the merge verdict.
+- Then report exactly one merge verdict: `GO — RELEASE: <target> — RELEASE PREP: <pending | not-required>` or `NO-GO — RELEASE: <target> — REASON: <blocking gate>`.
+- `GO` requires `DESIGN GO`, every PR correctly based/reviewed/green, local verification, and full milestone acceptance. `NO-GO` applies to pending or failed checks, incomplete review, scope drift, ambiguous readiness, manual gates, or unresolved release target.
+DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
 ```
 ```
 
-For any milestone involving deletion, destructive migrations, irreversible rewrites, user-data mutation, or source pruning, add this inside that milestone prompt:
+Add this to destructive milestones:
 
 ```text
 HUMAN REVIEW GATE: Do not merge or run destructive paths unattended until a human reviews dry-run output, rollback notes, and audit/tombstone logging.
@@ -184,36 +191,25 @@ HUMAN REVIEW GATE: Do not merge or run destructive paths unattended until a huma
 
 Before yielding, check and fix:
 
-- Every inventoried capability maps to at least one milestone.
-- The dependency graph is acyclic.
-- Every milestone has binary acceptance and command-backed verification.
-- Every milestone has an explicit named target, `unversioned`, `none`, or a visible `> GAP:`.
-- Each shared release train lists included milestones, trigger, required artifacts, and verification; version or changelog work is assigned only once per train.
-- No milestone exceeds `STACK_DEPTH_HINT` PRs.
-- Every `/goal` block traces to one milestone's deliverables, verification, and release train.
-- Every `/goal` block contains no-attribution rules, per-PR review, whole-stack review, and final release-aware `GO`/`NO-GO` verdict requirements.
-- Assumptions and gaps are visible, not buried in prose.
-- Mermaid diagrams parse when Mermaid validation tooling is available.
-- The only files written are `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md` unless the user explicitly requests otherwise.
+- Every capability maps to a milestone; the DAG is acyclic; every milestone has binary acceptance and command-backed verification.
+- Every milestone has an explicit release target and design-reevaluation row.
+- Every prompt includes the design gate, dependency-impact propagation, local-history treatment, docs-only reconciliation rule, per-PR/whole-stack review, and both verdict formats.
+- Release preparation is assigned once per train and only after every train milestone merges.
+- `.docs/DEVELOPMENT_PLAN_HISTORY.md` exists, is the only history ledger, and is ignored by an exact or broader verified rule.
+- Only the two authoritative artifacts, the one local history ledger, and the minimum `.gitignore` update required to ignore it are written.
 
 ## Error handling
 
 | Problem | Resolution |
 | --- | --- |
-| Folder contains no readable docs | Stop and report the empty input set. Do not invent a plan. |
-| Explicit file path is missing | Stop and report the missing path. Do not silently skip it. |
-| Source docs contradict each other | Emit blocking `> GAP:` items in chat; proceed only if a defensible default does not change architecture, data semantics, security posture, or acceptance. |
+| Folder contains no readable docs or an explicit path is missing | Stop; report the missing input. |
+| Source docs contradict on architecture, data semantics, security, or acceptance | Emit blocking `> GAP:`; do not invent a resolution. |
 | Repo tooling is absent | Treat as greenfield and make M1 establish verification. |
-| Verification cannot be fully automated | Use the smallest manual binary check, flag it in the milestone, and explain why automation is unavailable. |
-| Release target or policy is absent | Emit a visible `> GAP:`. Do not invent a semantic version, version bump, changelog entry, tag, or publication step. |
-| Existing `.docs/DEVELOPMENT_PLAN.md` or `.docs/EXECUTION_PROMPTS.md` exists | Read it first, then overwrite only when the user requested regeneration. Preserve no stale milestones. |
+| Release policy is absent | Emit visible `> GAP:`; do not invent version, changelog, tag, or publication work. |
+| Existing authoritative artifacts exist | Read them first; overwrite only on requested regeneration; preserve no stale milestones. |
+| History path is not ignored | Add only the exact ignore rule, verify it, then write the ledger. |
+| History ledger is missing later | Reconstruct evidence from committed artifacts, merged PRs, CI, and current code; do not treat its absence as plan loss. |
 
-## Output Format and Chat Response
+## Output and chat response
 
-1. Phase 0 ingest summary: capabilities, dependencies, release trains, assumptions, gaps, verification surface, and release conventions.
-2. Paths written.
-3. Quality-gate result.
-4. Any destructive milestones requiring human review.
-5. Release trains blocked by unresolved targets or manual release gates.
-
-Do not paste the full generated files into chat unless requested.
+Report the Phase 0 summary, paths written, ignored-history verification, quality-gate result, destructive human gates, and unresolved release targets. Do not paste generated files unless requested.

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -5,7 +5,7 @@ cases:
       Save the outputs as .docs/DEVELOPMENT_PLAN.md and .docs/EXECUTION_PROMPTS.md. Make the review process in each execution prompt robust enough for per-PR and whole-stack review, and make every milestone end with a structured GO/NO-GO merge decision.
     fixtures: []
     rubric:
-      - "creates exactly DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md under .docs"
+      - "creates DEVELOPMENT_PLAN.md, EXECUTION_PROMPTS.md, and the mandatory ignored DEVELOPMENT_PLAN_HISTORY.md ledger under .docs"
       - "includes source map, assumptions/gaps, dependency graph, milestones, acceptance, and verification"
       - "includes one /goal block per milestone with detailed per-PR and whole-stack review criteria"
       - "requires every milestone run to report GO/NO-GO with evidence for merge readiness"
@@ -17,6 +17,12 @@ cases:
       - type: contains
         target: ".docs/EXECUTION_PROMPTS.md"
         weight: 1.0
+      - type: contains
+        target: ".docs/DEVELOPMENT_PLAN_HISTORY.md"
+        weight: 0.9
+      - type: matches_regex
+        target: "(gitignore|gitignored|check-ignore)"
+        weight: 0.8
       - type: matches_regex
         target: "(Source Map|Assumptions|Gaps|Dependency Graph|Milestones)"
         weight: 0.8
@@ -135,3 +141,57 @@ cases:
     rubric:
       - "executing stacked PRs is stacked-prs territory, not plan/prompt generation"
     trigger_expected: false
+
+  - id: adaptive_milestone_design_gate
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md for M1 through M6. M4 changed
+      the persistence interface that M5 and M6 depend on. Before M5 implementation, require an
+      evidence-backed design gate that updates M5 and every affected future milestone before code
+      can start.
+    fixtures: []
+    rubric:
+      - "adds a mandatory DESIGN GO or DESIGN NO-GO gate before implementation"
+      - "requires repository and predecessor-evidence analysis rather than relying on the old plan"
+      - "updates the current milestone and every affected transitive dependent prompt and plan section"
+      - "blocks code when the design is invalid or reconciliation is incomplete"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(DESIGN GO|DESIGN NO-GO|design gate|design reconciliation)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(predecessor|merged PR|current codebase|repository evidence)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(dependent|downstream|transitive|M6)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(block.*code|before.*implementation|do not.*implement)"
+        weight: 0.9
+
+  - id: ignored_plan_history_ledger
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md with one local,
+      gitignored .docs/DEVELOPMENT_PLAN_HISTORY.md ledger. It must record each design-gate
+      decision, evidence, plan/prompt changes, and downstream impact, but the committed plan
+      and prompts remain authoritative.
+    fixtures: []
+    rubric:
+      - "creates exactly one additional history artifact at the requested path"
+      - "ensures the exact history path is gitignored without assuming a broader ignore rule"
+      - "treats the ledger as local evidence rather than authoritative planning state"
+      - "records no-change and changed design-gate decisions with evidence and impact"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: ".docs/DEVELOPMENT_PLAN_HISTORY.md"
+        weight: 1.0
+      - type: matches_regex
+        target: "(gitignore|gitignored|check-ignore)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(authoritative|source of truth|committed plan)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(evidence|downstream impact|PLAN REVISION)"
+        weight: 0.8


### PR DESCRIPTION
## Summary

Add an adaptive design-reconciliation contract to the planning and milestone-execution skills. Every milestone now validates its current design against the repository, merged predecessor outcomes, CI, verification evidence, and local design history before product work begins.

### Planning contract

- `plan-prompts` now generates three artifacts: committed `.docs/DEVELOPMENT_PLAN.md`, committed `.docs/EXECUTION_PROMPTS.md`, and local gitignored `.docs/DEVELOPMENT_PLAN_HISTORY.md`.
- The history ledger is explicitly reconstructible evidence, not the source of truth. The committed plan and prompts remain authoritative.
- Generated plans now include a Plan Evolution Protocol and per-milestone design-reevaluation requirements.
- Generated `/goal` blocks require an exact `DESIGN GO` or `DESIGN NO-GO` verdict before product-code branches or implementation PRs.
- Material drift updates the current milestone and every affected downstream milestone in both authoritative artifacts, then recomputes the dependency graph, critical path, and release trains.
- A material revision creates a docs-only `docs(plan): reconcile <milestone> design` prerequisite PR. It must be reviewed, green, and externally merged before implementation resumes.

### Execution contract

- `milestone-runner` serializes design gates in the canonical workspace before implementation waves launch.
- A missing ignored history ledger is rebuilt from committed planning artifacts, merged predecessor diffs and PR outcomes, CI/check state, verification output, and current code.
- A reconciliation merge invalidates affected provisional design decisions; the runner reloads the plan/prompt pair, rebuilds the DAG and release trains, and reruns the affected gates.
- Shared design drift blocks every affected lane. It explicitly prohibits continuing with scaffolding, partial code, allegedly unaffected work, or isolated worktree ledger writes.
- Parallel implementation remains available only after every candidate has a current `DESIGN GO — PLAN REVISION: none` against the same reconciled artifact revision.
- Post-merge outcomes append verified learnings to the local ledger and mark downstream milestones for fresh design review.

### Evaluation and catalog

- Added evaluation cases for adaptive design gates, dependent-prompt propagation, ignored-ledger handling, reconstruction after a missing ledger, reconciliation before parallel execution, shared-drift hard stops, and overlapping-file serialization.
- Updated existing evaluation coverage to require the mandatory local ledger even when the prompt does not name it.
- Updated the skill catalog and regenerated `manifest.yaml`.
- No `.docs` files are included in this branch.

## Skill Evaluator Results

```text
plan-prompts: 92/100 — PASS
milestone-runner: 92/100 — PASS
No evaluator CRITICAL or HIGH findings.
```

## Verification

```text
uv run scripts/validate_evals.py
Validated 72 skills, 17 agents, 9 hooks, 6 rules, 7 commands, 3 utilities, 11 presets — all passed

uv run scripts/validate_frontmatter.py
Validated 135 packages across 7 types — all passed

uv run scripts/validate_references.py
Validated 135 packages — all references intact

uv run scripts/evaluate_package.py --path skills/plan-prompts --threshold 70
92/100 — PASS

uv run scripts/evaluate_package.py --path skills/milestone-runner --threshold 70
92/100 — PASS

uv run pytest tests/ -v
303 passed
```

## Checklist

- [x] `SKILL.md` frontmatter validates for both changed skills.
- [x] Both descriptions contain six quoted trigger phrases and a `Use when` clause.
- [x] All file references validate.
- [x] Package evaluator scores are at least 70.
- [x] Package evaluator reports no CRITICAL or HIGH findings.
- [x] Evaluation schema and repository test suite pass.
- [x] No `.docs` files are committed.
- [ ] Tested locally with Claude Code.
