### PR TITLE
feat(architecture-diagram): rewrite evals and ripple v2.0.0 across armory

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -30,7 +30,8 @@ Tools, libraries, and projects that armory packages wrap, depend on, or were ins
 | **arXiv API**                            | [lukasschwab/arxiv.py](https://github.com/lukasschwab/arxiv.py)                                               | MIT                       | `arxiv-search`                       |
 | **pytest**                               | [pytest-dev/pytest](https://github.com/pytest-dev/pytest)                                                     | MIT                       | `test-harness`                       |
 | **KaTeX**                                | [KaTeX/KaTeX](https://github.com/KaTeX/KaTeX)                                                                 | MIT                       | `md-to-pdf`                          |
-| **Mermaid**                              | [mermaid-js/mermaid](https://github.com/mermaid-js/mermaid)                                                   | MIT                       | `md-to-pdf`, `architecture-diagram`  |
+| **Mermaid**                              | [mermaid-js/mermaid](https://github.com/mermaid-js/mermaid)                                                   | MIT                       | `md-to-pdf`                          |
+| **draw.io** (jgraph)                     | [jgraph/drawio](https://github.com/jgraph/drawio)                                                             | Apache-2.0                | `architecture-diagram` (icon geometry, fetched at runtime — see Vendoring Records) |
 | **Playwright** (Microsoft)               | [microsoft/playwright](https://github.com/microsoft/playwright)                                               | Apache-2.0                | `qa-systematic`                      |
 | **Marp** (marp-team)                     | [marp-team/marpit](https://github.com/marp-team/marpit) · [marp-team/marp-core](https://github.com/marp-team/marp-core) · [marp-team/marp-cli](https://github.com/marp-team/marp-cli) | MIT                       | `marp-slides`                        |
 
@@ -153,6 +154,22 @@ A third-party redistribution of an English distillation of that course exists at
 Kosha's pre-registered real-model Gate-0 evaluation is also cited, as a measured finding rather than a claim: an LLM-adjudicated dedup-and-contradiction loop trailed a prompt-only baseline by 0.28–0.33 on detection and safety across every provider cell tested (108 held-out contradictions, 2 embedding × 2 generation models). `kg-builder` uses this to require that any model adjudicator be measured against a prompt-only baseline before it is trusted. Kosha's governance guarantee held under the same evaluation; its decision-quality claim did not, and the skill states the distinction.
 
 **Re-sync policy:** Neither upstream is vendored, so there is nothing to diff. Revisit the Kosha citation if a later pre-registered Gate-0 run records a GO verdict, and revisit the OKF question separately — OKF bundles are linked Markdown documents with untyped links, not typed property graphs, so they are out of scope for this skill.
+
+### draw.io icon geometry — used by `architecture-diagram`
+
+**Upstream repo:** [jgraph/drawio](https://github.com/jgraph/drawio)
+**License:** Apache-2.0
+**Pinned commit:** `a1f615b7f5a5237da71de2ce2f057b5fa70b0aeb` (`dev` branch, verified 2026-08-15)
+
+**Not traditional vendoring — no files are copied into this repository.** AWS, Azure, and GCP's own terms permit using their icons to build architecture diagrams, but none grant redistribution rights for the raw files, so `architecture-diagram` ships zero icon assets. Instead:
+
+- `scripts/stencil2svg.py` converts draw.io's `mxgraph.aws4`/`mxgraph.gcp2` stencil XML (vector `move`/`line`/`curve`/`arc` primitives, no embedded rasters) into inline SVG, at render time, on the end user's own machine.
+- `scripts/svg_inline.py` inlines and namespaces draw.io's `azure2` real-SVG icon library the same way.
+- `scripts/fetch_icons.py` builds a local per-user cache pinned to the commit above, so output stays reproducible without this repository ever holding the icon files.
+
+The pinned commit governs which stencil/icon geometry is used; bumping it is a deliberate, reviewable change to `scripts/fetch_icons.py`, not an implicit `dev`-branch tracking dependency.
+
+**Re-sync policy:** Nothing is vendored, so there is nothing to diff against upstream `dev` churn. Bump `DRAWIO_SHA` in `scripts/fetch_icons.py` only after re-running the full corpus conversion and confirming no new conversion warnings, per `references/editability.md`.
 
 ## Conceptual Inspiration
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 
 | Skill                                                                | Description                                                                                                          |
 | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| [architecture-diagram](skills/architecture-diagram/)                 | Layered architecture diagrams as self-contained HTML with inline SVG icons and CSS Grid layout                       |
+| [architecture-diagram](skills/architecture-diagram/)                 | Editable SVG architecture diagrams with native AWS/Azure/GCP icons, deterministic zone-aware layout                 |
 | [concept-to-image](skills/concept-to-image/)                         | Turn concepts into polished HTML visuals, export as PNG or SVG                                                       |
 | [concept-to-video](skills/concept-to-video/)                         | Turn concepts into animated explainer videos using Manim — MP4/GIF output with audio overlay, templates, multi-scene |
 | [remotion-video](skills/remotion-video/)                             | Production motion graphics using Remotion (React) — branded content, data-driven video, audio sync, TailwindCSS      |

--- a/agents/media-producer/AGENT.md
+++ b/agents/media-producer/AGENT.md
@@ -108,7 +108,7 @@ Route to the appropriate skill based on concept type and output needs:
 
 | Concept Type                                         | Default Route                | Rationale                                               |
 | ---------------------------------------------------- | ---------------------------- | ------------------------------------------------------- |
-| System topology, infrastructure                      | architecture-diagram         | Purpose-built for component relationships and data flow |
+| System topology, infrastructure                      | architecture-diagram         | Purpose-built for component relationships; produces editable SVG with native AWS/Azure/GCP icons |
 | Static concept, comparison, illustration             | concept-to-image             | Single-frame visual with no temporal dimension          |
 | Algorithm, mathematical process, technical education | concept-to-video (Manim)     | Step-by-step animation reveals complexity incrementally |
 | Branded product demo, marketing video                | remotion-video (React)       | Polished motion graphics with brand consistency         |

--- a/agents/project-architect/AGENT.md
+++ b/agents/project-architect/AGENT.md
@@ -195,7 +195,7 @@ Address any findings from the review. If critical issues are found, revise the a
 | Artifact              | Format      | Description                                           |
 | --------------------- | ----------- | ----------------------------------------------------- |
 | Architecture Document | Markdown    | Complete system design with all sections from Phase 4 |
-| Architecture Diagram  | Mermaid/SVG | Visual system topology via architecture-diagram skill |
+| Architecture Diagram  | SVG         | Visual system topology via architecture-diagram skill |
 | ADRs                  | Markdown    | One per major decision via adr-writer skill           |
 | Requirements Summary  | Markdown    | Organized discovery findings from Phases 1-2          |
 

--- a/agents/proposal-writer/AGENT.md
+++ b/agents/proposal-writer/AGENT.md
@@ -216,7 +216,7 @@ Produce the structured proposal document using the Output Format below. Sections
 
 <Solution in business language>
 
-![Solution Architecture](architecture-diagram.png)
+![Solution Architecture](architecture-diagram.svg)
 
 <Technical detail as needed>
 

--- a/skills/architecture-diagram/evals/cases.yaml
+++ b/skills/architecture-diagram/evals/cases.yaml
@@ -3,46 +3,102 @@ cases:
     prompt: "Create an architecture diagram for our microservices: API Gateway, User Service, Order Service, PostgreSQL, Redis"
     fixtures: []
     rubric:
-      - "Output produces a self-contained HTML file"
-      - "Output uses SVG or CSS Grid for layout"
+      - "Output produces a self-contained, valid SVG file"
+      - "Output includes real <text> labels for every component, not outlined paths"
       - "Output includes connection lines or arrows between components"
+      - "Output does not use raster images or <use> clones for icons"
     trigger_expected: true
     assertions:
       - type: matches_regex
-        target: "(<html|<HTML|\\.html)"
+        target: "<svg[^>]*xmlns=\"http://www\\.w3\\.org/2000/svg\""
         weight: 1.0
-      - type: matches_regex
-        target: "(<svg|SVG|svg)"
+      - type: contains
+        target: "<text"
         weight: 0.8
       - type: contains
         target: "API Gateway"
         weight: 0.8
       - type: matches_regex
-        target: "(connection|arrow|line|path)"
+        target: "(<path|<line|<polyline)"
         weight: 0.8
       - type: not_contains
-        target: "external dependency"
-        weight: 0.6
+        target: "<image"
+        weight: 1.0
+      - type: not_contains
+        target: "base64,"
+        weight: 1.0
 
   - id: aws_deployment_diagram
-    prompt: "Draw a deployment diagram showing our AWS infrastructure"
+    prompt: "Draw a deployment diagram showing our AWS infrastructure: API Gateway, Lambda, DynamoDB inside a VPC"
     fixtures: []
     rubric:
-      - "Output shows containment hierarchy (e.g., VPC > Subnet > Instance)"
-      - "Output uses color-coded legends to distinguish component types"
+      - "Output shows containment hierarchy (e.g., VPC zone containing service nodes)"
+      - "Output uses AWS-native icon geometry, not generic placeholder icons"
+      - "Output is valid, self-contained SVG"
     trigger_expected: true
     assertions:
       - type: matches_regex
-        target: "(<html|<HTML|\\.html)"
+        target: "<svg[^>]*xmlns=\"http://www\\.w3\\.org/2000/svg\""
         weight: 1.0
       - type: matches_regex
-        target: "(VPC|Subnet|EC2|AWS|Region)"
+        target: "(VPC|Lambda|DynamoDB|API Gateway)"
         weight: 0.8
       - type: matches_regex
-        target: "(legend|Legend|color)"
+        target: "(zone-|stroke-dasharray)"
         weight: 0.6
+      - type: not_contains
+        target: "<use "
+        weight: 1.0
+
+  - id: azure_web_app_diagram
+    prompt: "Draw an Azure architecture diagram for our web app: App Gateway, App Service, SQL Database"
+    fixtures: []
+    rubric:
+      - "Output uses Azure-native icon geometry"
+      - "Output is valid, self-contained SVG with no external references"
+    trigger_expected: true
+    assertions:
       - type: matches_regex
-        target: "(container|zone|hierarchy|nested)"
+        target: "<svg[^>]*xmlns=\"http://www\\.w3\\.org/2000/svg\""
+        weight: 1.0
+      - type: matches_regex
+        target: "(App Gateway|App Service|SQL Database|Azure)"
+        weight: 0.8
+      - type: not_contains
+        target: "href=\"http"
+        weight: 1.0
+
+  - id: gcp_data_pipeline_diagram
+    prompt: "Create a GCP architecture diagram: Pub/Sub feeding Dataflow into BigQuery"
+    fixtures: []
+    rubric:
+      - "Output uses GCP-native icon geometry"
+      - "Output shows the pipeline's data flow direction"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "<svg[^>]*xmlns=\"http://www\\.w3\\.org/2000/svg\""
+        weight: 1.0
+      - type: matches_regex
+        target: "(Pub/Sub|PubSub|Dataflow|BigQuery)"
+        weight: 0.8
+
+  - id: multi_cloud_and_vpc_topology_diagram
+    prompt: "Draw our deployment topology: on-prem Nginx and PostgreSQL behind a VPC boundary, syncing nightly to an AWS S3 backup"
+    fixtures: []
+    rubric:
+      - "Output mixes a cloud provider's native icons with generic on-prem icons in one diagram"
+      - "Output shows containment hierarchy (VPC zone) and a labeled connection for the sync"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "<svg[^>]*xmlns=\"http://www\\.w3\\.org/2000/svg\""
+        weight: 1.0
+      - type: matches_regex
+        target: "(Nginx|PostgreSQL|S3)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(VPC|zone-)"
         weight: 0.6
 
   - id: negative_architecture_review
@@ -57,4 +113,11 @@ cases:
     fixtures: []
     rubric:
       - "Skill should not trigger for process flow diagrams"
+    trigger_expected: false
+
+  - id: negative_interactive_dashboard
+    prompt: "Build an interactive dashboard with toggleable tabs showing our service metrics"
+    fixtures: []
+    rubric:
+      - "Skill should not trigger for interactive/click-through HTML artifacts — that's static-web-artifacts-builder's job"
     trigger_expected: false

--- a/skills/static-web-artifacts-builder/SKILL.md
+++ b/skills/static-web-artifacts-builder/SKILL.md
@@ -87,10 +87,9 @@ Share the validated HTML file in conversation with the user so they can view it 
 | --------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------- |
 | Rich infographic with multiple sections, high data density      | Yes                                 | —                                                   |
 | Self-contained dashboard with interactive tabs or toggles       | Yes                                 | —                                                   |
-| Architecture diagram with bidirectional flows and layered tiers | Yes                                 | `architecture-diagram` for auto-generated from code |
+| Static architecture/topology diagram, editable afterward in Figma/Illustrator | No | `architecture-diagram` — produces real vector SVG, not this skill's interactive HTML |
 | Simple concept illustration or icon-style image                 | No                                  | `concept-to-image`                                  |
 | Slide deck or multi-page presentation                           | No                                  | `html-presentation`                                 |
-| Architecture diagram generated from existing codebase           | No                                  | `architecture-diagram`                              |
 | Single-page visual where CSS Grid layout control is critical    | Yes                                 | —                                                   |
 | Artifact must be screenshot-ready via Playwright                | Yes (with caveat — see Limitations) | —                                                   |
 


### PR DESCRIPTION
## Stack

Stack-Id: `cloud-diagram-e45515`
Base: `feat/cloud-diagram-skill-rewrite` (#93)
Position: 5/5

1. `feat/cloud-diagram-icon-pipeline` -> #90
2. `feat/cloud-diagram-layout-engine` -> #91
3. `feat/cloud-diagram-service-maps` -> #92
4. `feat/cloud-diagram-skill-rewrite` -> #93
5. `feat/cloud-diagram-ripple` -> this PR (leaf)

Depends on: #93
Upstack: none

## Summary

Final layer: eval cases updated for the new SVG contract plus cloud-provider triggers, and every armory file that described the old HTML/CSS-Grid output or routed around the old `architecture-diagram` / `static-web-artifacts-builder` overlap.

### `evals/cases.yaml`

Retargeted assertions from `<html` to real SVG markers (`xmlns`, real `<text>`, editability negative-assertions for `<image` and `base64,`). Added AWS/Azure/GCP/multi-cloud positive cases. Added a negative case for interactive dashboards — that's `static-web-artifacts-builder`'s job, not this skill's.

### `static-web-artifacts-builder/SKILL.md`

Its own overlap table self-contradicted: one row said "Yes" to architecture diagrams with layered tiers, another said "No, use architecture-diagram" two rows down. Resolved to a single row — static architecture diagrams are unambiguously `architecture-diagram`'s job now that it produces real editable SVG instead of interactive HTML.

### Agent routing/output tables

- `project-architect/AGENT.md`'s Output Artifacts table claimed `Mermaid/SVG` for a skill that has never touched Mermaid (grepped the whole skill directory, old and new — zero hits). Fixed to `SVG`.
- `proposal-writer/AGENT.md`'s template example embedded `architecture-diagram.png`. Fixed to `.svg`, matching actual output — confirmed `md-to-pdf` embeds SVG through its Playwright/Chromium pipeline natively, no conversion step needed.
- `media-producer/AGENT.md`'s routing rationale sharpened to mention the editable-SVG/native-icon differentiator.

### `README.md` / `ATTRIBUTIONS.md`

Catalog line updated. Added `jgraph/drawio` (Apache-2.0) as the icon-geometry source with a Vendoring Records entry explaining the runtime-fetch model — no files are copied into this repo (see #90's design rationale). Also corrected a pre-existing stale line attributing Mermaid to `architecture-diagram`, which was never accurate and this rewrite makes newly, unambiguously false to leave uncorrected.

### `manifest.yaml`

Regenerated via `scripts/generate_manifest.py` — description and version bump only, scoped to this package.

### `.claude/anatomy.md` and `adapters/`

Both gitignored (session-local / CI-regenerated). Confirmed nothing to commit — verified `anatomy.md`'s content locally via a scoped surgical fix rather than a full repo-wide regeneration, which would have pulled in roughly 1000 unrelated lines of drift correction accumulated by other sessions over time. Out of scope for this PR.

## Validation

- `uv run scripts/validate_evals.py` / `validate_references.py` / `validate_frontmatter.py` — all clean across all 139 armory packages
- `scripts/evaluate_package.py --path skills/architecture-diagram` — 100/100, unchanged from #93
- `uv run --with pytest --with pyyaml pytest skills/architecture-diagram/tests/` — 121 passed
- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — clean

## This completes the stack

Once this merges, `architecture-diagram` v2.0.0 is fully landed: real editable SVG output, native AWS/Azure/GCP icons sourced at runtime with zero vendored assets, deterministic layout, and every downstream reference in armory updated to match.
