### PR TITLE
feat(skills): add pr-swarm parallel PR-loop skill + command

### DIFF
--- a/commands/pr-swarm/COMMAND.md
+++ b/commands/pr-swarm/COMMAND.md
@@ -1,0 +1,78 @@
+---
+name: pr-swarm
+type: command
+description: 'Slash-command wrapper for the pr-swarm skill. `/pr-swarm #123 #456` (or bare numbers, space- or comma-separated) drives that many already-open pull requests to merge-ready at the same time, each in its own isolated git worktree and its own headless Claude Code session. Triggers on: "/pr-swarm", "pr-swarm #123 #456", "parallelize these PRs", "drive PR #123 and #456 to green in parallel", "own-PR-to-green fleet", "isolated worktree loops for my PRs". Use this command when a user wants a concise argument surface for parallelizing two or more of their own open pull requests while delegating independence checks, worktree naming, launch mechanics, and verification gates to skills/pr-swarm.'
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [git, pull-requests, worktree, slash-command, parallel-execution]
+  difficulty: advanced
+  phase: ship
+command:
+  syntax: /pr-swarm <PR#> [PR# ...]
+  handler: inline
+  dependencies:
+    - skills/pr-swarm
+---
+
+# PR Swarm Command
+
+Thin slash-command entry point for `skills/pr-swarm`. This command parses arguments and resolves PR numbers only. The skill owns independence checking, worktree/branch naming, lane launch mechanics, monitoring, verification gates, and teardown.
+
+## Workflow
+
+1. Parse every `#N` or bare `N` token from the argument string (space- or comma-separated). Deduplicate. Require at least one.
+2. For each number, resolve it against the current repository with `gh pr view N --json number,state,headRefName,baseRefName,author,url,isCrossRepository`.
+3. Load `skills/pr-swarm`.
+4. Hand off the full resolved PR list (including any dropped/flagged entries from step 2) to the skill's Phase 1 onward.
+5. Return the skill's per-PR report and fleet summary unchanged.
+
+## Syntax
+
+```text
+/pr-swarm #482 #491
+/pr-swarm 482, 491, 503
+/pr-swarm #482
+```
+
+A single PR number is valid — it still runs through the skill's full isolated-worktree-and-own-session path (see "Single-PR invocation" in `skills/pr-swarm/SKILL.md`); this command never collapses that to inline execution.
+
+## Argument Rules
+
+- Accept PR numbers with or without a leading `#`, separated by whitespace and/or commas.
+- Order is not significant — the swarm has no dependency ordering between lanes (contrast with `/stack-pr`, where positional order is the stack's parent chain).
+- A token that isn't a valid integer after stripping `#` is a parse error, not a silently-dropped argument.
+- Numbers are resolved against the repository of the current working directory; this command does not accept cross-repository `owner/repo#N` references.
+
+## Error Handling
+
+| Problem | Resolution |
+|---|---|
+| No PR numbers provided | Report the required syntax and stop |
+| A token isn't a valid PR number after parsing | Report the invalid token and stop before resolving any PR |
+| `gh pr view` fails for a given number (not found, no access) | Drop that PR from the swarm, report why, continue with the rest |
+| Fewer than 1 PR remains after resolution | Stop — there is nothing to swarm |
+| `gh` not authenticated | Stop before resolving any PR |
+| Not inside a git repository | Stop and report |
+
+## Output
+
+Return the delegated skill result exactly:
+
+1. Per-PR resolution notes (dropped/flagged entries and why).
+2. Independence-check result (pass, or the exact file/PR overlap that blocked the swarm).
+3. Worktree paths and branch names used.
+4. Final per-PR status table: `state`, `mergeStateStatus`, CI conclusion, unresolved-thread count, worktree clean/dirty, lane exit code.
+5. Teardown decision per PR.
+
+## Worked Example
+
+`/pr-swarm #482 #491` against a repo where #482 touches `src/status-line.ts` and #491 touches `src/mcp/autocomplete.ts`:
+
+1. Resolution: both `state: OPEN`, both authored by the invoking user, `isCrossRepository: false` for both — nothing dropped or flagged.
+2. Independence check (delegated to the skill): `git diff --name-only` on each PR's merge-base shows disjoint file sets — no overlap, proceed.
+3. Worktree/branch inference: `#482` → `feat/status-line-token-count` → short name `status-line-token-count` → `.worktrees/status-line-token-count`; `#491` → `feat/mcp-name-autocomplete` → `.worktrees/mcp-name-autocomplete`. Neither name collides, so no PR-number suffix is needed.
+4. Two lanes launch independently, each with its own `claude -p` process, own worktree, own log file. Neither lane's prompt mentions the other PR's number beyond the isolation instruction.
+5. The command returns the skill's fleet-status table once both lanes exit and are independently re-verified via `gh pr view` — not on either lane's self-reported "done".
+
+If step 2 instead found both PRs editing `src/shared/types.ts`, the command would stop right there and surface the overlap instead of creating either worktree — the independence check runs before any git state is mutated, not after.

--- a/commands/pr-swarm/evals/cases.yaml
+++ b/commands/pr-swarm/evals/cases.yaml
@@ -1,0 +1,78 @@
+cases:
+  - id: slash_two_numbers
+    prompt: "/pr-swarm #482 #491"
+    fixtures: []
+    rubric:
+      - "activates the pr-swarm command"
+      - "parses both PR numbers, stripping the leading #"
+      - "delegates to skills/pr-swarm for independence checking, worktree setup, and launch"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "skills/pr-swarm"
+        weight: 0.9
+      - type: matches_regex
+        target: "482"
+        weight: 0.8
+      - type: matches_regex
+        target: "491"
+        weight: 0.8
+
+  - id: slash_comma_separated_bare_numbers
+    prompt: "/pr-swarm 201, 205, 212"
+    fixtures: []
+    rubric:
+      - "activates the pr-swarm command"
+      - "parses bare (no #) comma-separated numbers into three PR numbers"
+      - "does not treat argument order as a dependency chain"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "201"
+        weight: 0.7
+      - type: matches_regex
+        target: "205"
+        weight: 0.7
+      - type: matches_regex
+        target: "212"
+        weight: 0.7
+
+  - id: slash_single_pr
+    prompt: "/pr-swarm #77"
+    fixtures: []
+    rubric:
+      - "a single PR number is valid input"
+      - "still runs the full isolated-worktree-and-own-session path, not a collapsed inline shortcut"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "77"
+        weight: 0.8
+      - type: matches_regex
+        target: "worktree"
+        weight: 0.6
+
+  - id: slash_no_numbers_error_handling
+    prompt: "/pr-swarm"
+    fixtures: []
+    rubric:
+      - "activates the pr-swarm command even with no arguments"
+      - "reports the required syntax and stops rather than guessing which PRs to act on"
+      - "does not resolve or act on any PR"
+    trigger_expected: true
+
+  - id: negative_stack_pr_syntax
+    prompt: "/stack-pr publish --base main feat/parser-core feat/parser-cache"
+    fixtures: []
+    rubric:
+      - "this is the stack-pr command's syntax, not pr-swarm's"
+      - "does not activate pr-swarm"
+    trigger_expected: false
+
+  - id: negative_natural_language_no_slash
+    prompt: "Can you check if any of my open PRs have merge conflicts?"
+    fixtures: []
+    rubric:
+      - "a general PR status question without an explicit multi-PR parallelization request is not this command's argument surface"
+      - "does not activate the pr-swarm command"
+    trigger_expected: false

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -915,6 +915,26 @@ packages:
     category: review
     difficulty: intermediate
     phase: review
+  - name: pr-swarm
+    version: 1.0.0
+    description: 'Parallelizes two or more independent "own PR to green" loops for a single repository using isolated git
+      worktrees and separate headless Claude Code sessions per PR — resolving merge conflicts, clearing review feedback, and
+      watching CI to completion without one PR''s diff or feedback leaking into another''s context. Triggers on: "parallelize
+      these PRs", "drive PR #123 and #456 to green in parallel", "own-PR-to-green fleet", "run these PRs concurrently", "isolated
+      worktree loops for my PRs", "pr-swarm". Use this skill when a user has two or more already-open, file-disjoint pull
+      requests in the same repository that each need conflict resolution, review-feedback triage, and CI monitoring, and wants
+      them driven to merge-ready at the same time instead of one after another.'
+    path: skills/pr-swarm
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/pr-swarm/SKILL.md
+    tags:
+    - git-worktree
+    - parallel-execution
+    - pull-requests
+    - headless-cli
+    - ci-monitoring
+    category: operations
+    difficulty: advanced
+    phase: ship
   - name: pre-landing-review
     version: 1.0.1
     description: 'Gate-oriented safety audit for code changes before landing, using a checklist with two-pass severity triage.
@@ -1959,6 +1979,25 @@ packages:
     - runbook
     category: development
     difficulty: intermediate
+    phase: ship
+  - name: pr-swarm
+    version: 1.0.0
+    description: 'Slash-command wrapper for the pr-swarm skill. `/pr-swarm #123 #456` (or bare numbers, space- or comma-separated)
+      drives that many already-open pull requests to merge-ready at the same time, each in its own isolated git worktree and
+      its own headless Claude Code session. Triggers on: "/pr-swarm", "pr-swarm #123 #456", "parallelize these PRs", "drive
+      PR #123 and #456 to green in parallel", "own-PR-to-green fleet", "isolated worktree loops for my PRs". Use this command
+      when a user wants a concise argument surface for parallelizing two or more of their own open pull requests while delegating
+      independence checks, worktree naming, launch mechanics, and verification gates to skills/pr-swarm.'
+    path: commands/pr-swarm
+    source: https://github.com/Mathews-Tom/armory/blob/main/commands/pr-swarm/COMMAND.md
+    tags:
+    - git
+    - pull-requests
+    - worktree
+    - slash-command
+    - parallel-execution
+    category: development
+    difficulty: advanced
     phase: ship
   - name: refactor
     version: 1.0.0

--- a/skills/pr-swarm/SKILL.md
+++ b/skills/pr-swarm/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: pr-swarm
+description: 'Parallelizes two or more independent "own PR to green" loops for a single repository using isolated git worktrees and separate headless Claude Code sessions per PR — resolving merge conflicts, clearing review feedback, and watching CI to completion without one PR''s diff or feedback leaking into another''s context. Triggers on: "parallelize these PRs", "drive PR #123 and #456 to green in parallel", "own-PR-to-green fleet", "run these PRs concurrently", "isolated worktree loops for my PRs", "pr-swarm". Use this skill when a user has two or more already-open, file-disjoint pull requests in the same repository that each need conflict resolution, review-feedback triage, and CI monitoring, and wants them driven to merge-ready at the same time instead of one after another.'
+metadata:
+  version: 1.0.0
+  category: operations
+  tags: [git-worktree, parallel-execution, pull-requests, headless-cli, ci-monitoring]
+  difficulty: advanced
+  phase: ship
+---
+
+# PR Swarm — Parallel Own-PR-to-Green Loops
+
+## Problem
+
+A repository checkout can only have one branch active at a time. A user with N independent, already-open pull requests — disjoint branches, disjoint changed files, no real relationship between them — that each need conflict resolution, review-feedback triage, and CI watching wastes wall-clock time driving them one after another when nothing about them actually depends on each other.
+
+## Root cause
+
+`git worktree` removes the one-checkout constraint: N branches can be checked out simultaneously, each in its own directory, sharing one `.git` object store. Combined with N independent headless Claude Code sessions (own process, own context window, own token budget — not subagents sharing this session's budget), the PRs can be driven to green concurrently with zero cross-talk.
+
+## Reference Files
+
+|File|Contents|Load When|
+|---|---|---|
+|`references/launch-mechanics.md`|`claude -p` flags, detached background launch pattern, watchdog/liveness checks, exit-code capture|Phase 5 (Launch)|
+|`references/verification-gates.md`|GitHub API correctness pitfalls: stale `mergeStateStatus`, body-only bot reviews, stale `statusCheckRollup` entries, review-thread pagination|Phase 6 (Monitor & Verify)|
+|`references/lane-prompt-template.md`|The literal per-lane task prompt (termination conditions, orientation, conflict resolution, watch loop)|Phase 4 (Lane Prompt)|
+
+## Scope boundary
+
+This skill drives PRs that are **already open**. It does not create PRs from issues, does not decide whether unrelated PRs are safe to parallelize (that's Phase 2, and it's a hard stop on any real overlap, not a judgment call this skill makes silently), and does not resolve PRs closed by a maintainer for policy reasons — see "Mid-loop external closure" in Phase 6.
+
+## Workflow
+
+### Phase 1 — Resolve each PR
+
+For every requested PR number `N`:
+
+```bash
+gh pr view N --json number,state,headRefName,baseRefName,author,url,isCrossRepository
+```
+
+- `state != OPEN` → drop this PR from the swarm and report why; do not silently skip it.
+- `isCrossRepository == true` (PR from an unrelated fork, not the user's own) → flag for confirmation before proceeding; this skill assumes the invoker's own fork/branch setup.
+- Author check: `gh api user --jq .login` vs. `author.login`. Mismatch is a warning, not a stop — co-driving a teammate's PR is legitimate, but the invoker should see it flagged.
+
+### Phase 2 — Independence check (mandatory, not optional)
+
+Do this before creating any worktree. A user asserting "these are unrelated" is not proof — verify the actual changed files:
+
+```bash
+for N in "${PRS[@]}"; do
+  base="$(gh pr view "$N" --json baseRefName -q .baseRefName)"
+  head="$(gh pr view "$N" --json headRefName -q .headRefName)"
+  git fetch origin "$head:refs/remotes/origin/$head" --quiet
+  merge_base="$(git merge-base "origin/$base" "origin/$head")"
+  files["$N"]="$(git diff --name-only "$merge_base" "origin/$head")"
+done
+```
+
+Pairwise-intersect `files[N]` against `files[M]` for every pair in the requested set. Any non-empty intersection → **stop**, report exactly which files and which two PRs collide, and ask before proceeding — running two lanes that touch the same file concurrently is exactly the failure mode this skill exists to prevent, not something to wave through because the user said it was fine.
+
+### Phase 3 — Worktree and branch naming (inferred, never asked for)
+
+Short name derivation from each `headRefName`:
+
+```bash
+raw="$head"                                   # e.g. feat/status-line-token-count
+short="${raw#*/}"                             # strip one leading "<type>/" segment if present
+short="$(echo "$short" | tr '[:upper:]_' '[:lower:]-' | tr -s '/' '-')"
+[[ -n "${used[$short]:-}" ]] && short="${short}-${N}"   # disambiguate collisions with the PR number
+used["$short"]=1
+```
+
+Worktree directory convention: check `bunfig.toml` / lockfile config / `.gitignore` for an existing `.worktrees/**` or `.wt/**` pattern first — that is the project's own sanctioned convention if present. Default to `.worktrees/<short>/` when nothing is declared. Free the main checkout first if it currently holds one of the target branches (`git switch main` or another branch outside the set — a branch can be checked out in only one worktree).
+
+```bash
+git worktree add ".worktrees/$short" "$head"
+```
+
+**Per-worktree install is mandatory under a hoisted linker** (check `bunfig.toml` for `linker = "hoisted"`, or npm/yarn without workspaces hoisting): `node_modules` is not shareable across worktrees since each can have a different lockfile state. Run installs for all lanes in parallel, not serially.
+
+**Gitignored build artifacts don't come back with a fresh worktree checkout** — native addons, generated code, compiled binaries. If the repo has any (check for `*.node`, `.wasm`, generated protobuf/codegen output, or a documented build step), rebuild or relink them per worktree before running tests; a lane that skips this fails with a confusing "module not found" that looks unrelated to its actual task.
+
+### Phase 4 — Lane prompt
+
+Render `references/lane-prompt-template.md` per PR, substituting `{PR_NUMBER}`, `{REPO}` (`owner/name`), `{WORKTREE_PATH}`, and `{OTHER_PR_NUMBERS}` (the rest of the swarm, so the lane's own COI instruction is concrete, not abstract). Write each rendered prompt to a file in the worktree (`$WORKTREE/.pr-swarm-prompt.md`) rather than passing it inline — a multi-hundred-word prompt through shell quoting is a real failure mode, a file path is not.
+
+### Phase 5 — Launch
+
+See `references/launch-mechanics.md` for the exact `claude -p` invocation, detachment pattern, and liveness-check mechanics. One lane per PR, launched independently — never chain multiple launches in a single tool call (each launch needs its own call so a launch failure for lane 2 doesn't silently ride on lane 1's success).
+
+### Phase 6 — Monitor and verify
+
+Poll every ~60-120s with jitter: tail each lane's log, check liveness (see `references/launch-mechanics.md` for the zombie-PID trap). **Never treat a lane's own self-reported completion as the gate.** After a lane's process exits, independently re-verify via the checks in `references/verification-gates.md` — merge state, CI conclusion, unresolved review threads (including body-only bot reviews), and current `state` (a maintainer-closed PR looks identical to a healthy one on every other field).
+
+### Phase 7 — Report
+
+Per PR: final `state`/`mergeStateStatus`, CI conclusion, unresolved-thread count (including the body-only-review scan), worktree clean/dirty, lane process exit code. A lane that exited non-zero, or whose PR isn't independently confirmed clean by the checks above, is reported unresolved — a lane's own "done" message is never sufficient on its own.
+
+### Phase 8 — Teardown
+
+Only after every lane is externally confirmed clean:
+
+```bash
+git worktree remove ".worktrees/$short"
+```
+
+Leave any unresolved PR's worktree in place for continued work. Removing a worktree just because the batch finished, while that one PR is still dirty, destroys debugging context for no benefit.
+
+## Output
+
+Report structure, filled in per swarm run:
+
+```text
+## Resolution
+#{N}: {short-name} — {state}, author={login}{, author mismatch flagged if applicable}
+...
+
+## Independence check
+PASS — no changed-file overlap across {PRS}
+  (or)
+STOP — #{N} and #{M} both touch {path}; resolve before proceeding
+
+## Worktrees
+#{N} → .worktrees/{short-name} (branch {headRefName})
+...
+
+## Fleet status
+| PR | state | mergeStateStatus | CI | unresolved threads | worktree | exit code |
+|---|---|---|---|---|---|---|
+
+## Teardown
+#{N}: removed / left in place (reason)
+```
+
+A PR missing from the "Fleet status" table (dropped in resolution or blocked by the independence check) must still appear in "Resolution" with the reason — never silently omitted from the report.
+
+## Single-PR invocation
+
+`pr-swarm` with exactly one PR still runs the full worktree-and-own-session path — no fast path that skips isolation. The value being delivered (own session, own context/budget, no shared state with the invoking conversation) doesn't depend on fan-out width; collapsing back to inline execution for N=1 would silently drop the one guarantee that was asked for.
+
+## Capacity sanity check
+
+- N concurrent `bun`/`npm`/test-suite runs is the real resource cost, not git or the GitHub API. Confirm core/RAM headroom before fanning out wide; on constrained machines, have lanes run targeted tests per iteration and reserve full suites for the final gate.
+- GitHub's REST/GraphQL rate limit (5000/hr authenticated) is nowhere near the ceiling at a 60-120s polling cadence for any realistic swarm size.
+- Disk: each worktree needs its own `node_modules` (or equivalent) under a hoisted linker. Budget accordingly — this is the correct tradeoff for true isolation, not a shortcut to avoid.
+- Lane wall-clock is asymmetric: a PR that's already mergeable can self-verify and exit in minutes; a PR needing real conflict resolution plus a native rebuild can run for hours with all-green CI. Don't read one lane's fast exit as a signal the others are stuck.
+
+## Error Handling
+
+| Problem | Resolution |
+|---|---|
+| PR number not found / no read access | Drop from swarm, report, continue with the rest |
+| PR `state != OPEN` | Drop from swarm, report why, do not attempt to reopen |
+| Two or more PRs share a changed file (Phase 2) | Stop before creating any worktree; report the exact overlap and ask |
+| Branch already checked out in the main worktree | `git switch` it away before `git worktree add` |
+| Worktree directory already exists from a prior run | Reuse it if the branch matches; otherwise stop and ask (don't silently overwrite) |
+| Hoisted-linker install fails in one lane | That lane's setup fails independently; other lanes proceed unaffected |
+| `gh` not authenticated, or missing `repo`/`workflow` scopes | Stop before Phase 1 — nothing downstream can function without it |
+
+## Verification
+
+- [ ] Every reported-clean PR was checked with the current `state`, not a cached read from earlier in the run
+- [ ] Independence check (Phase 2) ran and passed before any worktree was created
+- [ ] Every unresolved-thread count includes the body-only-review scan (`references/verification-gates.md`), not just `reviewThreads`
+- [ ] Every lane's exit code was captured, not inferred from log tail alone
+- [ ] Teardown only ran for lanes independently confirmed clean
+
+## Red Flags
+
+- Trusting a lane's final log line ("PR is ready to merge") without an independent `gh pr view` re-check
+- Skipping Phase 2 because "the user said they're unrelated"
+- Removing a worktree for a lane whose PR isn't confirmed clean, because the batch as a whole finished
+- Counting `reviewThreads.isResolved == false` as the complete unresolved-feedback signal without also scanning review bodies

--- a/skills/pr-swarm/evals/cases.yaml
+++ b/skills/pr-swarm/evals/cases.yaml
@@ -1,0 +1,61 @@
+cases:
+  - id: parallelize_two_prs
+    prompt: "I've got PR #482 and PR #491 open in this repo, both mine, touching completely different files. Can you drive both to merge-ready at the same time instead of one after another?"
+    fixtures: []
+    rubric:
+      - "activates the pr-swarm skill rather than driving the PRs sequentially"
+      - "runs the independence check (Phase 2) before creating any worktree"
+      - "creates one isolated git worktree per PR with an inferred branch/worktree name"
+      - "launches one independent headless Claude Code session per PR, not task subagents"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "worktree"
+        weight: 0.9
+      - type: matches_regex
+        target: "independen"
+        weight: 0.8
+      - type: matches_regex
+        target: "claude -p"
+        weight: 0.7
+
+  - id: three_pr_fleet
+    prompt: "Own-PR-to-green fleet: I need #201, #205, and #212 all driven to CI-green concurrently, each with its own session so their context doesn't mix."
+    fixtures: []
+    rubric:
+      - "activates the pr-swarm skill for three PRs"
+      - "infers each worktree/branch name from the PR's headRefName rather than asking the user to supply names"
+      - "enforces no cross-lane reference between the three PRs"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "headRefName|branch"
+        weight: 0.7
+      - type: matches_regex
+        target: "isolat|no cross-lane|does not reference"
+        weight: 0.7
+
+  - id: negative_single_sequential_pr
+    prompt: "Resolve the merge conflicts on PR #77 and get it through CI."
+    fixtures: []
+    rubric:
+      - "a single, already-serial PR-to-green task does not need worktree parallelization"
+      - "does not activate pr-swarm for one PR being handled inline in the current session"
+    trigger_expected: false
+
+  - id: negative_stacked_pr_topology
+    prompt: "Split this branch into three stacked PRs and publish them in dependency order."
+    fixtures: []
+    rubric:
+      - "stacked/dependent PR topology belongs to skills/stacked-prs, not pr-swarm"
+      - "pr-swarm is for independent PRs with no parent/child relationship"
+      - "does not activate pr-swarm"
+    trigger_expected: false
+
+  - id: negative_new_pr_from_issue
+    prompt: "Take issue #340 and open a new PR that fixes it."
+    fixtures: []
+    rubric:
+      - "creating a new PR from an issue is out of scope — pr-swarm only drives already-open PRs"
+      - "does not activate pr-swarm"
+    trigger_expected: false

--- a/skills/pr-swarm/references/lane-prompt-template.md
+++ b/skills/pr-swarm/references/lane-prompt-template.md
@@ -1,0 +1,51 @@
+# Lane Prompt Template
+
+Render this verbatim per PR, substituting `{PR_NUMBER}`, `{REPO}`, `{WORKTREE_PATH}`, and `{OTHER_PR_NUMBERS}` (comma-separated list of the swarm's other PR numbers, used only for the isolation instruction below — never their content). Write the rendered result to `{WORKTREE_PATH}/.pr-swarm-prompt.md` and pass that file's contents as the `claude -p` argument (see `references/launch-mechanics.md`).
+
+---
+
+```text
+Own PR #{PR_NUMBER} in {REPO} until it is merge-ready. Your working directory is
+{WORKTREE_PATH} — a dedicated git worktree already checked out to this PR's branch.
+Do not touch any other worktree or branch.
+
+ISOLATION: PRs {OTHER_PR_NUMBERS} are being driven concurrently by separate,
+independent sessions in this same repository. They are unrelated to your task.
+Never reference, read, or discuss their diffs, feedback, or state. If you notice
+your changes might overlap with theirs, stop and report it — do not attempt to
+coordinate directly.
+
+TERMINATION CONDITIONS (all must hold before you report done):
+1. PR state == OPEN (check this every iteration, not just once — a PR can be
+   closed externally at any point; if it happens, stop pushing and report
+   plainly instead of continuing to work on a dead PR)
+2. mergeStateStatus == CLEAN and mergeable == MERGEABLE
+3. Latest CI: every non-skipped check passed, none pending
+4. Zero unresolved review threads — including findings embedded in a review's
+   raw body text with no inline comment backing it (a bot reviewer can post a
+   full review whose body describes a finding via a blob permalink instead of
+   an inline comment; scan every COMMENTED/CHANGES_REQUESTED review's body,
+   not just reviewThreads)
+5. No new feedback landed in the last ~10 minutes (quiet window)
+6. Working tree clean; local HEAD matches the pushed remote head
+7. The repository's own test/typecheck/lint gate passes on the merged tree
+
+ORIENTATION:
+  gh auth status
+  gh pr view {PR_NUMBER} --repo {REPO} \
+    --json state,mergeable,mergeStateStatus,headRefOid,headRefName,baseRefName
+
+MERGE CONFLICTS: GitHub's mergeStateStatus can be stale. Verify with
+`git merge-tree --write-tree <base> <head>` before assuming a real conflict
+exists. If clean, `git merge <base> -m "..."` and push rather than replaying
+commits with rebase (fixup commits tailored to an older base can conflict
+individually even when the net merge doesn't).
+
+WATCH LOOP: after each push, wait ~10 minutes, re-check every condition above.
+Reset the quiet-window timer on any new feedback. Run one extra quiet window
+before declaring done, as insurance against reviewer lag.
+
+Report your final status against every termination condition explicitly —
+don't just say "done." If you cannot reach all seven conditions, report
+exactly which ones are unmet and why, rather than declaring partial success.
+```

--- a/skills/pr-swarm/references/launch-mechanics.md
+++ b/skills/pr-swarm/references/launch-mechanics.md
@@ -1,0 +1,62 @@
+# Launch Mechanics
+
+Verified against `claude` CLI v2.1.x (`claude --version` → `"2.1.x (Claude Code)"`). Re-verify against the installed version before trusting blindly — this is a living CLI, not a stable public API. Probe with `claude --version` before launching anything; a non-zero exit or a response missing `"Claude Code"` means stop and report, not fall back to a different tool.
+
+## The invocation
+
+```bash
+claude -p "$(cat "$WORKTREE/.pr-swarm-prompt.md")" \
+  --output-format stream-json --verbose \
+  --input-format text \
+  --strict-mcp-config \
+  --permission-mode bypassPermissions \
+  --no-session-persistence \
+  --session-id "$(python3 -c "import uuid,sys; print(uuid.uuid5(uuid.NAMESPACE_URL, sys.argv[1]))" "pr-swarm-$N")"
+```
+
+Flag rationale:
+
+- `-p`/`--print` — non-interactive, print-and-exit mode. Required; without it the process waits for interactive input and the lane never starts.
+- `--output-format stream-json --verbose` — real-time NDJSON event stream, needed to tail progress and find the lane's real final message (see "Reading the log" below). A single-shot `--output-format json` only returns a terminal summary and does not distinguish "still working" from "hung."
+- `--strict-mcp-config` — suppresses ambient MCP servers from the operator's own `~/.claude`/project config. Without it, a lane silently inherits whatever MCP servers, hooks, and CLAUDE.md the launching environment has configured — an unwanted capability leak for an unattended worker process. This should always be present, not conditional.
+- `--permission-mode bypassPermissions` — required for unattended execution; without it the lane blocks on the first tool-approval prompt it can't answer.
+- `--no-session-persistence` — avoids polluting the operator's own session history with N automated invocations.
+- `--session-id` — a deterministic UUID (v5, namespaced on the PR number) makes each lane's session traceable back to which PR it belongs to, without depending on log-file naming alone.
+
+**There is no CLI-level timeout flag.** `claude --help` has nothing matching `timeout|max-turns|max-time`. If a lane needs a hard time budget, enforce it externally by killing its process group after your own deadline — do not go looking for a flag that doesn't exist.
+
+## Detached background launch
+
+Run each lane's launch as its own, separate shell-tool call — never chain multiple `nohup ... &` launches inside one call. A single call whose foreground command chain completes can have its non-interactive shell reap backgrounded jobs launched earlier in the same chain before they've actually started; verify with `pgrep -fl "pr-swarm-<short>"` immediately after every single launch, not after the whole batch.
+
+```bash
+nohup bash -c '
+  claude -p "$(cat "'"$WORKTREE"'/.pr-swarm-prompt.md")" \
+    --output-format stream-json --verbose --input-format text \
+    --strict-mcp-config --permission-mode bypassPermissions \
+    --no-session-persistence --session-id "'"$SESSION_ID"'" \
+    > "'"$LOGFILE"'" 2>&1
+  echo $? > "'"$EXITFILE"'"
+' > /dev/null 2>&1 < /dev/null &
+disown
+```
+
+The `bash -c ... ; echo $? > exitfile` wrapper is what makes a real exit code recoverable later — a bare `nohup cmd &` loses the ability to `wait` for it once the launching shell call returns (the child is reparented, no longer a waitable job of that shell). Expect two PIDs per lane (the wrapper plus the `claude` process) — that's correct, not a double-launch.
+
+`nohup`/`disown` protect against `SIGHUP` when the launching shell exits, but do not by themselves guarantee the child survives every tool-boundary condition a given harness might impose on backgrounded work. **Treat this as unverified until smoke-tested**: launch one real multi-minute lane this way, then confirm its log is still growing a full minute or more after the launching tool call has returned and the conversation has moved on to other work — not immediately, since a boundary-kill looks identical to a healthy lane for the first several seconds. `setsid` (stronger session detachment) is not reliably available on macOS by default (it's a Linux/util-linux tool); don't depend on it as the primary mechanism without checking `command -v setsid` first, and fall back to the `nohup`/`disown` pattern above when absent.
+
+## Liveness checks
+
+```bash
+ps -p "$PID" -o pid=,stat=
+```
+
+**A `ps -p <pid>` check that only tests "is this PID present" gives a false positive for a zombie.** A process that has genuinely exited but hasn't been reaped yet still has a `ps` row. Always parse the `STAT` column explicitly and treat any state containing `Z` (`Z`, `Z+`) as exited — do not infer liveness from PID presence alone. Check liveness a full minute or more after launch, not immediately, per the detachment caveat above.
+
+## Reading the log — a trailing "aborted" turn is not automatically a failure
+
+A headless run's final turn is sometimes a harness-injected follow-up after the actual task's turn already completed and reported its final status; that trailing turn can itself fail (transient network blip) without touching the real work. Before writing off a process as failed, search backward through the log's NDJSON events for the last `assistant`-role message with non-empty `text` content — that is the lane's real final report, independent of what the very last event in the stream looks like. Still re-verify externally per `references/verification-gates.md` — a self-reported final status is never the gate, aborted trailing turn or not.
+
+## Stale marker files
+
+If `$EXITFILE`/`$LOGFILE` already exist from a previous run of this same swarm against the same repo, clear them (or compare mtime against the new launch timestamp) before relaunching — an old exit marker read as fresh produces a false-positive instant "done" for a lane that hasn't started yet.

--- a/skills/pr-swarm/references/verification-gates.md
+++ b/skills/pr-swarm/references/verification-gates.md
@@ -1,0 +1,78 @@
+# Verification Gates
+
+Contents: [Termination conditions](#termination-conditions) · [Merge-state staleness](#merge-state-staleness) · [Review-thread pagination](#review-thread-pagination) · [Body-only reviews](#body-only-reviews-the-critical-gap) · [Stale statusCheckRollup entries](#stale-statuscheckrollup-entries) · [The closed-PR trap](#the-closed-pr-trap) · [Quiet window](#quiet-window)
+
+These are GitHub API/`gh` CLI behaviors, not agent-specific — they apply regardless of which lane process produced the work.
+
+## Termination conditions
+
+A PR/lane is genuinely done only when **all** of the following hold simultaneously:
+
+1. `state == OPEN`
+2. `mergeStateStatus == CLEAN` and `mergeable == MERGEABLE`
+3. Latest CI: every non-skipped check passed, none pending
+4. Unresolved review threads = 0, **and** no unaddressed finding embedded in a body-only review (see below)
+5. No new feedback landed in the last ~10-minute quiet window
+6. Worktree clean; local HEAD matches the pushed remote head
+7. The repo's own test/lint/typecheck gate ran green on the merged tree, not just on the pre-merge branch
+
+## Merge-state staleness
+
+`gh pr view N --json mergeable,mergeStateStatus` can report `CONFLICTING`/`DIRTY` long after the branch would actually merge cleanly — GitHub's async mergeability recompute can simply not have re-run. Before believing "needs conflict resolution," check ground truth directly:
+
+```bash
+git merge-tree --write-tree upstream/main origin/<head>   # git >= 2.38
+```
+
+Exit `0` means a clean merge is possible right now, regardless of what the API says. If clean, `git merge upstream/main -m "..."` and push — don't replay commits one-by-one with `rebase` (a multi-commit branch can contain fixup commits tailored to an older base state that conflict individually even though the net merge doesn't). The push alone is usually what makes GitHub recompute and flip to `CLEAN`. On a repo with high upstream commit velocity, a verified-`CLEAN` state can regress within hours purely from cadence — re-check immediately before any final report, don't trust a read from earlier in the same run.
+
+## Review-thread pagination
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $n:Int!, $after:String) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$n) {
+        reviewThreads(first:100, after:$after) {
+          pageInfo { hasNextPage endCursor }
+          nodes { isResolved }
+        }
+      }
+    }
+  }' -F owner=<o> -F repo=<r> -F n=<N>
+```
+
+`gh api graphql --paginate` does not reliably terminate against a cursor-based query with variables — drive the `pageInfo.hasNextPage`/`endCursor` loop by hand. The response is wrapped in a top-level `data` key (`{"data": {"repository": {...}}}`); unwrap it explicitly before dereferencing `.repository.pullRequest...` — skipping `.data` doesn't throw immediately, it just makes `.repository` silently `undefined` until something dereferences it further down, which reads like an unrelated bug.
+
+## Body-only reviews — the critical gap
+
+`reviewThreads` only aggregates properly-anchored inline comments. A bot reviewer can instead submit a full review (`state: COMMENTED`) whose `body` text embeds a finding directly — including a manually-constructed blob-permalink pointing at flagged lines — with no inline comment object backing it at all. This has **no node in `reviewThreads`** and **no entry in the REST inline-comments endpoint**. A check that only queries `reviewThreads` will report 0 unresolved and pass a PR as clean while a real, unaddressed finding sits on the Conversation tab.
+
+Before declaring any PR clean, also fetch and scan every review's raw body:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $n:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$n) {
+        reviews(first:100) { nodes { id state author { login } body submittedAt url } }
+      }
+    }
+  }' -F owner=<o> -F repo=<r> -F n=<N>
+```
+
+Read every `COMMENTED`/`CHANGES_REQUESTED` review's `body` for severity badges, blocking/should-fix markers, or blob-permalink references. Cross-reference flagged lines against the branch's commit history to check whether a later commit already fixed it. A body-only review has no `resolveReviewThread` mutation to apply — the correct closure signal is a `gh pr comment` reply citing the review's timestamp/URL and the fixing commit SHA, not a thread-resolve call.
+
+## Stale `statusCheckRollup` entries
+
+The raw `statusCheckRollup` array accumulates every historical check-run row for a PR's head SHA, including ones superseded by a later rerun of the identically-named job. A naive tally of `conclusion` values can show `FAILURE > 0` on a genuinely green, mergeable PR. `mergeStateStatus`/`mergeable` are already the correct aggregate (computed from only the latest run per required check) — trust those over a manual count of the raw array. To confirm one specific job's true state, group entries by `name` and take the one with the latest `completedAt`; `gh pr checks N` (which already dedupes per job) is a fast independent cross-check.
+
+## The closed-PR trap
+
+`mergeStateStatus`/`mergeable`/CI conclusions/thread counts all keep returning normal-looking (even clean) data after a maintainer closes a PR — nothing about those fields signals closure. Always include `state` in every `gh pr view` call in this skill, at resolution and at final verification, and treat anything other than `OPEN` as an immediate stop, not something to work around by continuing to push commits to a dead PR.
+
+A closed PR is not automatically safe to reopen or replace with a fresh PR — some repos gate PR creation behind a contributor-approval mechanism, and reopening/opening fresh re-triggers that gate's evaluation even if the original PR predated the policy. If a PR closes mid-run: stop pushing, read the closing comment, check for a `CONTRIBUTING.md` contributor-gating policy and any existing issue/discussion already addressing it, and report the finding rather than reopening or opening a new PR without explicit instruction.
+
+## Quiet window
+
+After each push, CI restarts and `mergeStateStatus` typically goes `UNSTABLE` while pending. Wait roughly 10 minutes, re-check every condition. If new feedback landed during the wait, fix it, push, and reset the quiet-window timer — including feedback that lands in the few minutes right after a lane's own final self-check but before the orchestrator's external re-check catches it (a real race, not a bug in either check). One extra quiet window as insurance against reviewer lag before declaring a lane done is worth the wall-clock cost.


### PR DESCRIPTION
## Summary

Adds the `pr-swarm` skill + command pair: parallelizes two or more already-open, file-disjoint pull requests in the same repository to merge-ready at the same time, each driven by its own isolated `git worktree` and its own independent headless Claude Code session (`claude -p`) — no shared context/budget, no cross-lane diff or feedback leakage.

Three commits, each independently reviewable:

1. **`feat(skills): add pr-swarm parallel PR-loop skill`** — `skills/pr-swarm/SKILL.md` + `references/{launch-mechanics,verification-gates,lane-prompt-template}.md` + `evals/cases.yaml`. Owns the deep mechanics:
   - PR resolution (`gh pr view`), `state`/author checks
   - A **mandatory** changed-file independence check (`git diff --name-only` on each PR's merge-base) that hard-stops before creating any worktree if two requested PRs touch the same file — never a silent pass-through on the user's own assertion that they're unrelated
   - Branch/worktree short-name inference from `headRefName` (conventional-prefix stripping, kebab-case, PR-number disambiguation on collision) — never asks the user to name worktrees
   - `claude -p` launch mechanics: verified flags (`--strict-mcp-config`, `--permission-mode bypassPermissions`, `--no-session-persistence`, `--session-id`), the lack of a CLI timeout flag (external watchdog required), the zombie-PID liveness-check trap, and an explicitly flagged **unverified** caveat around background-process survival across tool-call boundaries — documented as an open risk to smoke-test, not asserted as fact
   - Verification gates: stale `mergeStateStatus`/`mergeable` (verify with `git merge-tree` before trusting "conflicting"), the body-only bot-review gap (`reviewThreads` alone misses findings embedded in a review's raw body with no inline comment), stale `statusCheckRollup` entries from superseded reruns, and the closed-PR trap (every other field can look healthy on a closed PR)
   - The literal per-lane task prompt template with termination conditions and cross-lane isolation instructions

2. **`feat(commands): add pr-swarm slash-command wrapper`** — `commands/pr-swarm/COMMAND.md` + `evals/cases.yaml`. Thin argument surface only: `/pr-swarm <PR#> [PR# ...]` parses PR numbers (with or without `#`, space- or comma-separated), resolves each against the current repo, and delegates everything else to `skills/pr-swarm` via a declared `command.dependencies` entry (mirrors the existing `stack-pr`/`stacked-prs` and `handoff`/`handoff` same-name command+skill pairing already in this repo). A single PR number is valid input and still runs the full isolated-worktree path — no inline fast path that would silently drop the session-isolation guarantee.

3. **`chore: regenerate manifest for pr-swarm packages`** — `manifest.yaml` via `scripts/generate_manifest.py`. Adds exactly the two new entries; no other package touched.

### Design notes worth flagging for review

- Targets **Claude Code's `claude -p` headless mode**, not any other agent CLI — matches this repo's stated Claude Code/Claude.ai scope (see prior issue #79 precedent) and the existing `agent-builder` skill's own headless-mode guidance.
- The independence check is intentionally a hard stop, not a warning — running two lanes concurrently against the same file is the exact failure mode this package exists to prevent.
- `references/launch-mechanics.md` explicitly documents one mechanic as **unverified**: whether Claude Code's Bash tool preserves a `nohup`/`disown`-backgrounded child across tool-call/turn boundaries. No authoritative source was found either way; the skill instructs checking liveness a minute+ after launch (not immediately) and treats unexpected mid-run death as evidence worth investigating rather than silently retrying. This should be smoke-tested against a real multi-minute run before being treated as settled.

## Skill Evaluator Results

`skills/pr-swarm` (via `scripts/evaluate_package.py`):

```text
Package: pr-swarm (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        20/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          96/100 (96%)
  Status: PASS
```

`commands/pr-swarm`:

```text
Package: pr-swarm (command)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        16/20
  D4 Content Depth:                  22/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          96/100 (96%)
  Status: PASS
```

Zero CRITICAL/HIGH findings on either package.

## Checklist

- [x] `SKILL.md` and `COMMAND.md` both have valid YAML frontmatter with `name` and `description`
- [x] Both package names are kebab-case, under 64 characters (`pr-swarm`)
- [x] Both descriptions are 200-1024 characters with trigger phrases and a "Use this ... when" clause
- [x] No angle brackets or pushy language in either description
- [x] No secrets, credentials, or internal URLs in any file
- [x] Tested locally: `uv run python scripts/validate_evals.py` and `uv run scripts/generate_manifest.py` both pass clean
- [x] All file references (`references/*.md`) resolve to existing files within `skills/pr-swarm/`
- [x] No cross-package `../` references; the only inter-package link is `command.dependencies: [skills/pr-swarm]`, matching the existing `stack-pr`/`stacked-prs` convention
- [x] Eval cases: skill has 2 positive / 3 negative; command has 4 positive / 2 negative (both exceed the 1+/2+ minimum)
- [x] Skill evaluator score is 70% or above on both packages (96%/96%)
- [x] No CRITICAL or HIGH findings from skill evaluator
