### PR TITLE
fix(package): write reproducible archives so checksum sync works

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,9 +42,21 @@ jobs:
       - name: Package adapter artifacts
         run: |
           mkdir -p dist
-          cd adapters/cursor && tar -czf ../../dist/armory-cursor.tar.gz .cursor && cd ../..
-          cd adapters/codex && tar -czf ../../dist/armory-codex.tar.gz AGENTS.md standards agents workflows skills && cd ../..
-          cd adapters/gemini && tar -czf ../../dist/armory-gemini.tar.gz .gemini && cd ../..
+          # tar records mtimes and gzip records its own timestamp, so an unchanged
+          # tree still produced a different tarball on every run. Pinning both keeps
+          # the artifacts byte-identical, which is what checksum-based release syncing
+          # and download verification depend on.
+          pack() {
+            dir="$1"; out="$2"; shift 2
+            tar --sort=name \
+                --mtime='UTC 1980-01-01' \
+                --owner=0 --group=0 --numeric-owner \
+                --format=gnu \
+                -cf - -C "${dir}" "$@" | gzip -n > "dist/${out}"
+          }
+          pack adapters/cursor armory-cursor.tar.gz .cursor
+          pack adapters/codex  armory-codex.tar.gz AGENTS.md standards agents workflows skills
+          pack adapters/gemini armory-gemini.tar.gz .gemini
           echo "Adapter artifacts:"
           ls -lh dist/armory-*.tar.gz
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -21,6 +21,16 @@ from scripts.package_types import (
 )
 
 
+# Archives must be byte-identical for identical content. zipfile.write() stamps each
+# entry with the source file's mtime, so a fresh checkout produced a different archive
+# from unchanged sources — which defeated checksum-based release syncing and made
+# published archives unverifiable. Entries are written with a fixed timestamp and a
+# normalized mode instead. 1980-01-01 is the earliest instant the ZIP format encodes.
+ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+MODE_EXECUTABLE = 0o755
+MODE_REGULAR = 0o644
+
+
 def validate_frontmatter(pkg_dir: Path, pkg_type: PackageType) -> dict[str, Any]:
     """Validate frontmatter in the type-specific definition file."""
     definition = pkg_dir / pkg_type.definition_file
@@ -87,7 +97,13 @@ def package(pkg_dir: Path, output_dir: Path, pkg_type: PackageType) -> Path:
     with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for file_path in included:
             arcname = file_path.relative_to(pkg_dir.parent)
-            zf.write(file_path, arcname)
+            # Git tracks only the executable bit, so collapsing to 755/644 keeps the
+            # archive identical across checkouts with different umasks.
+            executable = file_path.stat().st_mode & 0o111
+            info = zipfile.ZipInfo(arcname.as_posix(), date_time=ZIP_EPOCH)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = (MODE_EXECUTABLE if executable else MODE_REGULAR) << 16
+            zf.writestr(info, file_path.read_bytes())
             print(f"  added: {arcname}")
 
     for file_path in excluded:


### PR DESCRIPTION
## Summary

Makes packaged artifacts reproducible. Without this, the checksum-based release sync added in #87 is inert — it re-uploads the entire catalog on every run, exactly the behaviour it was meant to eliminate.

### What went wrong in #87

I verified the sync planner against a manifest I had generated **from the same local files I then compared against**, so it matched trivially. That never exercised the real condition: rebuild, then compare. It passed, and I reported "catalog unchanged → 0 uploads" as verified. It was not.

The post-merge run proved it. Attempt 2 on `main` read the published manifest (270 remote assets, `checksums.txt` present) and still planned 141 uploads:

```text
latest: 141 local artifact(s), 270 remote asset(s)
  upload    141
  unchanged 0
```

### Root cause

Nothing about packaging was reproducible.

- `zipfile.write()` stamps every entry with the source file's mtime. CI checks out fresh, so every `.skill` / `.agent` / `.hook` archive was byte-different from unchanged sources.
- `tar -czf` records per-entry mtimes, and gzip records its own timestamp, so all three adapter tarballs changed on every run too.

Identical content produced different bytes, so every digest differed, so everything re-uploaded.

### Fix

**`scripts/package.py`** writes entries via `ZipInfo` with a fixed `1980-01-01` timestamp (the earliest the ZIP format encodes) and a mode normalized to `755`/`644` — matching the executable bit git actually tracks, so archives stay identical across checkouts with different umasks. Entry order was already deterministic via sorted `rglob`.

**`package.yml`** pins tar's entry order, mtime, and ownership, and passes `gzip -n`.

## Verification

This time the test is rebuild-then-compare, with **every source file touched between builds** so mtimes genuinely differ:

| Artifact set | Result |
|---|---|
| 138 package archives (`.skill`, `.agent`, `.hook`, `.rule`, `.command`, `.utility`, `.preset`) | all byte-identical |
| 3 adapter tarballs, on `ubuntu:24.04` with GNU tar | all byte-identical |

Adapter tarballs were checked in a container matching the runner, because macOS ships bsdtar and does not accept these flags.

### What to expect after merge

The first `main` run rebuilds every artifact with new, now-reproducible bytes, so it uploads all 141 once more and republishes the manifest. Every subsequent run with an unchanged catalog should plan zero uploads. I will confirm that second run rather than assume it.

### Side benefit

Published archives are now verifiable: a downloaded `.skill` can be checked against `checksums.txt` on the release. That was not possible when the bytes changed on every build.

Refs #87
