### PR TITLE
feat(skills): add terminal milestone handoffs

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -862,7 +862,7 @@ packages:
     difficulty: advanced
     phase: build
   - name: plan-prompts
-    version: 1.2.0
+    version: 1.3.0
     description: Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update
       DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository
       design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -777,7 +777,7 @@ packages:
     difficulty: advanced
     phase: review
   - name: milestone-runner
-    version: 1.2.0
+    version: 1.3.0
     description: Use when asked to "run milestones", "execute EXECUTION_PROMPTS.md", "continue the milestone sequence", "run
       independent milestones in parallel", "merge the stack", or "reconcile M5" after prior work changes the current design.
       Not for generating plan files; use plan-prompts. Not for repairing one stack; use stacked-prs.

--- a/skills/milestone-runner/SKILL.md
+++ b/skills/milestone-runner/SKILL.md
@@ -2,7 +2,7 @@
 name: milestone-runner
 description: 'Use when asked to "run milestones", "execute EXECUTION_PROMPTS.md", "continue the milestone sequence", "run independent milestones in parallel", "merge the stack", or "reconcile M5" after prior work changes the current design. Not for generating plan files; use plan-prompts. Not for repairing one stack; use stacked-prs.'
 metadata:
-  version: 1.2.0
+  version: 1.3.0
   category: development
   tags: [milestones, orchestration, adaptive-planning, stacked-prs, ci, release-management, execution-prompts]
   difficulty: advanced
@@ -27,6 +27,8 @@ A milestone has two independent gates:
 2. **Merge gate.** After implementation, require release-aware `GO` plus external PR, CI, verification, and review evidence.
 
 An ignored history ledger is reconstructible local evidence, not authoritative state. `.docs/DEVELOPMENT_PLAN.md` and `.docs/EXECUTION_PROMPTS.md`, merged PRs, CI, and current code remain authoritative.
+
+Every terminal milestone result must print the literal heading `NEXT STEPS:` followed by concrete, ordered actions: the current milestone action, release-preparation state, and the next runnable milestone. A `NO-GO` must name remediation and either an independent milestone that can proceed or the reason no milestone can. A prose follow-up or JSON `next_steps` key is insufficient.
 
 | Evidence | Use |
 | --- | --- |
@@ -139,6 +141,7 @@ After all gates pass, merge with `stacked-prs` root-to-leaf. Recheck CI after ea
 5. If the train is incomplete, continue only with dependency-ready design gates.
 6. If target or required artifacts are `none`, record `RELEASE PREP: not-required`.
 7. If required, run `ship-workflow` in an isolated release-preparation branch only after all train milestones merge. Update only source-traceable version/changelog artifacts; require reviewed green merged release-preparation PR and post-merge release verification. Do not tag, publish, or create a hosted release without explicit plan evidence.
+8. After every `GO` or `NO-GO`, derive and report `NEXT STEPS` from the observed DAG, external merge state, and release-train contract. On `GO`, state whether to merge or record the milestone as merged, whether release preparation is deferred or must begin, and the next dependency-ready milestone. On `NO-GO`, state the exact remediation and retry gate, then either `SKIP <current milestone> FOR NOW; RUN <next milestone> — independent of <blocked dependency closure>` or `NO NEXT MILESTONE — <blocking reason>`. Do not advance a dependent milestone or invent release work.
 
 ## Output format
 
@@ -163,6 +166,12 @@ After all gates pass, merge with `stacked-prs` root-to-leaf. Recheck CI after ea
 - Review:
 - Release train:
 - Release preparation:
+
+## NEXT STEPS:
+1. Current milestone: <merge the reviewed stack | already merged | stop on NO-GO>.
+2. Release: <deferred until listed train members merge | begin declared preparation | not-required | blocked with reason>.
+3. Next milestone: <M# and dependency/release-train evidence | `SKIP <current> FOR NOW; RUN M# — independent of <closure>` | `none — reason`>.
+4. For `NO-GO`: <specific remediation and exact retry gate>; otherwise `not applicable`.
 
 ## Stop/Continue Decision
 <Run design gate | Reconcile plan | Launch implementation wave | Continue within release train | Prepare release | Stop on DESIGN NO-GO | Stop on failed gate>
@@ -194,5 +203,6 @@ Before yielding:
 - Every material revision merged through a reviewed green docs-only reconciliation PR before implementation.
 - Parallel work used isolated worktrees only after serialized design gates and a stable artifact revision.
 - Every merged milestone has verified post-merge behavior and recorded downstream reevaluation requirements.
+- Every terminal milestone result includes ordered `NEXT STEPS` covering the current action, release-preparation state, next runnable milestone or blocking reason, and `NO-GO` remediation when applicable.
 - Every completed release train has observed `RELEASE PREP` state and no early version/changelog work.
 - Cleanup removed only branches verified as merged.

--- a/skills/milestone-runner/evals/cases.yaml
+++ b/skills/milestone-runner/evals/cases.yaml
@@ -215,3 +215,36 @@ cases:
       - type: matches_regex
         target: "(explicit.*accept|user.*accept|conflict risk)"
         weight: 0.8
+
+  - id: terminal_next_steps_handoff
+    prompt: >
+      M4 is NO-GO because migration verification fails. M5 shares M4's v3.1.0 release train and
+      depends on M4. M6 is dependency-independent and targets v3.2.0. Report the required
+      terminal next steps without tagging or publishing.
+    fixtures: []
+    rubric:
+      - "reports an ordered NEXT STEPS handoff after the NO-GO verdict"
+      - "names migration remediation and a retry gate"
+      - "blocks dependent M5 and v3.1.0 release preparation"
+      - "permits only independent M6 to proceed and explicitly identifies the skip"
+      - "does not tag or publish"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "NEXT STEPS"
+        weight: 1.0
+      - type: matches_regex
+        target: "(migration|verification).*(remediat|retry|fix)|(remediat|retry|fix).*(migration|verification)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(M5|dependent|blocked)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(M6|independent|SKIP.*RUN)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(release preparation|RELEASE PREP|deferred|blocked)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(do not tag|do not publish|not.*publish)"
+        weight: 0.8

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-prompts
 description: 'Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.'
 metadata:
-  version: 1.2.0
+  version: 1.3.0
   category: development
   tags: [planning, execution-prompts, milestones, adaptive-planning, stacked-prs, release-management, docs]
   difficulty: advanced
@@ -177,7 +177,15 @@ FINAL VERDICTS:
 - Report the design verdict before the merge verdict.
 - Then report exactly one merge verdict: `GO — RELEASE: <target> — RELEASE PREP: <pending | not-required>` or `NO-GO — RELEASE: <target> — REASON: <blocking gate>`.
 - `GO` requires `DESIGN GO`, every PR correctly based/reviewed/green, local verification, and full milestone acceptance. `NO-GO` applies to pending or failed checks, incomplete review, scope drift, ambiguous readiness, manual gates, or unresolved release target.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+NEXT STEPS: (required after either merge verdict; concrete, ordered, and evidence-backed)
+1. Current milestone: `<merge the reviewed stack | already merged | stop on NO-GO>`.
+2. Release: `<deferred until listed train members merge | begin declared preparation | not-required | blocked with reason>`.
+3. Next milestone: `<M# and dependency/release-train evidence | SKIP <current> FOR NOW; RUN M# — independent of <closure> | none — reason>`.
+4. For `NO-GO`: `<specific remediation and exact retry gate>`; otherwise `not applicable`.
+- On `GO`, steps 1–3 are mandatory. On `NO-GO`, steps 1–4 are mandatory; never advance a dependent milestone.
+- Render the literal heading `NEXT STEPS:`. A prose follow-up or JSON `next_steps` key is insufficient.
+- Never infer a milestone, remediation, version/changelog artifact, tag, or publication action.
+DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and the required next-steps list.
 ```
 ```
 
@@ -193,7 +201,7 @@ Before yielding, check and fix:
 
 - Every capability maps to a milestone; the DAG is acyclic; every milestone has binary acceptance and command-backed verification.
 - Every milestone has an explicit release target and design-reevaluation row.
-- Every prompt includes the design gate, dependency-impact propagation, local-history treatment, docs-only reconciliation rule, per-PR/whole-stack review, and both verdict formats.
+- Every prompt includes the design gate, dependency-impact propagation, local-history treatment, docs-only reconciliation rule, per-PR/whole-stack review, both verdict formats, and a concrete `NEXT STEPS` contract.
 - Release preparation is assigned once per train and only after every train milestone merges.
 - `.docs/DEVELOPMENT_PLAN_HISTORY.md` exists, is the only history ledger, and is ignored by an exact or broader verified rule.
 - Only the two authoritative artifacts, the one local history ledger, and the minimum `.gitignore` update required to ignore it are written.

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -195,3 +195,37 @@ cases:
       - type: matches_regex
         target: "(evidence|downstream impact|PLAN REVISION)"
         weight: 0.8
+
+  - id: terminal_next_steps_contract
+    prompt: >
+      Generate DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md for M4 and M5 in release v3.1.0,
+      plus M6 in independent release v3.2.0. Every milestone must report concrete next steps:
+      a green M4 stack needs merge, deferred v3.1.0 preparation, and its next milestone; a
+      migration-verification NO-GO for M4 needs remediation and may skip to independent M6.
+      Do not tag or publish without source evidence.
+    fixtures: []
+    rubric:
+      - "requires ordered NEXT STEPS after both GO and NO-GO terminal verdicts"
+      - "links GO handoff to merge state, deferred or required release preparation, and a next dependency-ready milestone"
+      - "links NO-GO handoff to the failed gate, remediation and retry, and only an independent milestone that may proceed"
+      - "does not invent tag or publication work"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "NEXT STEPS"
+        weight: 1.0
+      - type: matches_regex
+        target: "(GO.*merge|merge.*GO|NO-GO)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(release preparation|RELEASE PREP|deferred)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(migration|remediat|retry)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(M6|independent|SKIP.*RUN)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(do not tag|do not publish|without source evidence)"
+        weight: 0.8


### PR DESCRIPTION
## Summary

Adds a required, concrete terminal handoff to Armory's adaptive planning skills.

- `plan-prompts` now generates a literal `NEXT STEPS:` block after every milestone `GO` or `NO-GO` verdict. The block requires the current milestone action, release-preparation disposition, next runnable milestone or a blocking reason, and NO-GO remediation plus an exact retry gate.
- `milestone-runner` now validates and reports the same ordered handoff from the observed DAG, external merge state, and declared release train.
- NO-GO results can explicitly bypass the currently blocked closure only for an independent milestone using `SKIP <current> FOR NOW; RUN <next> — independent of <closure>`.
- Both skills continue to prohibit inferred versioning, tags, publication, and other undeclared release actions.
- Adds focused evaluation cases for terminal next-step behavior and regenerates the relevant manifest entries at version `1.3.0`.

No `.docs` files are included.

## Skill Evaluator Results

```text
plan-prompts
  D1 Frontmatter Quality: 20/20
  D2 Trigger Coverage: 18/18
  D3 Structural Completeness: 16/20
  D4 Content Depth: 18/22
  D5 Consistency: 12/12
  D6 Compliance: 8/8
  Overall: 92/100 (92%) — PASS

milestone-runner
  D1 Frontmatter Quality: 20/20
  D2 Trigger Coverage: 18/18
  D3 Structural Completeness: 16/20
  D4 Content Depth: 18/22
  D5 Consistency: 12/12
  D6 Compliance: 8/8
  Overall: 92/100 (92%) — PASS
```

## Verification

- `uv run pytest tests/test_generate_adapters.py tests/test_generate_manifest.py -q` — 23 passed.
- `uv run scripts/validate_frontmatter.py` — 135 packages passed.
- `uv run scripts/validate_references.py` — 135 packages passed.
- `uv run python scripts/validate_evals.py` — 72 skills, 17 agents, 9 hooks, 6 rules, 7 commands, 3 utilities, and 11 presets passed.
- RED/GREEN/REFACTOR pressure scenarios verified the literal `NEXT STEPS:` requirement for GO, NO-GO, deferred release preparation, completed release trains, and independent-milestone continuation.

## Checklist

- [x] `SKILL.md` files have valid YAML frontmatter with names and descriptions.
- [x] Skill names remain kebab-case and under 64 characters.
- [x] Descriptions retain `Use when` clauses and trigger phrases.
- [x] No secrets, credentials, or internal URLs are included.
- [x] All `SKILL.md` references resolve.
- [x] Both package evaluator scores exceed 70%.
- [x] No CRITICAL or HIGH evaluator findings.
- [ ] Tested locally with Claude Code; validation and pressure scenarios ran through the current harness instead.