### PR TITLE
feat(architecture-diagram): add AWS/GCP/Azure service-to-icon mapping tables

### DIFF
--- a/skills/architecture-diagram/references/services-aws.yaml
+++ b/skills/architecture-diagram/references/services-aws.yaml
@@ -1,0 +1,429 @@
+# AWS service -> icon cache slug mapping for architecture-diagram.
+#
+# Every `slug` value below was verified present in the real icon cache built
+# from `jgraph/drawio@a1f615b` (draw.io's `mxgraph.aws4` stencil set, 1037
+# icons total) — see scripts/fetch_icons.py. `slug` is exactly the filename
+# (minus `.json`) render.py looks up under `<cache>/<sha>/aws/<slug>.json`.
+#
+# `aliases` are phrasings a user is likely to say ("bucket", "S3") that
+# should resolve to this entry when authoring a spec's `service:` field —
+# use the top-level key (the canonical slug) as the spec value.
+#
+# `color` is AWS's own architecture-icon category color
+# (https://aws.amazon.com/architecture/icons/), used as the node's fill.
+
+services:
+  lambda:
+    label: Lambda
+    aliases: [lambda, serverless function, faas]
+    color: "#ED7100"
+    category: compute
+  ec2:
+    label: EC2
+    aliases: [ec2, virtual machine, vm, instance]
+    color: "#ED7100"
+    category: compute
+  ecs:
+    label: ECS
+    aliases: [ecs, elastic container service]
+    color: "#ED7100"
+    category: compute
+  eks:
+    label: EKS
+    aliases: [eks, elastic kubernetes service, kubernetes]
+    color: "#ED7100"
+    category: compute
+  fargate:
+    label: Fargate
+    aliases: [fargate, serverless containers]
+    color: "#ED7100"
+    category: compute
+  elastic-beanstalk:
+    label: Elastic Beanstalk
+    aliases: [elastic beanstalk, beanstalk]
+    color: "#ED7100"
+    category: compute
+  app-runner:
+    label: App Runner
+    aliases: [app runner]
+    color: "#ED7100"
+    category: compute
+  lightsail:
+    label: Lightsail
+    aliases: [lightsail]
+    color: "#ED7100"
+    category: compute
+  batch:
+    label: Batch
+    aliases: [batch, aws batch]
+    color: "#ED7100"
+    category: compute
+  outposts:
+    label: Outposts
+    aliases: [outposts]
+    color: "#ED7100"
+    category: compute
+
+  s3:
+    label: S3
+    aliases: [s3, bucket, object storage, simple storage service]
+    color: "#7AA116"
+    category: storage
+  efs-standard:
+    label: EFS
+    aliases: [efs, elastic file system, nfs]
+    color: "#7AA116"
+    category: storage
+  elastic-block-store:
+    label: EBS
+    aliases: [ebs, elastic block store, block storage]
+    color: "#7AA116"
+    category: storage
+  s3-express-one-zone:
+    label: S3 Express One Zone
+    aliases: [s3 express]
+    color: "#7AA116"
+    category: storage
+  data-pipeline:
+    label: Data Pipeline
+    aliases: [data pipeline]
+    color: "#7AA116"
+    category: storage
+
+  dynamodb:
+    label: DynamoDB
+    aliases: [dynamodb, nosql database]
+    color: "#C925D1"
+    category: database
+  rds:
+    label: RDS
+    aliases: [rds, relational database, postgres, mysql, mariadb]
+    color: "#C925D1"
+    category: database
+  aurora:
+    label: Aurora
+    aliases: [aurora]
+    color: "#C925D1"
+    category: database
+  elasticache:
+    label: ElastiCache
+    aliases: [elasticache, redis, memcached, in-memory cache]
+    color: "#C925D1"
+    category: database
+  redshift:
+    label: Redshift
+    aliases: [redshift, data warehouse]
+    color: "#C925D1"
+    category: database
+  documentdb-with-mongodb-compatibility:
+    label: DocumentDB
+    aliases: [documentdb, mongodb-compatible database]
+    color: "#C925D1"
+    category: database
+  neptune:
+    label: Neptune
+    aliases: [neptune, graph database]
+    color: "#C925D1"
+    category: database
+  timestream:
+    label: Timestream
+    aliases: [timestream, time series database]
+    color: "#C925D1"
+    category: database
+  memorydb-for-redis:
+    label: MemoryDB for Redis
+    aliases: [memorydb]
+    color: "#C925D1"
+    category: database
+
+  cloudfront:
+    label: CloudFront
+    aliases: [cloudfront, cdn]
+    color: "#8C4FFF"
+    category: networking
+  route-53:
+    label: Route 53
+    aliases: [route 53, dns]
+    color: "#8C4FFF"
+    category: networking
+  vpc:
+    label: VPC
+    aliases: [vpc, virtual private cloud]
+    color: "#8C4FFF"
+    category: networking
+  application-load-balancer:
+    label: Application Load Balancer
+    aliases: [alb, application load balancer]
+    color: "#8C4FFF"
+    category: networking
+  elastic-load-balancing:
+    label: Elastic Load Balancing
+    aliases: [load balancer, elb]
+    color: "#8C4FFF"
+    category: networking
+  nat-gateway:
+    label: NAT Gateway
+    aliases: [nat gateway]
+    color: "#8C4FFF"
+    category: networking
+  internet-gateway:
+    label: Internet Gateway
+    aliases: [internet gateway]
+    color: "#8C4FFF"
+    category: networking
+  transit-gateway:
+    label: Transit Gateway
+    aliases: [transit gateway]
+    color: "#8C4FFF"
+    category: networking
+  direct-connect:
+    label: Direct Connect
+    aliases: [direct connect]
+    color: "#8C4FFF"
+    category: networking
+  api-gateway:
+    label: API Gateway
+    aliases: [api gateway, rest api, http api]
+    color: "#E7157B"
+    category: networking
+
+  sqs:
+    label: SQS
+    aliases: [sqs, queue, message queue]
+    color: "#E7157B"
+    category: integration
+  sns:
+    label: SNS
+    aliases: [sns, pub/sub, notification, topic]
+    color: "#E7157B"
+    category: integration
+  eventbridge:
+    label: EventBridge
+    aliases: [eventbridge, event bus]
+    color: "#E7157B"
+    category: integration
+  step-functions:
+    label: Step Functions
+    aliases: [step functions, state machine, workflow orchestration]
+    color: "#E7157B"
+    category: integration
+  appsync:
+    label: AppSync
+    aliases: [appsync, graphql]
+    color: "#E7157B"
+    category: integration
+  kinesis:
+    label: Kinesis
+    aliases: [kinesis, streaming]
+    color: "#8C4FFF"
+    category: analytics
+  kinesis-data-streams:
+    label: Kinesis Data Streams
+    aliases: [kinesis data streams]
+    color: "#8C4FFF"
+    category: analytics
+  kinesis-data-firehose:
+    label: Kinesis Data Firehose
+    aliases: [kinesis firehose]
+    color: "#8C4FFF"
+    category: analytics
+  managed-streaming-for-kafka:
+    label: Managed Streaming for Apache Kafka
+    aliases: [msk, kafka]
+    color: "#8C4FFF"
+    category: analytics
+
+  cognito:
+    label: Cognito
+    aliases: [cognito, user pool, authentication]
+    color: "#DD344C"
+    category: security
+  identity-and-access-management:
+    label: IAM
+    aliases: [iam, identity and access management, role, policy]
+    color: "#DD344C"
+    category: security
+  key-management-service:
+    label: KMS
+    aliases: [kms, key management service, encryption key]
+    color: "#DD344C"
+    category: security
+  secrets-manager:
+    label: Secrets Manager
+    aliases: [secrets manager]
+    color: "#DD344C"
+    category: security
+  certificate-manager:
+    label: Certificate Manager
+    aliases: [acm, certificate manager, tls certificate]
+    color: "#DD344C"
+    category: security
+  waf:
+    label: WAF
+    aliases: [waf, web application firewall]
+    color: "#DD344C"
+    category: security
+  shield:
+    label: Shield
+    aliases: [shield, ddos protection]
+    color: "#DD344C"
+    category: security
+  guardduty:
+    label: GuardDuty
+    aliases: [guardduty, threat detection]
+    color: "#DD344C"
+    category: security
+  macie:
+    label: Macie
+    aliases: [macie]
+    color: "#DD344C"
+    category: security
+  inspector:
+    label: Inspector
+    aliases: [inspector, vulnerability scanning]
+    color: "#DD344C"
+    category: security
+  network-firewall:
+    label: Network Firewall
+    aliases: [network firewall]
+    color: "#DD344C"
+    category: security
+  firewall-manager:
+    label: Firewall Manager
+    aliases: [firewall manager]
+    color: "#DD344C"
+    category: security
+  organizations:
+    label: Organizations
+    aliases: [organizations]
+    color: "#DD344C"
+    category: security
+  control-tower:
+    label: Control Tower
+    aliases: [control tower]
+    color: "#DD344C"
+    category: security
+
+  cloudwatch:
+    label: CloudWatch
+    aliases: [cloudwatch, monitoring, metrics, logs]
+    color: "#E7157B"
+    category: management
+  cloudtrail:
+    label: CloudTrail
+    aliases: [cloudtrail, audit log]
+    color: "#E7157B"
+    category: management
+  config:
+    label: Config
+    aliases: [aws config, compliance]
+    color: "#E7157B"
+    category: management
+  systems-manager:
+    label: Systems Manager
+    aliases: [systems manager, ssm]
+    color: "#E7157B"
+    category: management
+  codepipeline:
+    label: CodePipeline
+    aliases: [codepipeline, ci/cd pipeline]
+    color: "#E7157B"
+    category: devtools
+  codebuild:
+    label: CodeBuild
+    aliases: [codebuild]
+    color: "#E7157B"
+    category: devtools
+  codedeploy:
+    label: CodeDeploy
+    aliases: [codedeploy]
+    color: "#E7157B"
+    category: devtools
+
+  athena:
+    label: Athena
+    aliases: [athena, sql query engine]
+    color: "#8C4FFF"
+    category: analytics
+  glue:
+    label: Glue
+    aliases: [glue, etl]
+    color: "#8C4FFF"
+    category: analytics
+  lake-formation:
+    label: Lake Formation
+    aliases: [lake formation, data lake]
+    color: "#8C4FFF"
+    category: analytics
+  quicksight:
+    label: QuickSight
+    aliases: [quicksight, bi dashboard]
+    color: "#8C4FFF"
+    category: analytics
+  opensearch-service-index:
+    label: OpenSearch Service
+    aliases: [opensearch, elasticsearch]
+    color: "#8C4FFF"
+    category: analytics
+
+  sagemaker:
+    label: SageMaker
+    aliases: [sagemaker, ml training]
+    color: "#01A88D"
+    category: ai-ml
+  bedrock:
+    label: Bedrock
+    aliases: [bedrock, foundation model, genai]
+    color: "#01A88D"
+    category: ai-ml
+  rekognition:
+    label: Rekognition
+    aliases: [rekognition, image recognition]
+    color: "#01A88D"
+    category: ai-ml
+  comprehend:
+    label: Comprehend
+    aliases: [comprehend, nlp]
+    color: "#01A88D"
+    category: ai-ml
+  textract:
+    label: Textract
+    aliases: [textract, ocr]
+    color: "#01A88D"
+    category: ai-ml
+  transcribe:
+    label: Transcribe
+    aliases: [transcribe, speech-to-text]
+    color: "#01A88D"
+    category: ai-ml
+  polly:
+    label: Polly
+    aliases: [polly, text-to-speech]
+    color: "#01A88D"
+    category: ai-ml
+  personalize:
+    label: Personalize
+    aliases: [personalize, recommendation engine]
+    color: "#01A88D"
+    category: ai-ml
+  forecast:
+    label: Forecast
+    aliases: [forecast, time series forecasting]
+    color: "#01A88D"
+    category: ai-ml
+
+  client:
+    label: Client
+    aliases: [client, browser, end user, user]
+    color: "#232F3E"
+    category: generic
+  traditional-server:
+    label: External Server
+    aliases: [external system, on-prem server, legacy system]
+    color: "#232F3E"
+    category: generic
+  generic-firewall:
+    label: Firewall
+    aliases: [generic firewall]
+    color: "#232F3E"
+    category: generic

--- a/skills/architecture-diagram/references/services-azure.yaml
+++ b/skills/architecture-diagram/references/services-azure.yaml
@@ -1,0 +1,282 @@
+# Azure service -> icon cache slug mapping for architecture-diagram.
+#
+# Every `slug` value below was verified present in the real icon cache built
+# from `jgraph/drawio@a1f615b` (draw.io's `azure2` real-SVG icon library, 704
+# icons total) — see scripts/fetch_icons.py. Unlike AWS/GCP these are inlined
+# directly (svg_inline.py), not converted from a stencil DSL.
+#
+# A handful of services common in Azure DevOps-heavy architectures — Azure
+# Pipelines, Boards, Artifacts, Queue Storage, File Storage, VPN Gateway as a
+# distinct icon — have no dedicated icon in this set. Entries are omitted
+# rather than mapped to a misleading substitute.
+#
+# `color` is Azure's own architecture-icon service-category color
+# (https://learn.microsoft.com/en-us/azure/architecture/icons/), used as the
+# node's fill.
+
+services:
+  virtual-machine:
+    label: Virtual Machine
+    aliases: [virtual machine, vm, instance]
+    color: "#0078D4"
+    category: compute
+  app-services:
+    label: App Service
+    aliases: [app service, web app]
+    color: "#0078D4"
+    category: compute
+  function-apps:
+    label: Function Apps
+    aliases: [function apps, azure functions, faas, serverless function]
+    color: "#0078D4"
+    category: compute
+  kubernetes-services:
+    label: Kubernetes Services
+    aliases: [aks, azure kubernetes service, kubernetes]
+    color: "#0078D4"
+    category: compute
+  container-instances:
+    label: Container Instances
+    aliases: [container instances, aci]
+    color: "#0078D4"
+    category: compute
+  container-app-environments:
+    label: Container Apps
+    aliases: [container apps]
+    color: "#0078D4"
+    category: compute
+  batch-accounts:
+    label: Batch Accounts
+    aliases: [batch accounts, azure batch]
+    color: "#0078D4"
+    category: compute
+  vm-scale-sets:
+    label: VM Scale Sets
+    aliases: [vmss, vm scale set]
+    color: "#0078D4"
+    category: compute
+
+  storage-accounts:
+    label: Storage Accounts
+    aliases: [storage account, blob storage, object storage]
+    color: "#0078D4"
+    category: storage
+  blob-block:
+    label: Blob Storage
+    aliases: [blob, blob storage block]
+    color: "#0078D4"
+    category: storage
+  data-lake-storage-gen1:
+    label: Data Lake Storage
+    aliases: [data lake storage, data lake]
+    color: "#0078D4"
+    category: storage
+  managed-file-shares:
+    label: File Shares
+    aliases: [file share, azure files]
+    color: "#0078D4"
+    category: storage
+
+  sql-database:
+    label: SQL Database
+    aliases: [sql database, relational database]
+    color: "#0078D4"
+    category: database
+  azure-cosmos-db:
+    label: Cosmos DB
+    aliases: [cosmos db, cosmosdb, nosql database]
+    color: "#0078D4"
+    category: database
+  azure-database-postgresql-server:
+    label: Database for PostgreSQL
+    aliases: [postgres, postgresql]
+    color: "#0078D4"
+    category: database
+  azure-database-mysql-server:
+    label: Database for MySQL
+    aliases: [mysql]
+    color: "#0078D4"
+    category: database
+
+  key-vaults:
+    label: Key Vault
+    aliases: [key vault, secrets, certificates, encryption key]
+    color: "#0078D4"
+    category: security
+  azure-sentinel:
+    label: Microsoft Sentinel
+    aliases: [sentinel, siem, threat detection]
+    color: "#0078D4"
+    category: security
+  security-center:
+    label: Security Center
+    aliases: [security center, defender for cloud]
+    color: "#0078D4"
+    category: security
+  azure-active-directory:
+    label: Azure Active Directory
+    aliases: [active directory, entra id, identity provider]
+    color: "#0078D4"
+    category: identity
+  managed-identities:
+    label: Managed Identities
+    aliases: [managed identity]
+    color: "#0078D4"
+    category: identity
+
+  service-bus:
+    label: Service Bus
+    aliases: [service bus, message queue]
+    color: "#0078D4"
+    category: integration
+  event-grid-topics:
+    label: Event Grid Topics
+    aliases: [event grid, event bus]
+    color: "#0078D4"
+    category: integration
+  logic-apps:
+    label: Logic Apps
+    aliases: [logic apps, workflow orchestration]
+    color: "#0078D4"
+    category: integration
+  api-management-services:
+    label: API Management
+    aliases: [api management, apim, api gateway]
+    color: "#0078D4"
+    category: integration
+  event-hubs:
+    label: Event Hubs
+    aliases: [event hubs, streaming]
+    color: "#0078D4"
+    category: integration
+  data-factory:
+    label: Data Factory
+    aliases: [data factory, etl]
+    color: "#0078D4"
+    category: integration
+
+  application-insights:
+    label: Application Insights
+    aliases: [application insights, apm]
+    color: "#0078D4"
+    category: monitoring
+  log-analytics-workspaces:
+    label: Log Analytics Workspaces
+    aliases: [log analytics, logs]
+    color: "#0078D4"
+    category: monitoring
+  monitor:
+    label: Azure Monitor
+    aliases: [azure monitor, metrics, monitoring]
+    color: "#0078D4"
+    category: monitoring
+
+  virtual-networks:
+    label: Virtual Network
+    aliases: [virtual network, vnet]
+    color: "#0078D4"
+    category: networking
+  load-balancers:
+    label: Load Balancer
+    aliases: [load balancer]
+    color: "#0078D4"
+    category: networking
+  application-gateways:
+    label: Application Gateway
+    aliases: [application gateway]
+    color: "#0078D4"
+    category: networking
+  firewalls:
+    label: Firewall
+    aliases: [firewall]
+    color: "#0078D4"
+    category: networking
+  front-doors:
+    label: Front Door
+    aliases: [front door, cdn]
+    color: "#0078D4"
+    category: networking
+  cdn-profiles:
+    label: CDN Profile
+    aliases: [cdn profile]
+    color: "#0078D4"
+    category: networking
+  dns-zones:
+    label: DNS Zone
+    aliases: [dns zone, dns]
+    color: "#0078D4"
+    category: networking
+  expressroute-circuits:
+    label: ExpressRoute Circuit
+    aliases: [expressroute]
+    color: "#0078D4"
+    category: networking
+  traffic-manager-profiles:
+    label: Traffic Manager
+    aliases: [traffic manager]
+    color: "#0078D4"
+    category: networking
+  subnet:
+    label: Subnet
+    aliases: [subnet]
+    color: "#0078D4"
+    category: networking
+  private-endpoint:
+    label: Private Endpoint
+    aliases: [private endpoint]
+    color: "#0078D4"
+    category: networking
+  public-ip-addresses:
+    label: Public IP Address
+    aliases: [public ip]
+    color: "#0078D4"
+    category: networking
+
+  cognitive-services:
+    label: Cognitive Services
+    aliases: [cognitive services]
+    color: "#0078D4"
+    category: ai-ml
+  azure-machine-learning:
+    label: Azure Machine Learning
+    aliases: [machine learning, ml training]
+    color: "#0078D4"
+    category: ai-ml
+  azure-openai:
+    label: Azure OpenAI
+    aliases: [azure openai, genai, foundation model]
+    color: "#0078D4"
+    category: ai-ml
+  bot-services:
+    label: Bot Services
+    aliases: [bot service, chatbot]
+    color: "#0078D4"
+    category: ai-ml
+
+  azure-synapse-analytics:
+    label: Azure Synapse Analytics
+    aliases: [synapse, data warehouse]
+    color: "#0078D4"
+    category: analytics
+  azure-databricks:
+    label: Azure Databricks
+    aliases: [databricks, spark]
+    color: "#0078D4"
+    category: analytics
+
+  azure-devops:
+    label: Azure DevOps
+    aliases: [azure devops]
+    color: "#0078D4"
+    category: devops
+
+  iot-hub:
+    label: IoT Hub
+    aliases: [iot hub]
+    color: "#0078D4"
+    category: iot
+  digital-twins:
+    label: Digital Twins
+    aliases: [digital twins]
+    color: "#0078D4"
+    category: iot

--- a/skills/architecture-diagram/references/services-gcp.yaml
+++ b/skills/architecture-diagram/references/services-gcp.yaml
@@ -1,0 +1,231 @@
+# GCP service -> icon cache slug mapping for architecture-diagram.
+#
+# Every `slug` value below was verified present in the real icon cache built
+# from `jgraph/drawio@a1f615b` (draw.io's `mxgraph.gcp2` stencil set, 297
+# icons total) — see scripts/fetch_icons.py.
+#
+# GCP's stencil coverage is narrower than AWS's (297 vs 1037 icons). Several
+# services common in modern GCP architectures — GKE as a distinct icon from
+# the generic Kubernetes logo, Vertex AI, Artifact Registry, Cloud Build,
+# Secret Manager, Cloud KMS, Anthos, Eventarc, Workflows — have no dedicated
+# icon in this stencil set. Where no real icon exists, the entry is omitted
+# rather than mapped to a misleading substitute; render.py falls back to a
+# labeled placeholder for any node whose service isn't listed here.
+#
+# `color` is GCP's own architecture-icon palette
+# (https://cloud.google.com/icons), used as the node's fill.
+
+services:
+  compute-engine:
+    label: Compute Engine
+    aliases: [compute engine, virtual machine, vm, gce]
+    color: "#4285F4"
+    category: compute
+  cloud-run:
+    label: Cloud Run
+    aliases: [cloud run, serverless containers]
+    color: "#4285F4"
+    category: compute
+  cloud-functions:
+    label: Cloud Functions
+    aliases: [cloud functions, faas, serverless function]
+    color: "#4285F4"
+    category: compute
+  app-engine:
+    label: App Engine
+    aliases: [app engine]
+    color: "#4285F4"
+    category: compute
+  gke-on-prem:
+    label: GKE (on-prem)
+    aliases: [gke on-prem]
+    color: "#4285F4"
+    category: compute
+
+  cloud-storage:
+    label: Cloud Storage
+    aliases: [cloud storage, bucket, object storage, gcs]
+    color: "#34A853"
+    category: storage
+  persistent-disk:
+    label: Persistent Disk
+    aliases: [persistent disk, block storage]
+    color: "#34A853"
+    category: storage
+  cloud-filestore:
+    label: Filestore
+    aliases: [filestore, nfs]
+    color: "#34A853"
+    category: storage
+
+  cloud-sql:
+    label: Cloud SQL
+    aliases: [cloud sql, postgres, mysql, relational database]
+    color: "#4285F4"
+    category: database
+  cloud-spanner:
+    label: Spanner
+    aliases: [spanner, globally distributed database]
+    color: "#4285F4"
+    category: database
+  cloud-bigtable:
+    label: Bigtable
+    aliases: [bigtable, wide-column database]
+    color: "#4285F4"
+    category: database
+  cloud-firestore:
+    label: Firestore
+    aliases: [firestore, document database]
+    color: "#4285F4"
+    category: database
+  cloud-memorystore:
+    label: Memorystore
+    aliases: [memorystore, redis, in-memory cache]
+    color: "#4285F4"
+    category: database
+
+  bigquery:
+    label: BigQuery
+    aliases: [bigquery, data warehouse]
+    color: "#4285F4"
+    category: analytics
+  cloud-dataflow:
+    label: Dataflow
+    aliases: [dataflow, stream/batch processing]
+    color: "#4285F4"
+    category: analytics
+  cloud-dataproc:
+    label: Dataproc
+    aliases: [dataproc, spark, hadoop]
+    color: "#4285F4"
+    category: analytics
+  cloud-pubsub:
+    label: Pub/Sub
+    aliases: [pubsub, pub/sub, message queue, event bus]
+    color: "#4285F4"
+    category: analytics
+  cloud-composer:
+    label: Composer
+    aliases: [composer, airflow, workflow orchestration]
+    color: "#4285F4"
+    category: analytics
+  cloud-data-fusion:
+    label: Data Fusion
+    aliases: [data fusion, etl]
+    color: "#4285F4"
+    category: analytics
+
+  cloud-load-balancing:
+    label: Cloud Load Balancing
+    aliases: [load balancer, cloud load balancing]
+    color: "#4285F4"
+    category: networking
+  cloud-cdn:
+    label: Cloud CDN
+    aliases: [cdn, cloud cdn]
+    color: "#4285F4"
+    category: networking
+  cloud-dns:
+    label: Cloud DNS
+    aliases: [dns, cloud dns]
+    color: "#4285F4"
+    category: networking
+  cloud-armor:
+    label: Cloud Armor
+    aliases: [cloud armor, waf, ddos protection]
+    color: "#4285F4"
+    category: networking
+  cloud-nat:
+    label: Cloud NAT
+    aliases: [cloud nat, nat gateway]
+    color: "#4285F4"
+    category: networking
+  cloud-vpn:
+    label: Cloud VPN
+    aliases: [cloud vpn, vpn gateway]
+    color: "#4285F4"
+    category: networking
+  cloud-endpoints:
+    label: Cloud Endpoints
+    aliases: [cloud endpoints, api gateway]
+    color: "#4285F4"
+    category: networking
+
+  cloud-iam:
+    label: Cloud IAM
+    aliases: [iam, identity and access management, role, policy]
+    color: "#EA4335"
+    category: security
+  key-management-service:
+    label: Key Management Service
+    aliases: [kms, cloud kms, encryption key]
+    color: "#EA4335"
+    category: security
+  cloud-security-command-center:
+    label: Security Command Center
+    aliases: [security command center, threat detection]
+    color: "#EA4335"
+    category: security
+
+  cloud-vision-api:
+    label: Vision API
+    aliases: [vision api, image recognition]
+    color: "#0F9D58"
+    category: ai-ml
+  cloud-natural-language-api:
+    label: Natural Language API
+    aliases: [natural language api, nlp]
+    color: "#0F9D58"
+    category: ai-ml
+  cloud-translation-api:
+    label: Translation API
+    aliases: [translation api]
+    color: "#0F9D58"
+    category: ai-ml
+  cloud-speech-api:
+    label: Speech-to-Text
+    aliases: [speech-to-text, speech api]
+    color: "#0F9D58"
+    category: ai-ml
+  cloud-text-to-speech:
+    label: Text-to-Speech
+    aliases: [text-to-speech]
+    color: "#0F9D58"
+    category: ai-ml
+  cloud-automl:
+    label: AutoML
+    aliases: [automl, cloud automl]
+    color: "#0F9D58"
+    category: ai-ml
+
+  cloud-scheduler:
+    label: Cloud Scheduler
+    aliases: [cloud scheduler, cron]
+    color: "#4285F4"
+    category: management
+  cloud-tasks:
+    label: Cloud Tasks
+    aliases: [cloud tasks, task queue]
+    color: "#4285F4"
+    category: management
+  error-reporting:
+    label: Error Reporting
+    aliases: [error reporting]
+    color: "#4285F4"
+    category: management
+  cloud-monitoring:
+    label: Cloud Monitoring
+    aliases: [cloud monitoring, metrics]
+    color: "#4285F4"
+    category: management
+
+  apigee-api-platform:
+    label: Apigee
+    aliases: [apigee, api management]
+    color: "#4285F4"
+    category: networking
+  firebase:
+    label: Firebase
+    aliases: [firebase]
+    color: "#FFCA28"
+    category: mobile

--- a/skills/architecture-diagram/tests/test_service_maps.py
+++ b/skills/architecture-diagram/tests/test_service_maps.py
@@ -1,0 +1,92 @@
+"""Verify every service-mapping entry resolves to a real cached icon.
+
+These YAML files are curated by hand (they exist to translate what a user
+says — "S3 bucket", "load balancer" — into the exact slug the icon cache
+uses). Hand-curated data drifts from reality: a typo'd slug, a shape that
+gets renamed upstream, a copy-paste mistake across ~70 entries per provider.
+This test is the guard: every `slug` value must resolve to an actual file in
+the real cache built by `fetch_icons.py` at the pinned commit, not just look
+plausible.
+
+Requires the real cache to be present (built via `fetch_icons.py --provider
+all`); skips instead of failing when it isn't, since building it needs
+network access this test suite should not depend on for routine runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fetch_icons
+import pytest
+import yaml
+
+REFERENCES = Path(__file__).parent.parent / "references"
+MAPPING_FILES = {
+    "aws": REFERENCES / "services-aws.yaml",
+    "gcp": REFERENCES / "services-gcp.yaml",
+    "azure": REFERENCES / "services-azure.yaml",
+}
+
+
+def _real_cache_dir() -> Path | None:
+    """Locate a real, already-fetched cache for the pinned SHA. Checked in
+    order: explicit env override, then the default per-user cache location."""
+    import os
+
+    for candidate in (
+        os.environ.get("ARMORY_ICON_CACHE_TEST_DIR"),
+        str(fetch_icons.default_cache_dir()),
+    ):
+        if candidate:
+            path = Path(candidate) / fetch_icons.DRAWIO_SHA
+            if path.exists() and any(path.glob("*/*.json")):
+                return Path(candidate)
+    return None
+
+
+def _load_mapping(path: Path) -> dict[str, dict[str, object]]:
+    data = yaml.safe_load(path.read_text())
+    return data["services"]
+
+
+class TestMappingFileStructure:
+    @pytest.mark.parametrize("provider", sorted(MAPPING_FILES))
+    def test_file_exists_and_parses(self, provider: str) -> None:
+        mapping = _load_mapping(MAPPING_FILES[provider])
+        assert mapping, f"{provider} mapping is empty"
+
+    @pytest.mark.parametrize("provider", sorted(MAPPING_FILES))
+    def test_every_entry_has_required_fields(self, provider: str) -> None:
+        mapping = _load_mapping(MAPPING_FILES[provider])
+        for key, entry in mapping.items():
+            assert "label" in entry, f"{provider}/{key} missing label"
+            assert "color" in entry, f"{provider}/{key} missing color"
+            assert str(entry["color"]).startswith("#"), (
+                f"{provider}/{key} color must be a hex string"
+            )
+
+    @pytest.mark.parametrize("provider", sorted(MAPPING_FILES))
+    def test_no_duplicate_slugs_within_a_provider(self, provider: str) -> None:
+        mapping = _load_mapping(MAPPING_FILES[provider])
+        keys = list(mapping)
+        assert len(keys) == len(set(keys))
+
+
+@pytest.mark.skipif(
+    _real_cache_dir() is None,
+    reason="real icon cache not built — run fetch_icons.py --provider all first",
+)
+class TestSlugsResolveAgainstRealCache:
+    @pytest.mark.parametrize("provider", sorted(MAPPING_FILES))
+    def test_every_slug_has_a_cache_entry(self, provider: str) -> None:
+        cache_dir = _real_cache_dir()
+        assert cache_dir is not None
+        mapping = _load_mapping(MAPPING_FILES[provider])
+        provider_dir = cache_dir / fetch_icons.DRAWIO_SHA / provider
+        missing = [
+            key for key in mapping if not (provider_dir / f"{key}.json").exists()
+        ]
+        assert not missing, (
+            f"{provider} mapping references slugs with no cache entry: {missing}"
+        )


### PR DESCRIPTION
## Stack

Stack-Id: `cloud-diagram-e45515`
Base: `feat/cloud-diagram-layout-engine` (#91)
Position: 3/5

1. `feat/cloud-diagram-icon-pipeline` -> #90
2. `feat/cloud-diagram-layout-engine` -> #91
3. `feat/cloud-diagram-service-maps` -> this PR
4. `feat/cloud-diagram-skill-rewrite` -> TBD
5. `feat/cloud-diagram-ripple` -> TBD

Depends on: #91
Upstack: TBD

## Summary

Curated reference tables translating what a user says ("S3 bucket", "load balancer") into the exact icon cache slug an agent should write into a spec's `service:` field.

Purely agent-facing documentation — `render.py` has no alias resolution layer, a spec's `service` value IS the cache slug directly, so these tables don't change `render.py`'s interface at all. That's why this PR only depends on #91 (the cache format contract), not the other way around — PR2 and PR3 were independently buildable once #90 landed, just built sequentially here.

- `services-aws.yaml` — ~70 entries across compute/storage/database/networking/integration/security/analytics/ai-ml
- `services-gcp.yaml` — ~35 entries. GCP's stencil set is narrower than AWS's (297 vs 1037 icons), so several modern GCP services (GKE as distinct from the generic k8s logo, Vertex AI, Artifact Registry, Secret Manager, Cloud KMS, Anthos) have no dedicated icon and are documented as absent rather than mapped to a misleading substitute.
- `services-azure.yaml` — ~45 entries, same omit-rather-than-fake policy for gaps (Azure Pipelines/Boards/Artifacts, Queue/File Storage as distinct icons, VPN Gateway).

### The resolution test caught real bugs

`test_service_maps.py` resolves every single slug in all three files against the real cache built in #90. On the first run it caught two real transcription errors: the `efs`/`ebs` keys didn't match any real AWS slug — the actual cache entries are `efs-standard` and `elastic-block-store`. A hand-typed ~70-entry YAML table drifting from the real cache is exactly the failure mode this test exists to catch, and it did.

The cache-dependent tests skip (not fail) when no real cache is present, so CI doesn't need network access to validate structure/duplicates. Run with `ARMORY_ICON_CACHE_TEST_DIR=<dir>` pointed at a real `fetch_icons.py` output to exercise the full resolution check.

### Verified end to end

A real multi-cloud spec built entirely from these tables' entries (AWS Kinesis -> GCP Dataflow -> GCP BigQuery -> Azure Logic Apps) renders cleanly through `render.py` with zero warnings — screenshot below.

## Validation

- `uv run --with pytest --with pyyaml pytest skills/architecture-diagram/tests/` — 114 passed (111 + 3 skip without a real cache locally)
- `ARMORY_ICON_CACHE_TEST_DIR=... pytest test_service_maps.py` — 12/12 passed against the real cache
- `ruff check` / `ruff format --check` — clean
- `mypy --strict` on all scripts — clean
- Live CLI render of a real multi-cloud spec built from these tables
