### PR TITLE
fix(pr-swarm): react to first failing CI check instead of full matrix

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -916,7 +916,7 @@ packages:
     difficulty: intermediate
     phase: review
   - name: pr-swarm
-    version: 1.0.0
+    version: 1.1.0
     description: 'Parallelizes two or more independent "own PR to green" loops for a single repository using isolated git
       worktrees and separate headless Claude Code sessions per PR — resolving merge conflicts, clearing review feedback, and
       watching CI to completion without one PR''s diff or feedback leaking into another''s context. Triggers on: "parallelize

--- a/skills/pr-swarm/SKILL.md
+++ b/skills/pr-swarm/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-swarm
 description: 'Parallelizes two or more independent "own PR to green" loops for a single repository using isolated git worktrees and separate headless Claude Code sessions per PR — resolving merge conflicts, clearing review feedback, and watching CI to completion without one PR''s diff or feedback leaking into another''s context. Triggers on: "parallelize these PRs", "drive PR #123 and #456 to green in parallel", "own-PR-to-green fleet", "run these PRs concurrently", "isolated worktree loops for my PRs", "pr-swarm". Use this skill when a user has two or more already-open, file-disjoint pull requests in the same repository that each need conflict resolution, review-feedback triage, and CI monitoring, and wants them driven to merge-ready at the same time instead of one after another.'
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   category: operations
   tags: [git-worktree, parallel-execution, pull-requests, headless-cli, ci-monitoring]
   difficulty: advanced
@@ -24,7 +24,7 @@ A repository checkout can only have one branch active at a time. A user with N i
 |File|Contents|Load When|
 |---|---|---|
 |`references/launch-mechanics.md`|`claude -p` flags, detached background launch pattern, watchdog/liveness checks, exit-code capture|Phase 5 (Launch)|
-|`references/verification-gates.md`|GitHub API correctness pitfalls: stale `mergeStateStatus`, body-only bot reviews, stale `statusCheckRollup` entries, review-thread pagination|Phase 6 (Monitor & Verify)|
+|`references/verification-gates.md`|GitHub API correctness pitfalls: stale `mergeStateStatus`, body-only bot reviews, stale `statusCheckRollup` entries, review-thread pagination, reacting to the first failing check instead of waiting for the full CI matrix|Phase 6 (Monitor & Verify)|
 |`references/lane-prompt-template.md`|The literal per-lane task prompt (termination conditions, orientation, conflict resolution, watch loop)|Phase 4 (Lane Prompt)|
 
 ## Scope boundary
@@ -95,6 +95,8 @@ See `references/launch-mechanics.md` for the exact `claude -p` invocation, detac
 
 Poll every ~60-120s with jitter: tail each lane's log, check liveness (see `references/launch-mechanics.md` for the zombie-PID trap). **Never treat a lane's own self-reported completion as the gate.** After a lane's process exits, independently re-verify via the checks in `references/verification-gates.md` — merge state, CI conclusion, unresolved review threads (including body-only bot reviews), and current `state` (a maintainer-closed PR looks identical to a healthy one on every other field).
 
+A lane inheriting a PR that already has red CI or open feedback at launch is normal input, not a swarm-level stop condition — the independence check (Phase 2) governs whether the swarm proceeds, not the target PR's current health. Each lane's own orientation and watch loop react to that starting state directly (see `references/lane-prompt-template.md`): fix what's already visible first, and react to the first individually-failing check rather than waiting for every check in a CI run to finish, or for an admin-gated `gh run rerun` that a non-admin lane can't invoke anyway (see "React to the first failing check, not the full matrix" in `references/verification-gates.md`).
+
 ### Phase 7 — Report
 
 Per PR: final `state`/`mergeStateStatus`, CI conclusion, unresolved-thread count (including the body-only-review scan), worktree clean/dirty, lane process exit code. A lane that exited non-zero, or whose PR isn't independently confirmed clean by the checks above, is reported unresolved — a lane's own "done" message is never sufficient on its own.
@@ -158,6 +160,7 @@ A PR missing from the "Fleet status" table (dropped in resolution or blocked by 
 | Branch already checked out in the main worktree | `git switch` it away before `git worktree add` |
 | Worktree directory already exists from a prior run | Reuse it if the branch matches; otherwise stop and ask (don't silently overwrite) |
 | Hoisted-linker install fails in one lane | That lane's setup fails independently; other lanes proceed unaffected |
+| PR already has failing CI checks or unresolved feedback when the swarm launches | Not a stop condition — the lane starts by fixing what's already visible instead of waiting on a clean baseline (see `references/verification-gates.md`) |
 | `gh` not authenticated, or missing `repo`/`workflow` scopes | Stop before Phase 1 — nothing downstream can function without it |
 
 ## Verification
@@ -174,3 +177,4 @@ A PR missing from the "Fleet status" table (dropped in resolution or blocked by 
 - Skipping Phase 2 because "the user said they're unrelated"
 - Removing a worktree for a lane whose PR isn't confirmed clean, because the batch as a whole finished
 - Counting `reviewThreads.isResolved == false` as the complete unresolved-feedback signal without also scanning review bodies
+- A lane waiting for a full CI matrix to finish, or for an admin-gated `gh run rerun`, before reacting to a check that already failed or feedback that already landed

--- a/skills/pr-swarm/evals/cases.yaml
+++ b/skills/pr-swarm/evals/cases.yaml
@@ -35,6 +35,22 @@ cases:
         target: "isolat|no cross-lane|does not reference"
         weight: 0.7
 
+  - id: pr_with_existing_ci_failures
+    prompt: "Swarm PR #310 and PR #322 to green — heads up, #310 already has a couple of CI checks failing from before you even start, and there's open review feedback on it too."
+    fixtures: []
+    rubric:
+      - "activates pr-swarm despite one PR already having failing CI and open feedback at launch"
+      - "treats the existing failure/feedback as normal starting state to fix immediately, not a swarm-level stop condition"
+      - "does not block on being unable to force a fresh CI rerun without admin rights"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "already"
+        weight: 0.6
+      - type: matches_regex
+        target: "worktree"
+        weight: 0.6
+
   - id: negative_single_sequential_pr
     prompt: "Resolve the merge conflicts on PR #77 and get it through CI."
     fixtures: []

--- a/skills/pr-swarm/references/lane-prompt-template.md
+++ b/skills/pr-swarm/references/lane-prompt-template.md
@@ -34,6 +34,17 @@ ORIENTATION:
   gh auth status
   gh pr view {PR_NUMBER} --repo {REPO} \
     --json state,mergeable,mergeStateStatus,headRefOid,headRefName,baseRefName
+  gh pr checks {PR_NUMBER} --repo {REPO} | grep -v skipping
+
+A freshly-launched lane commonly inherits a PR with CI already red or
+feedback already unresolved from before this run started — that is normal
+starting state, not a reason to wait. Read the checks output and the PR's
+existing reviews/threads now. If anything above is already actionable (a
+check already reporting FAILURE, an unresolved review thread, or a
+body-only review finding), fix it as your first action. Being unable to
+force a fresh CI rerun (`gh run rerun` requires repo admin rights you do
+not have) is never a reason to stall — pushing your fix triggers a
+genuinely fresh run on its own.
 
 MERGE CONFLICTS: GitHub's mergeStateStatus can be stale. Verify with
 `git merge-tree --write-tree <base> <head>` before assuming a real conflict
@@ -41,9 +52,17 @@ exists. If clean, `git merge <base> -m "..."` and push rather than replaying
 commits with rebase (fixup commits tailored to an older base can conflict
 individually even when the net merge doesn't).
 
-WATCH LOOP: after each push, wait ~10 minutes, re-check every condition above.
-Reset the quiet-window timer on any new feedback. Run one extra quiet window
-before declaring done, as insurance against reviewer lag.
+WATCH LOOP: after each push, CI starts a new run. Poll per-job status via
+`gh pr checks {PR_NUMBER}`, not just the run-level aggregate — the moment
+any single non-skipped check reports FAILURE, or new review feedback lands,
+stop waiting on the rest of that run's still-pending checks and act on it
+immediately. You never need every check in a run to finish, or the full
+~10-minute quiet window to elapse, before reacting to something already
+actionable. Only treat the ~10-minute wait as genuine idle time once every
+currently-visible check is passing or still pending with zero failures and
+there is no unaddressed feedback. Reset the quiet-window timer on any new
+feedback or push. Run one extra quiet window before declaring done, as
+insurance against reviewer lag.
 
 Report your final status against every termination condition explicitly —
 don't just say "done." If you cannot reach all seven conditions, report

--- a/skills/pr-swarm/references/verification-gates.md
+++ b/skills/pr-swarm/references/verification-gates.md
@@ -1,6 +1,6 @@
 # Verification Gates
 
-Contents: [Termination conditions](#termination-conditions) · [Merge-state staleness](#merge-state-staleness) · [Review-thread pagination](#review-thread-pagination) · [Body-only reviews](#body-only-reviews-the-critical-gap) · [Stale statusCheckRollup entries](#stale-statuscheckrollup-entries) · [The closed-PR trap](#the-closed-pr-trap) · [Quiet window](#quiet-window)
+Contents: [Termination conditions](#termination-conditions) · [First-failure reaction](#react-to-the-first-failing-check-not-the-full-matrix) · [Merge-state staleness](#merge-state-staleness) · [Review-thread pagination](#review-thread-pagination) · [Body-only reviews](#body-only-reviews-the-critical-gap) · [Stale statusCheckRollup entries](#stale-statuscheckrollup-entries) · [The closed-PR trap](#the-closed-pr-trap) · [Quiet window](#quiet-window)
 
 These are GitHub API/`gh` CLI behaviors, not agent-specific — they apply regardless of which lane process produced the work.
 
@@ -15,6 +15,12 @@ A PR/lane is genuinely done only when **all** of the following hold simultaneous
 5. No new feedback landed in the last ~10-minute quiet window
 6. Worktree clean; local HEAD matches the pushed remote head
 7. The repo's own test/lint/typecheck gate ran green on the merged tree, not just on the pre-merge branch
+
+## React to the first failing check, not the full matrix
+
+`gh pr checks <N>` reports per-job status, not just a run-level aggregate. A run with ten jobs where one has already failed and nine are still queued or in progress is not "still running" from a triage standpoint — the failed job is actionable now. Start fixing it immediately; the still-pending jobs continue in the background and get re-checked on the next poll regardless. Waiting for every job in a run to reach a terminal state before looking at any of them wastes wall-clock time on jobs that were never going to change the fact that one of them already failed.
+
+This also means a lane rarely needs to force a fresh CI run at all: pushing the fix for an already-failed job triggers a brand-new run on its own. `gh run rerun` requires repo admin rights a contributor-driven lane typically doesn't have (`Must have admin rights to Repository`) — that's a non-issue here, not a blocker, because the normal fix-and-push cycle never depends on it. Reserve the close/reopen technique (`force-fresh-ci-without-admin-rerun` skill) for the narrow case of re-testing a suspected-flaky failure with no code change to push — not as a routine response to red CI.
 
 ## Merge-state staleness
 


### PR DESCRIPTION
## Summary

`pr-swarm` lanes previously treated CI/feedback state too passively:

- On launch, a lane only checked `state`/`mergeable`/`mergeStateStatus` — it never looked at whether the PR already had failing checks or open review feedback, and nothing told it to act on that immediately.
- The watch loop was a flat "push, wait ~10 minutes, re-check everything" cycle keyed off the run-level aggregate, so a lane sat idle even after an individual check had already failed.
- Neither the skill nor its lane prompt said anything about `gh run rerun` requiring repo admin rights — a lane could plausibly read "can't force a fresh CI run" as a reason to stall, when the normal fix-and-push cycle never depends on that command at all.

This PR makes lanes react to what's already visible instead of waiting on a clean baseline or a full CI matrix, and documents why an admin-gated rerun is a non-issue for the normal flow.

## What changed, by commit

**`fix(pr-swarm): react to first failing CI check instead of full matrix`** — `references/lane-prompt-template.md`, `references/verification-gates.md`
- Lane `ORIENTATION` now runs `gh pr checks {PR_NUMBER}` alongside `gh pr view`, and instructs the lane to treat a PR that already has failing checks or unresolved feedback at launch as normal starting state — fix it as the first action, don't wait for a clean baseline.
- `WATCH LOOP` rewritten from waiting the full ~10-minute quiet window before checking anything, to polling per-job status (`gh pr checks`) and reacting to the *first* individually-failing check or new feedback, without waiting for the rest of that run's still-pending checks. The passive quiet-window wait now only applies once nothing is currently actionable.
- New `verification-gates.md` section "React to the first failing check, not the full matrix": explains `gh pr checks` is per-job, not run-level, and that a lane rarely needs to force a fresh CI run at all since pushing a fix triggers one automatically — `gh run rerun` (admin-gated) is reserved for the narrow flaky-retest case, not the default response to red CI.

**`docs(pr-swarm): note first-failure reaction in skill and bump version`** — `SKILL.md`
- Phase 6 (Monitor & Verify) now states that a lane inheriting red CI or open feedback at launch is normal input, not a swarm-level stop condition — Phase 2's independence check is what actually gates the swarm, not the target PR's current health.
- Adds a matching row to the Error Handling table and a bullet to Red Flags.
- Updates the `verification-gates.md` reference-table description to mention the new first-failure-reaction content.
- Bumps `metadata.version` 1.0.0 → 1.1.0 for the behavioral change.

**`test(pr-swarm): cover pre-existing CI failure at swarm launch`** — `evals/cases.yaml`
- New case `pr_with_existing_ci_failures`: a swarm request where one PR already has failing checks and open feedback at launch. Asserts the skill still activates and the response treats the existing state as immediate work, not a blocker.

**`chore(pr-swarm): regenerate manifest for version bump`** — `manifest.yaml`
- `scripts/generate_manifest.py` output reflecting the `pr-swarm` version bump. No other manifest content changed.

## Verification

- `uv run python scripts/generate_manifest.py` — regenerated cleanly, diff limited to the version bump line.
- `uv run python scripts/validate_evals.py` — all packages pass, including the new eval case (73 skills validated).
- `uv run python scripts/evaluate_package.py --path skills/pr-swarm` — 96/100 (PASS), unchanged from before this change.
- `python -c "import yaml; yaml.safe_load(open('skills/pr-swarm/evals/cases.yaml'))"` — new eval case parses correctly (6 cases total).

## Skill Evaluator Results

```text
Package: pr-swarm (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        20/20
  D4 Content Depth:                  18/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          96/100 (96%)
  Status: PASS
```

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter with `name` and `description`
- [x] Skill name is kebab-case, under 64 characters
- [x] Description is 200-1024 characters with trigger phrases and "Use when" clause
- [x] No angle brackets or pushy language in description
- [x] No secrets, credentials, or internal URLs in any file
- [x] Tested locally (`scripts/validate_evals.py`, `scripts/evaluate_package.py`)
- [x] All file references in `SKILL.md` resolve to existing files
- [x] Skill evaluator score is 70% or above (96%)
- [x] No CRITICAL or HIGH findings from skill evaluator
