### PR TITLE
feat(kg-builder): add knowledge-graph build skill

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -128,6 +128,32 @@ The upstream repo structures prompts as Python functions returning f-strings. We
 
 **Re-sync policy:** Compare upstream against the pinned commit before merging updates. Preserve armory's `codebase-advisor` naming and routing boundary unless `codebase-auditor` is formally deprecated.
 
+### Knowledge-graph curriculum and governance patterns — used by `kg-builder`
+
+`kg-builder` vendors **no** upstream text, code, or assets. It is written independently. Two bodies of prior work informed its content and are recorded here for provenance.
+
+**Field grounding — Southeast University graduate Knowledge Graph course**
+
+**Course:** 东南大学《知识图谱》研究生课程, Prof. 汪鹏 (Peng Wang)
+**Repo:** [npubird/KnowledgeGraphCourse](https://github.com/npubird/KnowledgeGraphCourse)
+**License:** **No license file.** The GitHub API reports `license: null` and the repository root contains no `LICENSE` or `COPYING`. No derivative-work permission is established.
+
+Because no license grants derivative rights, nothing from that repository is reproduced here. `kg-builder` uses only the field's standard, non-copyrightable pipeline decomposition — ontology modeling, entity/relation/event extraction, knowledge fusion, KG×LLM serving — which is common to the published knowledge-graph literature and predates that course. No lecture text, slide content, translated outline, or PDF is included, and the skill deliberately carries no per-lecture curriculum map.
+
+A third-party redistribution of an English distillation of that course exists at [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering) (MIT). It was evaluated and **not** ingested: its scope conflates knowledge graphs with agent task graphs, its task-graph half duplicates `task-decomposer`, `milestone-runner`, `pr-swarm`, `team-lead`, and `project-planner`, and it relicenses a derivative of an unlicensed upstream. No content was taken from it.
+
+**Governance patterns — Kosha**
+
+**Repo:** [Mathews-Tom/Kosha](https://github.com/Mathews-Tom/Kosha) (`kosha-okf`)
+**License:** Apache-2.0
+**Referenced at:** v0.1.0
+
+`references/provenance-and-supersession.md` describes a claim-ledger design — append-only supersession, `supersedes`/`contradicts` lineage, bitemporal validity, a checkable no-silent-overwrite invariant, and a human gate on irreversible steps — for which Kosha is a reference implementation (`src/kosha/model.py`, `assert_no_silent_overwrite` in `src/kosha/contradiction/escalate.py`). The pattern is described, not copied; no Kosha code or documentation text is included, and `kg-builder` takes no dependency on `kosha-okf`.
+
+Kosha's pre-registered real-model Gate-0 evaluation is also cited, as a measured finding rather than a claim: an LLM-adjudicated dedup-and-contradiction loop trailed a prompt-only baseline by 0.28–0.33 on detection and safety across every provider cell tested (108 held-out contradictions, 2 embedding × 2 generation models). `kg-builder` uses this to require that any model adjudicator be measured against a prompt-only baseline before it is trusted. Kosha's governance guarantee held under the same evaluation; its decision-quality claim did not, and the skill states the distinction.
+
+**Re-sync policy:** Neither upstream is vendored, so there is nothing to diff. Revisit the Kosha citation if a later pre-registered Gate-0 run records a GO verdict, and revisit the OKF question separately — OKF bundles are linked Markdown documents with untyped links, not typed property graphs, so they are out of scope for this skill.
+
 ## Conceptual Inspiration
 
 | Concept                                        | Source                                                                                                                  | Used by                                  |

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -580,6 +580,23 @@ packages:
     - adaptive
     category: review
     difficulty: intermediate
+  - name: kg-builder
+    version: 1.0.0
+    description: Designs and builds knowledge graphs from documents — ontology modeling with domain/range constraints, entity/relation/event
+      extraction, entity resolution, provenance and supersession, and GraphRAG serving. Use when asked to "build a knowledge
+      graph", "design an ontology", "extract entities and relations", "deduplicate entities", "entity resolution", "add GraphRAG",
+      or "graph memory for an agent". NOT for multi-agent task graphs or agent orchestration, use task-decomposer.
+    path: skills/kg-builder
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/kg-builder/SKILL.md
+    tags:
+    - knowledge-graph
+    - ontology
+    - entity-resolution
+    - graphrag
+    - provenance
+    category: data
+    difficulty: advanced
+    phase: build
   - name: lightpanda-browser
     version: 1.0.1
     description: 'Lightweight headless browser automation via Lightpanda and agent-browser CLI: 9x lower memory, 11x faster

--- a/skills/kg-builder/SKILL.md
+++ b/skills/kg-builder/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: kg-builder
+description: 'Designs and builds knowledge graphs from documents — ontology modeling with domain/range constraints, entity/relation/event extraction, entity resolution, provenance and supersession, and GraphRAG serving. Use when asked to "build a knowledge graph", "design an ontology", "extract entities and relations", "deduplicate entities", "entity resolution", "add GraphRAG", or "graph memory for an agent". NOT for multi-agent task graphs or agent orchestration, use task-decomposer.'
+metadata:
+  version: 1.0.0
+  category: data
+  tags: [knowledge-graph, ontology, entity-resolution, graphrag, provenance]
+  difficulty: advanced
+  phase: build
+---
+
+# KG Builder
+
+A knowledge graph is a product with a schema, not a pile of triples. Quality comes from
+pipeline order: model the domain **before** extracting, validate **during** extraction, fuse
+**before** storing, and attach provenance to every fact from the first write.
+
+This skill covers the full build — value test, ontology, extraction, quality gate, entity
+resolution, serving, and maintenance — plus the boundary question that decides whether the
+result is trustworthy: which stages are deterministic code and which are LLM judgment.
+
+**Scope note.** This is about knowledge graphs — what an agent *remembers*. It is not about
+task graphs, agent orchestration, or multi-agent topology.
+
+## Reference Files
+
+| File                                       | Contents                                                             | Load When            |
+|---|---|---|
+| `references/ontology-design.md`            | Competency questions, entity/relation types, domain/range, storage choice | Phase 1              |
+| `references/extraction.md`                 | Source routing, NER/RE/EE prompt patterns, validation, failure modes | Phase 2              |
+| `references/fusion.md`                     | Blocking, matching layers, merge policy, threshold bands             | Phase 3              |
+| `references/serving.md`                    | GraphRAG retrieval, path queries, community summaries, query layer   | Phase 4              |
+| `references/provenance-and-supersession.md` | Claim model, append-only updates, contradiction handling, audit trail | Phase 1 and Phase 4  |
+
+## The deterministic / LLM boundary
+
+Decide this before writing code. Code owns control flow, identity, validation, and merges.
+The model gets contained judgments behind a typed interface, each with a measured baseline.
+
+| Stage             | Deterministic (code)                              | LLM judgment (measure it)             |
+|---|---|---|
+| Source routing    | format detection, structured mapping              | —                                     |
+| Entity extraction | span capture, type validation, dictionary matching | "what entities are in this text"      |
+| Relation extraction | domain/range enforcement, endpoint checks       | "which relation does this sentence assert" |
+| Quality gate      | sampling, scoring, thresholds                     | —                                     |
+| Blocking          | key generation, candidate pairing                 | —                                     |
+| Matching          | string/attribute/structure scoring                | ambiguous middle band only            |
+| Merge             | canonical selection, edge union, lineage          | — (never let a model own a merge)     |
+| Serving           | traversal, subgraph selection, serialization      | the agent's own reasoning             |
+
+**Measure every LLM surface against a prompt-only baseline before trusting it.** This is not
+theoretical caution. In a pre-registered real-model evaluation of an LLM-adjudicated dedup and
+contradiction loop, the loop trailed a plain prompt-only baseline by 0.28–0.33 on detection and
+safety across every provider cell tested. Adjudication that is not measured is decoration.
+
+## Workflow
+
+### Phase 1 — Design (do not skip)
+
+1. **Value test.** A graph pays off when queries are multi-hop ("who worked with X on projects
+   using Y"), when entities recur across documents, or when the relationships *are* the data.
+   If every query is a single-hop lookup or an aggregation, use a table and stop here. Write
+   the kill criterion down before continuing.
+2. **Competency questions.** Write the 10–20 questions the graph must answer. These are the
+   ontology's spec and its test suite. Anything you cannot path through the finished schema is
+   a missing type or relation.
+3. **Ontology.** 5–15 entity types, 10–30 relation types, each relation with explicit domain
+   and range. Precise verb names (`ACQUIRED`, `DEPENDS_ON`) — never `RELATED_TO`. Keep it in
+   `ontology.yaml` as the single source of truth; every extraction prompt embeds it verbatim.
+4. **Storage and identity.** Choose property graph (default), RDF/OWL (interop, description-logic
+   reasoning), or typed edges in SQLite (<50K nodes). Decide *now* how time and provenance attach
+   to every fact — retrofitting provenance after fusion is effectively impossible.
+
+Validate the schema before extracting anything:
+
+```bash
+uv run scripts/validate_ontology.py ontology.yaml
+```
+
+### Phase 2 — Extract
+
+5. **Route by source type.** Structured sources (databases, CSVs, APIs) map column → type in
+   deterministic code with no model involved. Semi-structured sources (HTML tables, infoboxes)
+   get per-layout parsers. Only unstructured text enters the LLM pipeline. Running NLP over
+   already-structured data is the classic waste.
+6. **Entities.** Dictionaries and exact rules first for closed vocabularies — free,
+   deterministic, perfect precision. LLM extraction for open text, with the ontology in the
+   prompt. Always capture surface form, canonical guess, type, source pointer, and confidence.
+7. **Relations.** Extract only between entities that already passed step 6; never let relation
+   extraction invent endpoints. Constrain output to the ontology's relation list and **validate
+   domain/range in code**. Require a verbatim evidence quote that *asserts* the relation —
+   co-occurrence is not assertion ("Musk discussed Twitter" is not `OWNS`).
+8. **Events.** For dynamic domains, extract events as first-class nodes (trigger + typed
+   arguments + time), never flattened into pairwise edges — flattening loses which acquisition
+   happened at which price.
+
+### Phase 3 — Consolidate
+
+9. **Quality gate.** Sample 50 items and score entity precision and relation precision before
+   fusing anything. Target ≥90% precision. Fix the prompt or the rules, then re-run — never
+   hand-patch the output. Recall improves with more passes; bad precision poisons the graph
+   permanently.
+10. **Fusion.** Blocking → matching → merge. Blocking avoids O(n²) comparison; matching scores
+    string, attribute, and **structural** evidence (two `J. Smith` nodes sharing three coauthors
+    and an affiliation are one person; identical names with disjoint neighborhoods are not);
+    merge policy is deterministic code that keeps the canonical name, unions aliases and edges,
+    preserves conflicting values with provenance, and records `merged_from` for undo.
+    An erroneous merge is far more damaging than a missed one — it silently fuses two entities'
+    entire edge sets. Auto-merge only above the high band; queue the middle for review.
+
+Check the blocking strategy against labeled pairs before running it at scale:
+
+```bash
+uv run scripts/blocking_report.py candidates.jsonl --labels matches.jsonl
+```
+
+### Phase 4 — Serve and maintain
+
+11. **Serving.** Entity-link the query, expand 1–2 hops, serialize the subgraph as compact
+    `(head)-[REL {time, source}]->(tail)` lines grouped by head. For multi-hop questions retrieve
+    *paths* between the query's entities, not neighborhoods around each — the path is the answer
+    skeleton. Cluster and pre-summarize for "what are the themes" questions.
+12. **Maintenance.** New facts supersede rather than overwrite: keep the prior claim with
+    `status`, `supersedes`, and validity interval. When a new fact contradicts a stored one, keep
+    both with time and provenance and prefer the newer at retrieval. Re-run fusion periodically —
+    unmaintained memory graphs rot exactly like unfused extractions.
+
+## Output
+
+Deliver these artifacts, in this order:
+
+| Artifact             | Contents                                                             |
+|---|---|
+| `competency.md`      | The 10–20 questions, each marked answerable or blocked                |
+| `ontology.yaml`      | Entity types, relation types with domain/range, event argument schemas |
+| `extraction/`        | Per-source-type prompts and deterministic mappings                    |
+| `quality-report.md`  | Sampled entity and relation precision, with sample size and method    |
+| `fusion-report.md`   | Blocking reduction ratio, pair recall, merge counts per band          |
+| The graph            | Nodes and edges, every one carrying `source`, `extracted_at`, confidence |
+
+Report precision as a sampled estimate with its sample size. A precision number without a
+stated sampling method is a vibe.
+
+## Working rules
+
+- **Schema first, always.** Extraction without an ontology produces a word cloud with arrows.
+  If the user resists schema design, induce a minimal 5-type ontology from three sample
+  documents and show it for approval — never skip to extraction.
+- **Provenance on every fact.** `source`, `extracted_at`, confidence. Non-negotiable; fusion and
+  trust both depend on it.
+- **Pilot before scale.** Run 10 documents through all four phases first. The pilot exposes
+  ontology gaps at 1% of the cost.
+- **Never auto-accept an induced schema.** LLM-proposed ontologies overfit their sample
+  documents. Prune to the minimal set that answers the competency questions.
+- **The LLM is stage machinery, not the pipeline.** It slots into extraction and the ambiguous
+  matching band. The surrounding schema, validation, and merge policy are what make the output
+  a knowledge graph rather than a transcript.
+
+## Errors and troubleshooting
+
+| Symptom                              | Cause                                    | Fix                                                        |
+|---|---|---|
+| Graph full of `Concept`/`Thing` nodes | Extracted without an ontology            | Phase 1 first, then re-extract                              |
+| Same person appears as four nodes     | No canonical-form rule; fusion skipped   | Define the rule in `ontology.yaml`; run Phase 3             |
+| Confident but wrong relations         | Co-occurrence treated as assertion       | Require evidence quotes; enforce domain/range in code       |
+| Events flattened into edge soup       | No event argument schema                 | Promote events to first-class nodes with typed arguments    |
+| Precision collapses as sources grow   | One prompt drifting across document types | Per-source-type prompts; run the quality gate per source    |
+| Fusion merges two real entities       | Threshold too low; no structural layer   | Raise the auto-merge band; add neighborhood comparison; undo via `merged_from` |
+| Multi-hop answers are wrong but fluent | Unfused duplicates break paths          | Re-run fusion; paths cannot cross duplicate boundaries      |
+| GraphRAG returns noise                | Hop expansion too wide                   | Cap at 2 hops, or re-rank; retrieve paths, not neighborhoods |
+| Retrieval is stale after updates      | Facts overwritten instead of superseded  | Adopt the claim model in `references/provenance-and-supersession.md` |

--- a/skills/kg-builder/evals/cases.yaml
+++ b/skills/kg-builder/evals/cases.yaml
@@ -1,0 +1,227 @@
+cases:
+  - id: build_graph_from_documents
+    prompt: "I have 400 supplier contracts as PDFs. I want to build a knowledge graph so I can ask which suppliers depend on which sub-suppliers. Where do I start?"
+    fixtures: []
+    rubric:
+      - "runs the value test and confirms multi-hop queries justify a graph"
+      - "insists on competency questions and an ontology before extraction"
+      - "does not jump straight to entity extraction"
+      - "specifies domain and range on relation types"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(competency question|ontology)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(domain|range)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(multi-hop|multi hop)"
+        weight: 0.7
+      - type: not_contains
+        target: "TODO"
+        weight: 0.3
+
+  - id: design_ontology
+    prompt: "Help me design an ontology for an internal engineering knowledge base covering people, services, and incidents."
+    fixtures: []
+    rubric:
+      - "asks for or writes competency questions first"
+      - "proposes a small type set rather than an exhaustive taxonomy"
+      - "gives each relation an explicit domain and range"
+      - "rejects vague relation names like RELATED_TO"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(domain|range)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(CONTRIBUTED_TO|AFFECTED|[A-Z]+_[A-Z]+)"
+        weight: 0.8
+      - type: not_contains
+        target: "RELATED_TO:"
+        weight: 0.6
+      - type: matches_regex
+        target: "(canonical|provenance)"
+        weight: 0.5
+
+  - id: extract_entities_and_relations
+    prompt: "What prompt should I use to extract entities and relations from unstructured incident reports into my graph?"
+    fixtures: []
+    rubric:
+      - "separate passes for entities and relations, not one mega-prompt"
+      - "embeds the ontology in the prompt"
+      - "requires a verbatim evidence quote per extraction"
+      - "validates domain and range in code rather than in the prompt"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(evidence|verbatim|quote)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(ontology)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(separate pass|one pass|two pass|per stage)"
+        weight: 0.7
+      - type: matches_regex
+        target: "(domain/range|domain and range)"
+        weight: 0.7
+
+  - id: deduplicate_entities
+    prompt: "My graph has 40k company records with tons of duplicates — Acme Corp, Acme Corporation, ACME. How do I deduplicate entities without wrecking the graph?"
+    fixtures: []
+    rubric:
+      - "prescribes blocking before matching to avoid quadratic comparison"
+      - "layers string, attribute, and structural evidence"
+      - "treats a false merge as worse than a missed merge"
+      - "requires a reversible merge policy with merged_from"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(blocking|block)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(neighborhood|structural|structure layer)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(reversib|undo|merged_from)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(threshold|band)"
+        weight: 0.6
+
+  - id: entity_resolution_recall_ceiling
+    prompt: "How do I know if my blocking strategy for entity resolution is good enough before I run it on the full dataset?"
+    fixtures: []
+    rubric:
+      - "identifies pair recall as the ceiling on fusion recall"
+      - "requires a labeled match set to measure against"
+      - "distinguishes reduction ratio from pair recall"
+      - "recommends a union of several blocking keys"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(pair recall|recall)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(reduction ratio|reduction)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(label|ground truth)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(blocking_report|union)"
+        weight: 0.5
+
+  - id: add_graphrag
+    prompt: "I want to add GraphRAG to my agent so it answers from our knowledge graph instead of hallucinating. How should retrieval work?"
+    fixtures: []
+    rubric:
+      - "routes by question type and says which questions the graph should not serve"
+      - "retrieves paths between entities for multi-hop questions, not neighborhoods"
+      - "serializes as triples carrying provenance and time"
+      - "requires a vector-only baseline over the same source text"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(path|paths)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(baseline|vector)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(provenance|source)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(hop)"
+        weight: 0.6
+
+  - id: graph_memory_for_agent
+    prompt: "I want graph memory for an agent that accumulates facts across sessions. How do I handle a new fact that contradicts something already stored?"
+    fixtures: []
+    rubric:
+      - "supersedes rather than overwrites, keeping the prior claim addressable"
+      - "keeps both claims with time and provenance"
+      - "separates validity time from record time"
+      - "distinguishes temporal change from genuine contradiction"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(supersede|supersedes)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(provenance|source)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(keep both|both claims|retain both)"
+        weight: 0.8
+      - type: not_contains
+        target: "overwrite the"
+        weight: 0.5
+
+  - id: measure_llm_adjudicator
+    prompt: "I'm using an LLM to decide whether two extracted entities are the same. Is that a good idea?"
+    fixtures: []
+    rubric:
+      - "restricts model adjudication to the ambiguous middle band"
+      - "requires measurement against a prompt-only baseline on labeled pairs"
+      - "notes engineered loops have measurably lost to prompt-only baselines"
+      - "keeps the merge policy itself in deterministic code"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(baseline)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(middle band|ambiguous)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(deterministic|code)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(label|held-out|measure)"
+        weight: 0.7
+
+  - id: reject_graph_when_table_suffices
+    prompt: "We have a flat list of 5000 products and we look each one up by SKU. Should we build a knowledge graph for it?"
+    fixtures: []
+    rubric:
+      - "applies the value test and answers no"
+      - "identifies single-hop lookup as the disqualifying pattern"
+      - "recommends a table or plain search instead"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(single-hop|single hop|lookup)"
+        weight: 1.0
+      - type: matches_regex
+        target: "(table|database|no)"
+        weight: 0.9
+      - type: not_contains
+        target: "ontology.yaml"
+        weight: 0.4
+
+  - id: negative_agent_orchestration
+    prompt: "Design a graph for my multi-agent system — which agents are nodes, what handoffs are allowed between them, and where the human approval gate goes."
+    fixtures: []
+    rubric:
+      - "agent orchestration topology is task-decomposer territory, not knowledge graphs"
+      - "does not propose an ontology, entity extraction, or fusion"
+    trigger_expected: false
+
+  - id: negative_rag_quality_audit
+    prompt: "Our vector RAG pipeline hallucinates. Measure its retrieval precision and groundedness and tell me what's broken."
+    fixtures: []
+    rubric:
+      - "auditing an existing vector RAG pipeline is rag-auditor territory"
+      - "no knowledge graph is being built here"
+    trigger_expected: false
+
+  - id: negative_graph_visualization
+    prompt: "Draw me a dependency diagram of the modules in this repository."
+    fixtures: []
+    rubric:
+      - "diagram rendering is a visualization task, not knowledge graph construction"
+      - "does not propose ontology design or entity resolution"
+    trigger_expected: false

--- a/skills/kg-builder/references/extraction.md
+++ b/skills/kg-builder/references/extraction.md
@@ -1,0 +1,166 @@
+# Extraction: Sources, Entities, Relations, Events
+
+Extraction is where cost is spent and where precision is won or lost. The ontology constrains
+every step; validation runs in code, not in the prompt.
+
+## Contents
+
+- [Route by source type](#route-by-source-type)
+- [Entity extraction](#entity-extraction)
+- [Relation extraction](#relation-extraction)
+- [Event extraction](#event-extraction)
+- [Prompt patterns](#prompt-patterns)
+- [Chunking](#chunking)
+- [The quality gate](#the-quality-gate)
+- [Failure modes](#failure-modes)
+
+## Route by source type
+
+Match the method to the structure of the source. Running a language model over data that is
+already structured is the most common and most expensive mistake in this pipeline.
+
+| Source                                              | Method                                                                      | Model involved      |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------- |
+| Structured — databases, CSVs, APIs                   | Direct mapping: column → ontology type, written once per source              | No                  |
+| Semi-structured — HTML tables, infoboxes, wikis, JSON | Parser per layout family                                                     | Only for messy cells |
+| Unstructured — prose, transcripts, PDFs, tickets     | Entity → relation → event passes                                             | Yes                 |
+
+Write the structured mappings first. They are cheap, perfectly precise, and they populate the
+canonical entity set that unstructured extraction will later link against — which measurably
+improves the unstructured pass, because most of its entities are now dictionary hits.
+
+## Entity extraction
+
+Two mechanisms, in this order:
+
+1. **Dictionaries and exact rules** for closed vocabularies you already possess: product names,
+   team roster, ticker symbols, ontology enum values, anything from the structured pass. Exact
+   match beats any model — free, deterministic, perfect precision.
+2. **LLM extraction** for open-ended text, with the ontology's types, definitions, and examples
+   in the prompt.
+
+Always capture, per mention:
+
+| Field       | Why                                                        |
+| ----------- | ----------------------------------------------------------- |
+| `surface`   | The literal string as written — needed for alias building   |
+| `canonical` | Best-guess normalized form under the ontology's rule        |
+| `type`      | Must be an ontology type; anything else is rejected         |
+| `source`    | Document id plus character span or sentence index           |
+| `evidence`  | Verbatim sentence containing the mention                    |
+| `confidence`| high / medium / low — drives the quality gate sample         |
+
+Two classical error classes survive into the LLM era and cause most of the damage:
+
+- **Nested and discontinuous mentions.** "University of California, Berkeley professor John
+  Smith" contains an organization inside a person context. Models routinely emit one span
+  covering both.
+- **Type ambiguity.** "Apple", "Mercury", "Ford" — the type depends entirely on context.
+
+Both are mitigated by the same requirement: make the model quote the evidence sentence. Quoting
+forces the model to attend to the disambiguating context rather than the string alone.
+
+## Relation extraction
+
+Three constraints, each of which removes a whole class of error:
+
+1. **Only between entities that passed the entity pass.** Never let relation extraction invent
+   an endpoint. This single rule stops compounding errors — a hallucinated entity that acquires
+   three hallucinated relations becomes four wrong facts instead of one.
+2. **Constrained to the ontology's relation list, validated in code.** An `EMPLOYED_BY` edge
+   from Organization → Organization is rejected by the domain/range check without a model
+   round-trip. Do the check in code; a prompt instruction is not a validation.
+3. **Evidence must assert, not merely co-occur.** Models happily assert whatever the prior
+   suggests when two entities appear in one sentence. "Musk discussed Twitter" is not `OWNS`.
+   Require a verbatim quote and reject any edge whose quote does not state the relation.
+
+Keep a `candidate_relations` side-list for repeated relations the ontology does not model.
+Review it weekly and promote real ones into the ontology — forcing them into an existing wrong
+type is how a schema silently degrades into `RELATED_TO`.
+
+## Event extraction
+
+Use when the domain is dynamic: news, incidents, transactions, funding rounds, deployments.
+
+An event is a **trigger** (the word or phrase signalling it) plus **typed arguments**
+(participants, time, place, values) plus an **event type** from the ontology.
+
+Events are first-class nodes with edges to their arguments. Never flatten a four-argument event
+into six pairwise edges — the flattening loses which acquisition happened at which price, and
+the information cannot be recovered afterwards.
+
+Reject any event missing its trigger evidence. A trigger-less event is an inference the model
+made, not a fact the source stated.
+
+**Event-to-event edges.** When the question is "what leads to what" rather than "what is related
+to what", model causal, temporal, and conditional edges between event nodes. Distinguish
+*reported as causing* from *observed to co-occur* with separate relation types — the source
+asserting causation is itself a fact with provenance.
+
+## Prompt patterns
+
+One pass per stage. A single mega-prompt that extracts entities, relations, and events together
+produces worse output at every stage and makes failures impossible to attribute.
+
+```text
+You are extracting knowledge for a graph with this ontology:
+<ontology>          # verbatim contents of ontology.yaml
+
+From the text below, extract every entity matching the ontology types.
+For each, emit: {surface, canonical, type, evidence, confidence}
+
+Rules:
+- Only types declared in the ontology. Recurring concepts with no matching
+  type go in a separate "candidates" list — do not force them into a type.
+- evidence must be a verbatim quote from the text containing the mention.
+- Do not merge distinct mentions; deduplication happens in a later stage.
+
+<text>
+```
+
+The relation pass adds the recognized-entity list, the relation inventory with domain and range,
+and one additional rule: *assert only relations the evidence sentence states directly.*
+
+The event pass adds the per-event-type argument schemas and the rule: *reject any event whose
+trigger you cannot quote.*
+
+## Chunking
+
+- Overlap chunks by 10–15% so entities on sentence boundaries survive.
+- Extract per chunk; do not attempt cross-chunk resolution here. Fusion reconciles.
+- Keep the chunk's document id and offset on every extracted item — the source pointer must
+  survive chunking or provenance is lost at the first step.
+- Chunk on structural boundaries (sections, tickets, messages) when they exist. Fixed-size
+  chunking over structured prose splits facts across boundaries for no benefit.
+
+## The quality gate
+
+Run before fusion, never after. Fusion over bad extractions produces a confidently wrong graph
+that is expensive to unwind.
+
+1. Sample 50 extracted items, stratified across source types and confidence bands.
+2. Score **entity precision**: is the entity real, and is its type correct?
+3. Score **relation precision**: does the quoted sentence actually assert this edge?
+4. Target ≥90% precision before proceeding.
+5. When precision misses, fix the prompt or the rules and re-run the pass. Never hand-correct
+   the output — hand-correction hides the defect and it returns at scale.
+
+Recall improves with more passes and more sources. Precision does not: bad precision poisons the
+graph permanently, because fusion propagates wrong facts into merged entities where they are no
+longer traceable to the extraction that produced them.
+
+Report the number with its sample size and stratification. Precision without a stated sampling
+method is not a measurement.
+
+## Failure modes
+
+| Symptom                                       | Cause                                              | Fix                                                                |
+| --------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| Graph full of `Concept` / `Thing` nodes        | Extracted with no ontology                          | Design the ontology, then re-extract                                |
+| Same person appears as four nodes              | No canonical-form rule; fusion not run              | Declare the rule in `ontology.yaml`; run fusion                     |
+| Confident, fluent, wrong relations             | Co-occurrence treated as assertion                  | Evidence-quote requirement plus domain/range validation in code     |
+| Events flattened into edge soup                | No per-event argument schema                        | Promote events to nodes with typed arguments                        |
+| Precision collapses as sources are added       | One prompt drifting across document types           | Per-source-type prompts; run the quality gate per source            |
+| Entities with no source pointer                | Provenance dropped during chunking                  | Carry document id and offset through the chunker                    |
+| Extraction cost grows superlinearly            | Structured sources routed through the model         | Move them to deterministic mappings                                 |
+| Model invents plausible entities not in text   | No evidence requirement, or evidence not checked    | Require verbatim quotes and verify the quote appears in the source  |

--- a/skills/kg-builder/references/fusion.md
+++ b/skills/kg-builder/references/fusion.md
@@ -1,0 +1,167 @@
+# Fusion: Entity Resolution and Merge Policy
+
+Fusion is the stage that decides whether the graph is useful. Skipping it is the single most
+common reason a knowledge-graph project produces something nobody uses: an unfused graph answers
+multi-hop questions *wrongly and confidently*, because every path breaks at a duplicate boundary.
+
+## Contents
+
+- [What fusion is resolving](#what-fusion-is-resolving)
+- [Blocking](#blocking)
+- [Matching](#matching)
+- [Threshold bands](#threshold-bands)
+- [Merge policy](#merge-policy)
+- [Ontology matching](#ontology-matching)
+- [Measuring fusion](#measuring-fusion)
+- [Incremental fusion](#incremental-fusion)
+
+## What fusion is resolving
+
+Every extraction pass produces duplicates, within a source and across sources:
+
+- Surface variation — "SEU", "Southeast University", "东南大学"
+- Abbreviation and legal suffix — "Acme Corp", "Acme Corporation", "ACME"
+- Genuine ambiguity — "Bob Smith" in document 3 and "Robert Smith" in document 41 may or may not
+  be one person, and the text alone does not settle it
+
+The output of fusion is not "fewer nodes". It is **stable identity**: a guarantee that a given
+real-world thing has exactly one node, so that a path through it is a real path.
+
+## Blocking
+
+Never compare all pairs. At 100K entities, exhaustive comparison is 5×10⁹ pairs.
+
+Group candidates cheaply first; only pairs inside a block get scored:
+
+| Blocking key                    | Catches                                    | Misses                                  |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------- |
+| Same type + shared token        | "Acme Corp" / "Acme Corporation"           | "IBM" / "International Business Machines" |
+| Normalized key (lowercase, strip punctuation, drop legal suffixes) | Suffix and casing variation | Genuine synonyms                          |
+| Acronym expansion               | "SEU" / "Southeast University"             | Non-initialism abbreviations             |
+| Embedding neighborhood (top-k)  | Paraphrase and translation                 | Short strings; embedding-model blind spots |
+| External identifier             | Anything with a shared id — perfect signal | Entities lacking the identifier          |
+
+Use several keys in union, not one. Each key has a different blind spot; the union's recall is
+what matters, and a single key never gets there.
+
+Two numbers characterize a blocking strategy, and you must know both:
+
+- **Reduction ratio** — fraction of all pairs eliminated. Higher is cheaper.
+- **Pair recall** — fraction of true matches that survive into some block. Anything blocking
+  filters out can never be matched, at any threshold, by any model downstream.
+
+Blocking recall is a hard ceiling on fusion recall. Measure it before scaling:
+
+```bash
+uv run scripts/blocking_report.py candidates.jsonl --labels matches.jsonl
+```
+
+## Matching
+
+Score surviving pairs on layered evidence. Layers are ordered cheapest-first; the expensive
+layers only run on pairs the cheap ones leave undecided.
+
+1. **String layer.** Normalized equality, alias table hit, acronym expansion, edit distance.
+   Resolves the large majority of true matches at near-zero cost.
+2. **Attribute layer.** Compatible attributes — same founding year, same email domain, same
+   external identifier. Attribute *conflict* is strong negative evidence and should be able to
+   veto a string match on its own.
+3. **Structure layer.** Compare neighborhoods. Two `J. Smith` nodes sharing three coauthors and
+   an affiliation are the same person; two with identical names and disjoint neighborhoods are
+   not. This is the layer naive deduplication omits and the one that resolves the genuinely hard
+   cases, because it uses information the strings do not contain.
+4. **Model adjudication — ambiguous middle band only.** Show both nodes' attributes,
+   neighborhoods, and evidence quotes, and ask whether they are the same entity.
+
+### Measure the adjudicator before trusting it
+
+A model adjudicator is a claim about decision quality, and claims need baselines. Build a
+labeled set of pairs from the middle band and compare the adjudicator against a prompt-only
+baseline on the same pairs.
+
+This is not hypothetical. In a pre-registered real-model evaluation of an LLM-adjudicated
+dedup-and-contradiction loop over 108 held-out cases across two embedding models and two
+generation models, the loop **trailed the prompt-only baseline by 0.28–0.33 on detection and
+safety in every provider cell**. The engineered loop lost to the plain prompt. Unmeasured
+adjudication is decoration, and it is decoration that costs a model call per pair.
+
+If the adjudicator does not beat the baseline, widen the auto-bands and send the middle to human
+review instead. That is a legitimate outcome, not a failure.
+
+## Threshold bands
+
+Three bands, two thresholds, and the bands are not symmetric:
+
+| Band            | Action                          | Sizing principle                                            |
+| --------------- | ------------------------------- | ------------------------------------------------------------ |
+| Above high      | Auto-merge                      | Set from labeled data so false-merge rate is near zero        |
+| Middle          | Adjudicate or queue for a human | Should be small; a large middle band means weak features      |
+| Below low       | Auto-reject                     | Generous — a missed merge is recoverable later                |
+
+**Asymmetry is the point.** An erroneous merge silently fuses two entities' entire edge sets, and
+every query afterwards returns a blend of two real things with no signal that anything is wrong.
+A missed merge leaves two nodes that a later pass can still join. Tune the high threshold for
+precision, not for how many merges it produces.
+
+## Merge policy
+
+Deterministic code. Never a model judgment — a model that decides *whether* two nodes match must
+still not decide *what the merged node contains*.
+
+| Field                | Policy                                                                       |
+| -------------------- | ----------------------------------------------------------------------------- |
+| Canonical name       | Apply the ontology's canonical-form rule; longest legal form breaks ties       |
+| Aliases              | Union of all surface forms, each retaining its source                          |
+| Edges                | Union; deduplicate identical (type, target, time) triples                      |
+| Conflicting values   | **Keep both**, each with its provenance — never silently overwrite             |
+| Provenance           | Union of source pointers; earliest `extracted_at` retained per claim           |
+| `merged_from`        | Record every absorbed node id so the merge is reversible                       |
+
+Conflicting attribute values are signal, not noise. Two sources disagreeing on a founding year
+means one is wrong or they mean different events. Overwriting destroys the only evidence that a
+question exists. Store both, surface the conflict, and let the retrieval layer prefer by recency
+or source trust — see [`provenance-and-supersession.md`](provenance-and-supersession.md).
+
+Every merge must be undoable. `merged_from` plus append-only claims is what makes an
+over-aggressive threshold a recoverable mistake instead of permanent corruption.
+
+## Ontology matching
+
+When fusing two *graphs* rather than two instance sets, align the schemas first:
+
+1. Align entity and relation types by name and definition — a reasonable model task.
+2. **Verify with instance overlap.** If source A's `Firm` nodes mostly resolve to source B's
+   `Company` nodes, the type mapping is confirmed by data rather than by the model's opinion.
+3. Translate source B's edges through the confirmed mapping.
+4. Only then run instance fusion.
+
+Skipping step 2 is how two graphs get merged under a plausible but wrong type mapping, which is
+much harder to detect afterwards than a wrong instance merge.
+
+## Measuring fusion
+
+Report four numbers, each with its method:
+
+| Metric                | How to obtain it                                                          |
+| --------------------- | -------------------------------------------------------------------------- |
+| Blocking pair recall  | Labeled match set; fraction surviving blocking                              |
+| Reduction ratio       | Pairs after blocking ÷ all pairs                                            |
+| Merge precision       | Sample 50 auto-merges; how many are correct                                 |
+| Merge recall estimate | Sample entities with known duplicates; how many were joined                 |
+
+A duplicate-rate claim ("duplicates ≈ 0 after fusion") is only meaningful against a labeled set.
+Re-ingesting the same documents and observing zero new nodes tests idempotence, which is a
+useful mechanical property and is *not* evidence that distinct duplicates were resolved.
+
+## Incremental fusion
+
+For graphs that grow continuously — agent memory, ongoing ingests:
+
+1. Block the new facts against the existing graph, not against each other alone.
+2. Match and merge with the same machinery and the same thresholds. Divergent thresholds between
+   the initial build and the incremental path produce a graph whose identity rules changed
+   halfway through and cannot be reasoned about.
+3. Re-run full fusion periodically. Entities that were ambiguous when first seen often become
+   resolvable once their neighborhoods fill in — the structure layer gets stronger over time.
+4. Re-score stale confidences on the same schedule. Unmaintained memory graphs rot exactly like
+   unfused extractions.

--- a/skills/kg-builder/references/ontology-design.md
+++ b/skills/kg-builder/references/ontology-design.md
@@ -1,0 +1,179 @@
+# Ontology Design and Storage Choice
+
+The schema is the product. Everything downstream — extraction prompts, validation, fusion
+thresholds, query shape — is derived from it. Design it before touching data.
+
+## Contents
+
+- [The value test](#the-value-test)
+- [Competency questions](#competency-questions)
+- [Building the type system](#building-the-type-system)
+- [Schema design rules](#schema-design-rules)
+- [Storage and representation](#storage-and-representation)
+- [The ontology file](#the-ontology-file)
+- [Ontology induction](#ontology-induction)
+
+## The value test
+
+A graph earns its maintenance cost under three conditions:
+
+1. **Multi-hop queries.** "Which engineers contributed to services that had incidents last
+   quarter" traverses three types. A table would need three joins written by hand per question.
+2. **Entities recur across documents.** The same supplier appears in 400 contracts under six
+   spellings. Resolution is the value; the graph is where resolved identity lives.
+3. **Relationships are the data.** Dependency chains, citation networks, ownership structures —
+   the edges carry the meaning, not the nodes.
+
+Counter-indications, each of which should stop the project:
+
+- Every query is a single-hop lookup by key. Use a table.
+- Every query is an aggregation ("total spend by region"). Use a warehouse; graphs are bad at
+  aggregation.
+- The corpus is small and static and one person answers questions from it. Use search.
+
+Write the kill criterion into `competency.md` before proceeding, so the decision is auditable
+later when someone asks why this exists.
+
+## Competency questions
+
+Write 10–20 real questions in the user's own words. They serve three jobs at once: they are the
+ontology's specification, its test suite, and the acceptance criteria for the finished graph.
+
+Rules:
+
+- Real questions from real users, not questions invented to fit a schema you already imagined.
+- Include at least three multi-hop questions. If you cannot write three, revisit the value test.
+- Mark each question with the answer shape it needs: single node, list, path, subgraph, or
+  aggregate. Aggregates are a signal that part of this belongs in a database.
+
+Walk every question through the finished schema on paper. Any question you cannot path through
+is a missing entity type or a missing relation — not a query problem.
+
+## Building the type system
+
+1. **Entity types** — extract the nouns the competency questions turn on. Start with 5–15. Each
+   type needs a one-line definition and 2–3 real examples from the corpus. If you cannot produce
+   two real examples, the type is speculative; drop it.
+2. **Relation types** — extract the verbs. Start with 10–30. Every relation carries an explicit
+   **domain** and **range**: `EMPLOYED_BY: Person → Organization`. Note cardinality where it
+   constrains extraction (a Person has one birthplace; a Person has many employers over time).
+3. **Attributes versus entities** — if it has its own relationships, it is an entity ("City" has
+   a country and a population). If it is a value you filter or sort on, it is an attribute
+   ("founding year").
+4. **Event types** — for dynamic domains, define per-event-type argument schemas:
+   `Acquisition: {acquirer, target, price, date}`. Events are nodes, not edges.
+5. **Type hierarchy only where queries need it.** `Company ⊂ Organization` is worth having if
+   some questions span all organizations. Otherwise stay flat — flat schemas are easier to
+   extract against and easier to validate.
+
+## Schema design rules
+
+- **Precise verb names.** `ACQUIRED`, `CITES`, `DEPENDS_ON`. Never `RELATED_TO`, `HAS_LINK`,
+  `ASSOCIATED_WITH`. A vague relation makes every downstream query ambiguous and makes
+  domain/range validation useless.
+- **Merge types that are always queried together.** Two types that never appear apart in a
+  competency question are one type with an attribute.
+- **Split a type that needs disambiguating qualifiers.** If `CONTRIBUTED_TO` keeps needing
+  `role: "author" | "editor"`, make two relation types instead.
+- **Define the canonical-form rule at modeling time.** Full legal name? Lowercased? Which
+  language? Fusion enforces whatever rule is stated here, so an unstated rule means fusion has
+  nothing to enforce.
+- **Every fact carries time and provenance.** Decide the mechanism now — see
+  [`provenance-and-supersession.md`](provenance-and-supersession.md). In property graphs these
+  are edge properties; in RDF use RDF-star or reification; in SQLite they are columns. Adding
+  them after fusion is effectively impossible because the merges have already discarded the
+  information.
+
+## Storage and representation
+
+| Representation                          | Choose when                                                                            | Cost                                                                 |
+| --------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **Property graph** (Neo4j, Kùzu, Memgraph) | Default for products and agent memory. Arbitrary key-value properties on nodes and edges. | No formal semantics; consistency is your code's job.                  |
+| **RDF / OWL**                           | Interop with published ontologies, standards compliance, description-logic reasoning (subsumption, consistency checking). | Verbose; edge properties need RDF-star or reification; heavier tooling. |
+| **Typed edges in SQLite or JSON**       | Under ~50K nodes, single application, agent-local memory.                               | Query power capped; migrate when multi-hop queries get slow or frequent. |
+
+### The query layer is part of the design
+
+Choosing a store is not choosing a query strategy. Decide, before extraction:
+
+- **Which traversals are hot.** Index the entry points those traversals start from — usually
+  canonical name and external identifier.
+- **How deep traversals may go.** Set a hop cap in code. Unbounded traversal over a graph with
+  one hub node returns the whole graph.
+- **What the agent-facing surface is.** Deterministic, parameterized traversals beat handing a
+  model raw query-language access: they are testable, cacheable, and cannot be prompt-injected
+  into scanning the whole store.
+- **Where the embedding index lives.** If fusion or retrieval uses vector similarity, the index
+  is derived state. It must be rebuildable from the graph, and rebuild must be cheap enough to
+  run after every ingest.
+
+### On graph reasoning and embeddings
+
+Representation learning (TransE and its successors) and rule-based reasoning are real parts of
+the knowledge-graph field, and they are largely **not** what an agent memory graph needs. Link
+prediction answers "which edges are probably missing" — a research question. Agent memory needs
+"which facts do I actually have, and where did they come from." Reach for embeddings for
+*blocking* during fusion and for entity linking at query time. Reach for rule-based reasoning
+(transitive closure, type inference) when the ontology has a real hierarchy and the queries need
+it. Do not add either because the literature features them.
+
+## The ontology file
+
+Keep one `ontology.yaml` as the single source of truth. Every extraction prompt embeds it
+verbatim; the validator checks it; the fusion merge policy reads the canonical-form rules from it.
+
+```yaml
+canonical_form:
+  Person: "full name as first written, title stripped"
+  Organization: "full legal name, no suffix normalization"
+
+entities:
+  Person:
+    desc: an individual engineer, manager, or author
+    examples: [Jane Doe, A. Kowalski]
+  Service:
+    desc: a deployable software unit with an owner
+    examples: [payments-api, billing-worker]
+  Incident:
+    desc: a production failure with a start time
+    examples: [INC-4012]
+
+relations:
+  CONTRIBUTED_TO:
+    domain: Person
+    range: Service
+  AFFECTED:
+    domain: Incident
+    range: Service
+    attrs: [severity]
+
+events:
+  Incident:
+    trigger: outage or alert
+    args: [service, start_time, resolved_time, severity]
+```
+
+Three entity types, two relations, one event type fully answer "which engineers contributed to
+services that had incidents last quarter." Resist adding a type until a competency question
+demands it.
+
+Validate it before extracting:
+
+```bash
+uv run scripts/validate_ontology.py ontology.yaml
+```
+
+The validator rejects relations whose domain or range names an undeclared entity type, vague
+relation names, event argument schemas with no trigger, and entity types with no examples.
+
+## Ontology induction
+
+Semi-automatic schema induction is useful as a *draft generator*, never as a decision:
+
+1. Give a model 3–5 representative documents.
+2. Ask it to propose entity and relation types **with a verbatim evidence quote for each**.
+3. Prune manually to the minimal set that answers the competency questions.
+
+Induced ontologies overfit their sample documents — they mint a type for whatever the first five
+documents happened to emphasize. The evidence-quote requirement makes the overfit visible: a
+proposed type supported by one quote from one document is not a type.

--- a/skills/kg-builder/references/provenance-and-supersession.md
+++ b/skills/kg-builder/references/provenance-and-supersession.md
@@ -1,0 +1,146 @@
+# Provenance and Supersession
+
+Every fact in the graph must answer three questions: where did this come from, when was it true,
+and what did it replace. A graph that cannot answer them cannot be audited, cannot be safely
+merged, and cannot be trusted after its first update.
+
+This is the stage most pipelines defer and none successfully retrofit. Fusion discards the
+information provenance is derived from, so provenance added after fusion is reconstruction, not
+record.
+
+## Contents
+
+- [The claim model](#the-claim-model)
+- [Supersession instead of overwrite](#supersession-instead-of-overwrite)
+- [The no-silent-overwrite invariant](#the-no-silent-overwrite-invariant)
+- [Contradiction handling](#contradiction-handling)
+- [Validity time versus record time](#validity-time-versus-record-time)
+- [Audit trail](#audit-trail)
+- [Retrieval over a claim ledger](#retrieval-over-a-claim-ledger)
+
+## The claim model
+
+Make the *claim* the atomic unit, not the edge. An edge is the current consensus; a claim is a
+specific assertion by a specific source at a specific time. The graph is a projection of the
+claim ledger.
+
+| Field            | Purpose                                                             |
+| ---------------- | --------------------------------------------------------------------- |
+| `claim_id`       | Stable identity; content-addressed so identical claims collapse       |
+| `statement`      | The assertion — a typed triple, plus its verbatim evidence quote      |
+| `source_id`      | Which document, record, or run asserted it                            |
+| `asserted_at`    | When the source made the assertion (record time)                      |
+| `effective_from` | When the fact started being true (validity time)                      |
+| `effective_to`   | When it stopped, if it has                                            |
+| `status`         | `current` / `superseded` / `retracted`                                |
+| `supersedes`     | The `claim_id` this replaces — the lineage pointer                    |
+| `contradicts`    | A `claim_id` this materially conflicts with                           |
+| `confidence`     | Extraction or adjudication confidence                                 |
+| `reviewer`       | Who approved it, when a human gate was involved                       |
+
+Two fields do the heavy lifting. `supersedes` makes history reconstructable. `contradicts` makes
+disagreement a first-class state rather than a race between writes.
+
+## Supersession instead of overwrite
+
+When new information arrives about an existing fact, **append a new claim and mark the old one
+superseded**. Do not edit the old claim in place.
+
+```text
+claim_7a2  Jane Doe EMPLOYED_BY Acme     effective_from 2023-01  status superseded
+claim_e11  Jane Doe EMPLOYED_BY Globex   effective_from 2025-06  status current
+                                          supersedes claim_7a2
+```
+
+What this buys, none of which is available from an in-place update:
+
+- **Reconstructable history.** "What did the graph believe on this date" is a query, not an
+  archaeology project.
+- **Reversible mistakes.** A wrong merge or a bad extraction is undone by re-projecting without
+  the offending claims.
+- **Attributable disagreement.** Two sources disagreeing produce two claims, not a last-write-wins
+  coin flip whose outcome depends on ingest order.
+- **Debuggable retrieval.** When an agent answers wrongly, the claim that produced the answer is
+  identifiable and its source is one hop away.
+
+Cost is storage and one indirection at query time. Both are cheap. Losing the ability to explain
+where an answer came from is not.
+
+## The no-silent-overwrite invariant
+
+State the guarantee as a checkable property, not a convention:
+
+> For every ingest, each claim present before the ingest is, after it, either still `current`,
+> or `superseded` by a claim that names it in `supersedes`, or explicitly `retracted` with a
+> reason.
+
+A claim that simply disappears violates the invariant. Assert this in code after every ingest and
+fail the ingest when it trips. Written as an assertion it is enforced; written as a design note
+it is aspirational, and it will be violated by the first fusion bug nobody noticed.
+
+The same invariant makes over-aggressive fusion survivable. Merges that discard claims fail the
+check immediately, at ingest, rather than surfacing months later as a query that returns a blend
+of two real entities.
+
+## Contradiction handling
+
+When a new claim materially conflicts with a stored one:
+
+1. **Keep both.** Never resolve by deletion.
+2. **Link them** with `contradicts` in both directions.
+3. **Classify the conflict:**
+
+| Class            | Example                                                    | Resolution                                              |
+| ---------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| Temporal change  | Employer changed                                            | Not a conflict — set `effective_to` on the prior claim   |
+| Granularity      | "Berlin" versus "Germany"                                   | Not a conflict — both true; model the hierarchy          |
+| Source disagreement | Two filings give different founding years                | Keep both; prefer by source trust at retrieval            |
+| Genuine error    | One source is simply wrong                                  | Retract with a reason; retraction is recorded, not deleted |
+
+Most detected "contradictions" are the first two classes. A detector that does not separate
+temporal change from real conflict will flood the review queue and get switched off.
+
+**Measure the detector.** If contradiction detection is a model call, compare it against a
+prompt-only baseline on a labeled held-out set before relying on it. In a pre-registered
+real-model evaluation, an engineered detection loop trailed the prompt-only baseline by 0.28–0.33
+on detection and safety across every provider cell tested. The governance machinery — lineage,
+reversibility, audit trail — held up under the same evaluation. The *judgment* did not. Ship the
+machinery; measure the judgment.
+
+## Validity time versus record time
+
+Keep them separate. Conflating them makes both unusable.
+
+- **Validity time** (`effective_from` / `effective_to`) — when the fact was true in the world.
+- **Record time** (`asserted_at`) — when the source said so.
+
+A contract signed in March and ingested in June has validity time March and record time June.
+"What was true in April" and "what did we know in April" are different questions, both legitimate,
+and only a bitemporal record answers both.
+
+## Audit trail
+
+For graphs whose contents carry consequence:
+
+- **Batch identity.** Every ingest gets a run id; every claim records the run that produced it.
+- **Reviewable diff.** Express an ingest as a proposed set of claim additions and supersessions,
+  reviewable before it lands.
+- **Human gate on irreversible steps.** Place the gate where a mistake is expensive to undo —
+  merges above the auto-threshold, retractions, schema changes — not on every write. A gate on
+  everything makes the human the bottleneck and gets bypassed.
+- **Replay.** The graph is a projection of the ledger, so it must be rebuildable from the ledger
+  alone. If it is not, some state lives outside the audit trail and the trail is decorative.
+
+## Retrieval over a claim ledger
+
+Serving reads the projection, not the raw ledger:
+
+1. Default to `status: current`.
+2. Prefer higher-trust sources when claims conflict; when trust is equal, prefer the more recent
+   `asserted_at`.
+3. Filter by validity time when the query is time-scoped ("who owned this in 2024").
+4. **Surface unresolved contradictions in the serialized output** rather than silently picking
+   one. An agent told two sources disagree can say so; an agent handed one arbitrary side states
+   it as fact.
+5. Carry `claim_id` and `source_id` into the serialized context so an answer is traceable to the
+   assertion that produced it.

--- a/skills/kg-builder/references/serving.md
+++ b/skills/kg-builder/references/serving.md
@@ -1,0 +1,145 @@
+# Serving the Graph to Agents
+
+A graph nobody queries is a data-modelling exercise. Serving is where the pipeline either pays
+for itself or does not — and it must be measured against the boring baseline it claims to beat.
+
+## Contents
+
+- [Retrieval strategy by question type](#retrieval-strategy-by-question-type)
+- [Path retrieval](#path-retrieval)
+- [Serialization](#serialization)
+- [Community summaries](#community-summaries)
+- [The agent-facing surface](#the-agent-facing-surface)
+- [Graph as agent memory](#graph-as-agent-memory)
+- [Proving the graph earns its cost](#proving-the-graph-earns-its-cost)
+
+## Retrieval strategy by question type
+
+Route by question shape. Most real question sets contain a large fraction that the graph should
+not serve at all, and pretending otherwise is how graph retrieval acquires a reputation for being
+slower and worse than vector search.
+
+| Question type                              | Strategy                                     | Should the graph serve it? |
+| ------------------------------------------ | ---------------------------------------------- | -------------------------- |
+| "What is X?"                                | Entity lookup, return node plus 1 hop         | Yes, cheaply               |
+| "How are X and Y connected?"                | Path retrieval between the two entities       | Yes — this is the point    |
+| "Who did X with Y on Z?"                    | Multi-hop constrained traversal               | Yes — this is the point    |
+| "What are the themes in this corpus?"       | Precomputed community summaries               | Yes, offline               |
+| "Summarize this document"                   | Return the source document                    | No — use the document store |
+| "Find passages about X"                     | Vector search over source text                | No — use the vector index  |
+| "Total spend by region"                     | Aggregate query                               | No — use the warehouse     |
+
+Say out loud which questions do not need the graph. A retrieval layer that routes everything
+through traversal will lose to plain vector search on the majority of a realistic question set.
+
+## Path retrieval
+
+For multi-hop questions, retrieve the **paths between** the query's entities, not the
+neighborhoods around each one.
+
+Neighborhood expansion around two entities returns two clouds and asks the model to find the
+connection inside them. Path retrieval returns the connection itself. The path is the answer
+skeleton; the model's job reduces to narrating it.
+
+Practical constraints:
+
+- Cap path length at 3–4 hops. Longer paths are almost always spurious.
+- Rank paths by shortest first, then by aggregate edge confidence.
+- Return at most a handful. Twenty paths between two entities means the graph has a hub node
+  that should be excluded from traversal.
+- Exclude hub nodes explicitly. A node with 10,000 edges connects everything to everything and
+  makes every path meaningless.
+
+## Serialization
+
+Serialize the retrieved subgraph as compact typed lines grouped by head entity:
+
+```text
+Jane Doe (Person)
+  -[CONTRIBUTED_TO {since: 2024-03, src: doc/onboarding.md}]-> payments-api (Service)
+  -[REPORTS_TO {src: hr/roster.csv}]-> A. Kowalski (Person)
+
+INC-4012 (Incident)
+  -[AFFECTED {severity: high, src: incidents/4012.md}]-> payments-api (Service)
+```
+
+Rules that matter:
+
+- **Triples beat prose.** A model can quote an exact fact from a triple table; it paraphrases
+  prose summaries and the paraphrase is where fabrication enters.
+- **Carry provenance inline.** The source pointer is what makes the answer checkable. Without
+  it, a graph-grounded answer is indistinguishable from a confident guess.
+- **Carry time inline.** "Works at X" without a validity interval is a fact that quietly expires.
+- **Deduplicate before serializing.** The same edge reached by two paths must appear once.
+- **Budget the context.** Cap the serialized subgraph. Truncate by dropping lowest-confidence
+  edges first, and say in the output that truncation happened.
+
+## Community summaries
+
+For corpus-level questions ("what are the main themes", "what does this codebase do"):
+
+1. Cluster the graph offline — connected components, label propagation, or modularity-based
+   clustering.
+2. Summarize each cluster once, storing the summary as a node with edges to its members.
+3. At query time retrieve summaries, not members.
+
+This is precomputation, so its cost is amortized and its staleness is real. Re-cluster when the
+graph grows materially, and stamp each summary with the graph revision it was built from so a
+stale summary is detectable rather than silently wrong.
+
+## The agent-facing surface
+
+Expose deterministic, parameterized traversals. Do not hand a model raw query-language access to
+the store.
+
+| Surface                            | Why                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| `find_entities(name, type)`        | Entity linking entry point; bounded result set                                  |
+| `get_entity(id, hops=1)`           | Node plus neighborhood, hop-capped in code                                      |
+| `find_paths(from, to, max_hops=3)` | The multi-hop primitive                                                         |
+| `list_summaries(cluster?)`         | Corpus-level questions without loading members                                  |
+
+Parameterized traversals are testable, cacheable, hop-capped, and cannot be talked into scanning
+the entire store. Generated query-language strings are none of those things: they fail in ways
+that depend on the phrasing of the prompt, which makes regressions unreproducible.
+
+Be honest about the boundary this does and does not create. Exposing only traversal tools shapes
+what the graph offers; it does not prevent a host agent that also has filesystem or database
+tools from reading around the surface. Only a sandboxed serving boundary enforces that.
+
+## Graph as agent memory
+
+For agents accumulating knowledge across sessions:
+
+1. **Write path.** After a session, run extraction over the new information with the same
+   ontology, then fuse into the existing graph with the same thresholds. Memory writes are not a
+   separate pipeline; reusing the build pipeline is what keeps identity rules consistent.
+2. **Read path.** At session start, retrieve via traversal rather than dumping the graph into
+   context. The whole point of the structure is that it lets you load a minimal relevant set.
+3. **Supersession, not overwrite.** New facts supersede prior claims and keep them addressable.
+   See [`provenance-and-supersession.md`](provenance-and-supersession.md).
+4. **Contradiction.** Keep both claims with time and provenance; prefer the newer at retrieval;
+   surface the conflict when both are recent. Facts change — the graph should record the change,
+   not fight it.
+5. **Hygiene.** Re-run fusion and re-score confidences periodically.
+
+## Proving the graph earns its cost
+
+Build the evaluation set **before** either system runs, or the comparison is unfalsifiable.
+
+1. Write 30 questions spanning the question types above, including the ones the graph should not
+   serve. Write the answer key first.
+2. Build a **vector-only baseline over the same source text**. Same corpus, same generator, same
+   token budget.
+3. Report per question type, not in aggregate. An aggregate number hides the actual finding,
+   which is nearly always: the graph wins on multi-hop and connection questions and loses
+   elsewhere.
+4. Report tokens and latency alongside accuracy. A graph that wins on accuracy while costing five
+   times the tokens and three times the latency has not necessarily won.
+5. State what the numbers are measured on. Results from a deterministic or toy retrieval stand-in
+   verify mechanics only; they are not evidence of real-model retrieval quality, and reporting
+   them as if they were is how a project acquires a claim it cannot defend.
+
+If the graph does not win on multi-hop questions against the vector baseline, it is not earning
+its maintenance cost. That is a real possible outcome and the correct response is to narrow the
+graph's role to the queries it wins, not to widen the claim.

--- a/skills/kg-builder/scripts/blocking_report.py
+++ b/skills/kg-builder/scripts/blocking_report.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Blocking strategy report for kg-builder entity resolution.
+
+Blocking recall is a hard ceiling on fusion recall: any true match that no blocking key
+puts in a shared block can never be matched downstream, at any threshold, by any model.
+This script measures that ceiling against labeled pairs before you scale.
+
+Reports, per key and for the union of keys:
+  - reduction ratio  — fraction of all pairs eliminated (higher is cheaper)
+  - pair recall      — fraction of true matches surviving into some block (the ceiling)
+  - candidate pairs  — how many comparisons the matcher will actually run
+
+No external dependencies — standard library only.
+
+Input formats (JSON Lines):
+
+  candidates.jsonl   one record per entity
+      {"id": "e1", "type": "Organization", "name": "Acme Corp",
+       "attrs": {"domain": "acme.com"}}
+
+  matches.jsonl      one record per known true match (order-insensitive)
+      {"a": "e1", "b": "e7"}
+
+Usage:
+    python blocking_report.py candidates.jsonl --labels matches.jsonl
+    python blocking_report.py candidates.jsonl --labels matches.jsonl --format json
+    python blocking_report.py candidates.jsonl --labels matches.jsonl --min-recall 0.95
+    python blocking_report.py candidates.jsonl --attr-key domain
+
+Exit codes:
+    0  report produced (and union recall >= --min-recall when given)
+    1  union pair recall below --min-recall
+    2  input missing or malformed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+# Legal-form suffixes stripped when building the normalized key. Suffix variation is the
+# single most common surface difference between duplicate organization records.
+LEGAL_SUFFIXES = frozenset({
+    "inc", "inc.", "incorporated", "corp", "corp.", "corporation", "llc", "l.l.c.",
+    "ltd", "ltd.", "limited", "plc", "gmbh", "ag", "sa", "s.a.", "nv", "bv", "co", "co.",
+    "company", "holdings", "group", "the",
+})
+
+_PUNCT = re.compile(r"[^\w\s]", re.UNICODE)
+_WS = re.compile(r"\s+")
+
+Pair = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class Entity:
+    id: str
+    type: str
+    name: str
+    attrs: dict[str, Any]
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip accents and punctuation, collapse whitespace."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    cleaned = _PUNCT.sub(" ", stripped.lower())
+    return _WS.sub(" ", cleaned).strip()
+
+
+def normalized_key(entity: Entity) -> set[str]:
+    """Type plus the name with punctuation, casing, and legal suffixes removed."""
+    tokens = [t for t in normalize(entity.name).split() if t not in LEGAL_SUFFIXES]
+    if not tokens:
+        return set()
+    return {f"{entity.type}|norm|{' '.join(tokens)}"}
+
+
+def token_keys(entity: Entity) -> set[str]:
+    """Type plus each significant token. Catches shared-word variants."""
+    tokens = [t for t in normalize(entity.name).split() if t not in LEGAL_SUFFIXES and len(t) > 2]
+    return {f"{entity.type}|tok|{t}" for t in tokens}
+
+
+def acronym_keys(entity: Entity) -> set[str]:
+    """Bridge an initialism to its expansion: 'SEU' <-> 'Southeast University'."""
+    tokens = [t for t in normalize(entity.name).split() if t not in LEGAL_SUFFIXES]
+    keys: set[str] = set()
+    if len(tokens) >= 2:
+        keys.add(f"{entity.type}|acr|{''.join(t[0] for t in tokens)}")
+    if len(tokens) == 1 and 2 <= len(tokens[0]) <= 6:
+        keys.add(f"{entity.type}|acr|{tokens[0]}")
+    return keys
+
+
+def prefix_keys(entity: Entity) -> set[str]:
+    """First four characters of the normalized name. Cheap catch-all for typos."""
+    norm = normalize(entity.name).replace(" ", "")
+    return {f"{entity.type}|pre|{norm[:4]}"} if len(norm) >= 4 else set()
+
+
+def make_attr_key(attr: str) -> Callable[[Entity], set[str]]:
+    """Block on an exact shared attribute value, e.g. an email domain or external id."""
+    def key(entity: Entity) -> set[str]:
+        value = entity.attrs.get(attr)
+        return {f"{entity.type}|{attr}|{normalize(str(value))}"} if value else set()
+    return key
+
+
+BUILTIN_KEYS: dict[str, Callable[[Entity], set[str]]] = {
+    "normalized": normalized_key,
+    "token": token_keys,
+    "acronym": acronym_keys,
+    "prefix": prefix_keys,
+}
+
+
+def load_entities(path: Path) -> list[Entity]:
+    entities: list[Entity] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{lineno}: invalid JSON: {exc}") from exc
+        if "id" not in record or "name" not in record:
+            raise ValueError(f"{path}:{lineno}: record needs at least 'id' and 'name'")
+        entities.append(Entity(
+            id=str(record["id"]),
+            type=str(record.get("type", "_")),
+            name=str(record["name"]),
+            attrs=record.get("attrs") or {},
+        ))
+    if not entities:
+        raise ValueError(f"{path}: no records")
+    return entities
+
+
+def load_labels(path: Path, known_ids: set[str]) -> tuple[set[Pair], list[str]]:
+    """Load true-match pairs. Returns the pair set plus warnings for unknown ids."""
+    pairs: set[Pair] = set()
+    warnings: list[str] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{lineno}: invalid JSON: {exc}") from exc
+        if "a" not in record or "b" not in record:
+            raise ValueError(f"{path}:{lineno}: match record needs 'a' and 'b'")
+        a, b = str(record["a"]), str(record["b"])
+        if a == b:
+            continue
+        for missing in (i for i in (a, b) if i not in known_ids):
+            warnings.append(f"{path}:{lineno}: match references unknown entity id '{missing}'")
+        pairs.add((a, b) if a < b else (b, a))
+    return pairs, warnings
+
+
+def candidate_pairs(entities: Iterable[Entity], key_fn: Callable[[Entity], set[str]]) -> set[Pair]:
+    """Pairs sharing at least one blocking key."""
+    blocks: dict[str, list[str]] = defaultdict(list)
+    for entity in entities:
+        for key in key_fn(entity):
+            blocks[key].append(entity.id)
+
+    pairs: set[Pair] = set()
+    for members in blocks.values():
+        if len(members) < 2:
+            continue
+        for a, b in combinations(sorted(set(members)), 2):
+            pairs.add((a, b))
+    return pairs
+
+
+def score(pairs: set[Pair], truth: set[Pair], total_pairs: int) -> dict[str, float | int]:
+    found = len(pairs & truth)
+    return {
+        "candidate_pairs": len(pairs),
+        "reduction_ratio": round(1 - (len(pairs) / total_pairs), 6) if total_pairs else 0.0,
+        "matches_retained": found,
+        "pair_recall": round(found / len(truth), 6) if truth else 0.0,
+    }
+
+
+def build_report(
+    entities: list[Entity],
+    truth: set[Pair],
+    key_names: list[str],
+    attr_keys: list[str],
+) -> dict[str, Any]:
+    total_pairs = len(entities) * (len(entities) - 1) // 2
+
+    key_fns: dict[str, Callable[[Entity], set[str]]] = {
+        name: BUILTIN_KEYS[name] for name in key_names
+    }
+    for attr in attr_keys:
+        key_fns[f"attr:{attr}"] = make_attr_key(attr)
+
+    per_key: dict[str, dict[str, float | int]] = {}
+    union: set[Pair] = set()
+    for name, fn in key_fns.items():
+        pairs = candidate_pairs(entities, fn)
+        per_key[name] = score(pairs, truth, total_pairs)
+        union |= pairs
+
+    union_score = score(union, truth, total_pairs)
+    missed = sorted(truth - union)
+
+    return {
+        "entities": len(entities),
+        "all_pairs": total_pairs,
+        "labeled_matches": len(truth),
+        "per_key": per_key,
+        "union": union_score,
+        "missed_matches": missed[:50],
+        "missed_total": len(missed),
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"entities         {report['entities']}",
+        f"all pairs        {report['all_pairs']}",
+        f"labeled matches  {report['labeled_matches']}",
+        "",
+        f"{'key':<16} {'cand pairs':>11} {'reduction':>10} {'recall':>8}",
+        f"{'-' * 16} {'-' * 11} {'-' * 10} {'-' * 8}",
+    ]
+    for name, stats in report["per_key"].items():
+        lines.append(
+            f"{name:<16} {stats['candidate_pairs']:>11} "
+            f"{stats['reduction_ratio']:>10.4f} {stats['pair_recall']:>8.4f}"
+        )
+    union = report["union"]
+    lines += [
+        f"{'-' * 16} {'-' * 11} {'-' * 10} {'-' * 8}",
+        f"{'UNION':<16} {union['candidate_pairs']:>11} "
+        f"{union['reduction_ratio']:>10.4f} {union['pair_recall']:>8.4f}",
+        "",
+        f"Union pair recall is the ceiling on fusion recall: {union['matches_retained']} of "
+        f"{report['labeled_matches']} true matches survive blocking.",
+    ]
+    if report["missed_total"]:
+        lines.append("")
+        lines.append(f"unreachable true matches ({report['missed_total']}):")
+        lines += [f"  {a} <-> {b}" for a, b in report["missed_matches"]]
+        if report["missed_total"] > len(report["missed_matches"]):
+            lines.append(f"  ... and {report['missed_total'] - len(report['missed_matches'])} more")
+        lines.append("")
+        lines.append("Add a blocking key that bridges these, or accept the recall ceiling.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Measure blocking reduction and pair recall")
+    parser.add_argument("candidates", type=Path, help="entities as JSON Lines")
+    parser.add_argument("--labels", type=Path, help="known true-match pairs as JSON Lines")
+    parser.add_argument(
+        "--keys", default="normalized,token,acronym,prefix",
+        help="comma-separated builtin keys (default: all)",
+    )
+    parser.add_argument(
+        "--attr-key", action="append", default=[], metavar="ATTR",
+        help="also block on an exact shared attrs value; repeatable",
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "--min-recall", type=float, default=None,
+        help="exit 1 when union pair recall falls below this",
+    )
+    args = parser.parse_args(argv)
+
+    key_names = [k.strip() for k in args.keys.split(",") if k.strip()]
+    unknown = [k for k in key_names if k not in BUILTIN_KEYS]
+    if unknown:
+        print(
+            f"ERROR   unknown blocking key(s): {', '.join(unknown)}; "
+            f"available: {', '.join(BUILTIN_KEYS)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        entities = load_entities(args.candidates)
+    except (OSError, ValueError) as exc:
+        print(f"ERROR   {exc}", file=sys.stderr)
+        return 2
+
+    truth: set[Pair] = set()
+    if args.labels:
+        try:
+            truth, warnings = load_labels(args.labels, {e.id for e in entities})
+        except (OSError, ValueError) as exc:
+            print(f"ERROR   {exc}", file=sys.stderr)
+            return 2
+        for warning in warnings:
+            print(f"WARN    {warning}", file=sys.stderr)
+    else:
+        print(
+            "WARN    no --labels given; reduction ratios are reported but pair recall "
+            "cannot be measured, and recall is the number that matters",
+            file=sys.stderr,
+        )
+
+    report = build_report(entities, truth, key_names, args.attr_key)
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+
+    if args.min_recall is not None and report["union"]["pair_recall"] < args.min_recall:
+        print(
+            f"FAIL    union pair recall {report['union']['pair_recall']:.4f} "
+            f"below required {args.min_recall}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/kg-builder/scripts/validate_ontology.py
+++ b/skills/kg-builder/scripts/validate_ontology.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""
+Ontology validator for kg-builder.
+
+Checks an `ontology.yaml` before any extraction runs. Catches the schema defects that
+silently degrade a graph: relations pointing at undeclared entity types, vague relation
+names that make domain/range validation meaningless, event schemas with no trigger, and
+entity types nobody can give an example of.
+
+Usage:
+    uv run validate_ontology.py ontology.yaml
+    uv run validate_ontology.py ontology.yaml --format json
+    uv run validate_ontology.py ontology.yaml --strict     # warnings also fail
+
+Exit codes:
+    0  valid (warnings may be present unless --strict)
+    1  invalid — errors found
+    2  file missing or unparseable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Relation names that defeat the purpose of typed edges. A relation must name a specific
+# verb; these make every downstream query ambiguous and every domain/range check vacuous.
+VAGUE_RELATIONS = frozenset({
+    "RELATED_TO", "RELATES_TO", "HAS_LINK", "LINKED_TO", "ASSOCIATED_WITH",
+    "CONNECTED_TO", "REFERS_TO", "HAS", "IS", "OF", "ABOUT", "SEE_ALSO",
+})
+
+RELATION_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+TYPE_NAME_RE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+
+MIN_ENTITY_TYPES = 2
+MAX_ENTITY_TYPES = 40
+MAX_RELATION_TYPES = 80
+
+
+@dataclass
+class Report:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _as_mapping(value: Any, label: str, report: Report) -> dict[str, Any]:
+    """Coerce a section to a mapping, recording an error when it is the wrong shape."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        report.error(f"'{label}' must be a mapping of name -> definition, got {type(value).__name__}")
+        return {}
+    return value
+
+
+def check_entities(entities: dict[str, Any], report: Report) -> set[str]:
+    """Validate entity type declarations; return the set of declared type names."""
+    if not entities:
+        report.error("no entity types declared — an ontology with no entities cannot constrain extraction")
+        return set()
+
+    count = len(entities)
+    if count < MIN_ENTITY_TYPES:
+        report.warn(f"{count} entity type(s); a graph usually needs at least {MIN_ENTITY_TYPES}")
+    if count > MAX_ENTITY_TYPES:
+        report.warn(
+            f"{count} entity types exceeds {MAX_ENTITY_TYPES} — large schemas overfit the sample "
+            "corpus; prune to the types your competency questions actually need"
+        )
+
+    for name, body in entities.items():
+        if not TYPE_NAME_RE.match(str(name)):
+            report.error(f"entity type '{name}' must be PascalCase (e.g. 'Person', 'ServiceTeam')")
+
+        if not isinstance(body, dict):
+            report.error(f"entity type '{name}' must be a mapping with 'desc' and 'examples'")
+            continue
+
+        if not str(body.get("desc", "")).strip():
+            report.error(f"entity type '{name}' has no 'desc' — extraction prompts embed it verbatim")
+
+        examples = body.get("examples") or []
+        if not isinstance(examples, list) or len(examples) < 2:
+            report.warn(
+                f"entity type '{name}' has fewer than 2 examples — a type you cannot exemplify "
+                "twice from the real corpus is probably speculative"
+            )
+
+    return set(entities)
+
+
+def check_relations(relations: dict[str, Any], declared: set[str], report: Report) -> None:
+    """Validate relation declarations against the declared entity types."""
+    if not relations:
+        report.error("no relation types declared — nodes without typed edges are a list, not a graph")
+        return
+
+    if len(relations) > MAX_RELATION_TYPES:
+        report.warn(f"{len(relations)} relation types exceeds {MAX_RELATION_TYPES}; consider merging near-duplicates")
+
+    for name, body in relations.items():
+        label = str(name)
+
+        if not RELATION_NAME_RE.match(label):
+            report.error(f"relation '{label}' must be SCREAMING_SNAKE_CASE (e.g. 'EMPLOYED_BY')")
+
+        if label.upper() in VAGUE_RELATIONS:
+            report.error(
+                f"relation '{label}' is too vague — name the specific verb (ACQUIRED, DEPENDS_ON). "
+                "Vague relations make domain/range validation vacuous."
+            )
+
+        if not isinstance(body, dict):
+            report.error(f"relation '{label}' must be a mapping with 'domain' and 'range'")
+            continue
+
+        for slot in ("domain", "range"):
+            value = body.get(slot)
+            if not value:
+                report.error(f"relation '{label}' has no '{slot}' — unconstrained edges cannot be validated in code")
+                continue
+            for type_name in value if isinstance(value, list) else [value]:
+                if str(type_name) not in declared:
+                    report.error(
+                        f"relation '{label}' {slot} references undeclared entity type '{type_name}'"
+                    )
+
+
+def check_events(events: dict[str, Any], declared: set[str], report: Report) -> None:
+    """Validate event schemas.
+
+    Events are first-class nodes, so an event type must also be declared as an entity
+    type — the `events` section attaches an argument schema to it. An event schema with
+    no matching entity type is dangling: nothing in the graph can carry those arguments.
+    """
+    for name, body in events.items():
+        label = str(name)
+
+        if not TYPE_NAME_RE.match(label):
+            report.error(f"event type '{label}' must be PascalCase")
+
+        if not isinstance(body, dict):
+            report.error(f"event type '{label}' must be a mapping with 'trigger' and 'args'")
+            continue
+
+        if not str(body.get("trigger", "")).strip():
+            report.error(
+                f"event type '{label}' has no 'trigger' — an event with no trigger evidence "
+                "is an inference, not an extracted fact"
+            )
+
+        args = body.get("args") or []
+        if not isinstance(args, list) or not args:
+            report.error(f"event type '{label}' has no 'args' — flattening loses which event carried which value")
+        elif len(args) < 2:
+            report.warn(f"event type '{label}' has one argument; a single-argument event is usually an attribute")
+
+        if label not in declared:
+            report.error(
+                f"event type '{label}' is not declared under 'entities' — events are "
+                "first-class nodes, so the type must exist before it can carry arguments"
+            )
+
+
+def check_canonical_form(canonical: dict[str, Any], declared: set[str], report: Report) -> None:
+    """Canonical-form rules are what fusion enforces; unstated means unenforced."""
+    if not canonical:
+        report.warn(
+            "no 'canonical_form' rules — fusion enforces whatever rule is stated here, "
+            "so an absent rule means entity resolution has nothing to normalize against"
+        )
+        return
+
+    for type_name in canonical:
+        if str(type_name) not in declared:
+            report.error(f"canonical_form references undeclared entity type '{type_name}'")
+
+    missing = sorted(declared - {str(k) for k in canonical})
+    if missing:
+        report.warn(f"no canonical_form rule for: {', '.join(missing)}")
+
+
+def check_reachability(relations: dict[str, Any], declared: set[str], report: Report) -> None:
+    """An entity type no relation touches cannot participate in a multi-hop query."""
+    touched: set[str] = set()
+    for body in relations.values():
+        if not isinstance(body, dict):
+            continue
+        for slot in ("domain", "range"):
+            value = body.get(slot)
+            if not value:
+                continue
+            for type_name in value if isinstance(value, list) else [value]:
+                touched.add(str(type_name))
+
+    isolated = sorted(declared - touched)
+    if isolated:
+        report.warn(
+            f"entity type(s) with no relations: {', '.join(isolated)} — "
+            "unreachable types cannot appear in a multi-hop answer"
+        )
+
+
+def validate(doc: Any) -> Report:
+    """Run every check against a parsed ontology document."""
+    report = Report()
+
+    if not isinstance(doc, dict):
+        report.error("ontology root must be a mapping")
+        return report
+
+    known = {"entities", "relations", "events", "canonical_form"}
+    for key in doc:
+        if str(key) not in known:
+            report.warn(f"unknown top-level key '{key}' (expected: {', '.join(sorted(known))})")
+
+    entities = _as_mapping(doc.get("entities"), "entities", report)
+    relations = _as_mapping(doc.get("relations"), "relations", report)
+    events = _as_mapping(doc.get("events"), "events", report)
+    canonical = _as_mapping(doc.get("canonical_form"), "canonical_form", report)
+
+    declared = check_entities(entities, report)
+    check_relations(relations, declared, report)
+    check_events(events, declared, report)
+    check_canonical_form(canonical, declared, report)
+    check_reachability(relations, declared, report)
+
+    return report
+
+
+def render_text(report: Report, path: Path) -> str:
+    lines: list[str] = []
+    for message in report.errors:
+        lines.append(f"ERROR   {message}")
+    for message in report.warnings:
+        lines.append(f"WARN    {message}")
+    if report.ok and not report.warnings:
+        lines.append(f"OK      {path} is a valid ontology")
+    else:
+        lines.append("")
+        lines.append(f"{len(report.errors)} error(s), {len(report.warnings)} warning(s) in {path}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a kg-builder ontology.yaml")
+    parser.add_argument("ontology", type=Path, help="path to ontology.yaml")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--strict", action="store_true", help="treat warnings as failures")
+    args = parser.parse_args(argv)
+
+    path: Path = args.ontology
+    if not path.is_file():
+        print(f"ERROR   no such file: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        print(f"ERROR   unparseable YAML in {path}: {exc}", file=sys.stderr)
+        return 2
+
+    report = validate(doc)
+
+    if args.format == "json":
+        print(json.dumps({
+            "path": str(path),
+            "valid": report.ok,
+            "errors": report.errors,
+            "warnings": report.warnings,
+        }, indent=2))
+    else:
+        print(render_text(report, path))
+
+    if not report.ok:
+        return 1
+    if args.strict and report.warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `kg-builder`, a tool-neutral skill for designing and building knowledge graphs: value test, ontology modeling with domain/range constraints, source routing, entity/relation/event extraction, a sampled quality gate, entity resolution, GraphRAG serving, and claim-ledger maintenance.

Armory had no coverage here. The nearest packages solve different problems — `rag-auditor` evaluates an existing vector RAG pipeline, `immune` is non-graph adaptive memory. The skill is explicitly scoped to knowledge graphs (what an agent *remembers*) and routes agent-orchestration requests away to `task-decomposer`, so it does not overlap `task-decomposer`, `milestone-runner`, `pr-swarm`, `team-lead`, or `project-planner`.

### Why not just ingest `codejunkie99/graph-engineering`

That repo was evaluated as the ingestion candidate and rejected. Three reasons, recorded in `ATTRIBUTIONS.md` so they don't get re-litigated:

1. **Scope conflation.** It bundles knowledge graphs with agent task graphs under one name. The two share only the word "graph" — a KG's nodes are entities, a task graph's nodes are jobs. A package named `graph-engineering` would trigger on the orchestration meaning and deliver an ontology tutorial.
2. **Duplication.** Its task-graph half (75 lines) restates patterns armory already ships as working procedure across five packages, plus `agents/_registry.yaml`, which encodes the orchestration graph as executable config.
3. **Licensing.** It relicenses under MIT an English derivative of `npubird/KnowledgeGraphCourse`, which has no license file at all (GitHub API reports `license: null`; no `LICENSE` in the repo root). No derivative-work permission is established.

Nothing from either repo is vendored. `kg-builder` uses only the field's standard, non-copyrightable pipeline decomposition and deliberately carries no per-lecture curriculum map.

### What this adds beyond a standard pipeline write-up

Two things that decide whether the output is trustworthy, both absent from the candidate:

- **The deterministic/LLM boundary**, as an explicit per-stage table, with the rule that every model surface is measured against a prompt-only baseline before it is trusted. This is backed by a measurement, not a preference: in a pre-registered real-model evaluation, an LLM-adjudicated dedup-and-contradiction loop trailed a prompt-only baseline by 0.28–0.33 on detection and safety across every provider cell tested. Reference implementation is Kosha (Apache-2.0), credited in `ATTRIBUTIONS.md`, pattern described rather than copied, no dependency taken.
- **The storage and query layer**, which agent-facing traversal actually runs on, plus an honest note on where graph embeddings and reasoning do and do not belong in agent memory.

### Executable gates

Two scripts make the pipeline's hardest checks enforceable rather than advisory:

- `scripts/validate_ontology.py` (PEP 723 inline deps, run via `uv run`) rejects relations whose domain or range names an undeclared entity type, vague relation names that make domain/range validation vacuous, event schemas with no trigger, event types not declared as entities, and entity types with no examples.
- `scripts/blocking_report.py` (stdlib only) measures the ceiling on fusion recall — any true match no blocking key groups together can never be matched downstream, at any threshold, by any model. Reports reduction ratio and pair recall per key and for the union, lists unreachable true matches, and gates on `--min-recall`.

Both were smoke-tested against fixtures. Representative output:

```text
key               cand pairs  reduction   recall
normalized                 3     0.9333   0.4000
token                      4     0.9111   0.6000
acronym                    5     0.8889   0.8000
prefix                     3     0.9333   0.4000
UNION                      5     0.8889   0.8000

unreachable true matches (1):
  e4 <-> e5
```

Adding `--attr-key domain` lifts union recall to 1.0000, demonstrating the reference doc's "use several keys in union" claim on real output. `--min-recall 0.95` correctly exits 1 at 0.40.

## Skill Evaluator Results

```text
Package: kg-builder (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        20/20
  D4 Content Depth:                  22/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          100/100 (100%)
  Status: PASS
```

No CRITICAL or HIGH findings. Repo-wide evaluation went from 137 packages / 109 pass / 28 fail to 138 / 110 / 28 — one added pass, no new failures; the 28 are pre-existing.

Each of the four commits was verified independently green in a detached worktree against manifest sync, `validate_evals.py`, and the evaluator at threshold 70.

## Evals

Twelve cases: nine positive covering ontology design, extraction prompting, entity resolution, the blocking recall ceiling, GraphRAG retrieval, graph-memory contradiction handling, adjudicator measurement, and correctly refusing a graph when a table suffices.

Three negative cases pin the routing boundaries: multi-agent orchestration topology belongs to `task-decomposer`, auditing an existing vector RAG pipeline belongs to `rag-auditor`, and rendering a dependency diagram is a visualization task.

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter with `name` and `description`
- [x] Skill name is kebab-case, under 64 characters
- [x] Description is 200-1024 characters with trigger phrases and "Use when" clause
- [x] No angle brackets or pushy language in description
- [x] No secrets, credentials, or internal URLs in any file
- [x] Tested locally with Claude Code
- [x] All file references in `SKILL.md` resolve to existing files
- [x] Skill evaluator score is 70% or above
- [x] No CRITICAL or HIGH findings from skill evaluator
