### PR TITLE
fix(architecture-diagram): clamp corridor lane offsets to the actual gap

### DIFF
--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -35,8 +35,8 @@ import yaml
 ICON = 64
 NODE_W = 120
 NODE_H = 118  # icon + two label lines + padding
-COL_GAP = 64
-ROW_GAP = 32
+COL_GAP = 90
+ROW_GAP = 44
 MARGIN = 32
 TITLE_H = 44
 ZONE_PAD = 22
@@ -343,9 +343,33 @@ class RoutedEdge:
 
 
 def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
+    """Corridor membership must be known before assigning lane offsets, or a
+    parallel-edge stack can grow past the row/column gap and cross through
+    the very node row it was routing around. Verified failure mode: 4
+    same-rank targets fanning out from one TB source pushed the 3rd/4th lane
+    offset past ROW_GAP, drawing those segments through the target row's
+    node bodies instead of the gap above them. Fix: pre-count each
+    corridor's membership, then size lane spacing to fit inside the actual
+    available gap regardless of how many edges share it."""
+    corridor_of: dict[int, tuple[float, str]] = {}
+    for i, e in enumerate(spec.edges):
+        a, b = node_boxes[e.src], node_boxes[e.dst]
+        if spec.direction == "TB":
+            ax, bx = a.x + a.w / 2, b.x + b.w / 2
+            if abs(ax - bx) >= 1:
+                corridor_of[i] = (a.y2, "h")
+        else:
+            ay, by = a.y + a.h / 2, b.y + b.h / 2
+            if abs(ay - by) >= 1:
+                corridor_of[i] = (a.x2, "v")
+
+    corridor_size: dict[tuple[float, str], int] = {}
+    for key in corridor_of.values():
+        corridor_size[key] = corridor_size.get(key, 0) + 1
+
+    lane_index: dict[tuple[float, str], int] = {}
     routed = []
-    lane_use: dict[tuple[float, str], int] = {}
-    for e in spec.edges:
+    for i, e in enumerate(spec.edges):
         a, b = node_boxes[e.src], node_boxes[e.dst]
         if spec.direction == "TB":
             ax, ay = a.x + a.w / 2, a.y2
@@ -354,10 +378,12 @@ def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
                 d = f"M{ax:g},{ay:g} L{bx:g},{by - 6:g}"
                 mx, my = ax + 8, (ay + by) / 2
             else:
-                mid = ay + 24
-                key = (mid, "h")
-                lane_use[key] = lane_use.get(key, 0) + 1
-                mid += (lane_use[key] - 1) * 10
+                key = corridor_of[i]
+                n = corridor_size[key]
+                spacing = min(8.0, 16.0 / max(n - 1, 1))
+                idx = lane_index.get(key, 0)
+                lane_index[key] = idx + 1
+                mid = ay + 10 + idx * spacing
                 d = f"M{ax:g},{ay:g} L{ax:g},{mid:g} L{bx:g},{mid:g} L{bx:g},{by - 6:g}"
                 mx, my = (ax + bx) / 2, mid - 6
         else:
@@ -367,10 +393,12 @@ def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
                 d = f"M{ax:g},{ay:g} L{bx - 6:g},{by:g}"
                 mx, my = (ax + bx) / 2, ay - 8
             else:
-                mid = ax + 28
-                key = (mid, "v")
-                lane_use[key] = lane_use.get(key, 0) + 1
-                mid += (lane_use[key] - 1) * 10
+                key = corridor_of[i]
+                n = corridor_size[key]
+                spacing = min(10.0, 40.0 / max(n - 1, 1))
+                idx = lane_index.get(key, 0)
+                lane_index[key] = idx + 1
+                mid = ax + 16 + idx * spacing
                 d = f"M{ax:g},{ay:g} L{mid:g},{ay:g} L{mid:g},{by:g} L{bx - 6:g},{by:g}"
                 mx, my = mid + 6, (ay + by) / 2
         routed.append(RoutedEdge(edge=e, path_d=d, label_pos=(mx, my)))

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 import render
 from render import (
+    COL_GAP,
+    ROW_GAP,
     Box,
     Edge,
     IconRef,
@@ -316,6 +318,77 @@ class TestRouting:
         )
         routed = route_edges(spec2, boxes)
         assert routed[0].path_d != routed[1].path_d
+
+    def test_dense_fan_out_corridor_stays_within_the_gap_tb(self) -> None:
+        """Regression test for a real bug found while showcasing the tool:
+        one TB source fanning out to 4 same-rank targets pushed the 3rd/4th
+        parallel lane offset past ROW_GAP, drawing those horizontal jog
+        segments through the target row's node bodies instead of the gap
+        above them (verified visually — the 'query'/'fetch secrets' labels
+        rendered on top of unrelated icons). Every corridor's horizontal
+        segment must sit strictly above the target row's top edge."""
+        source = Box(1000, 0, 120, 118)  # deliberately x-misaligned with every target
+        targets = {
+            "b": Box(0, ROW_GAP + 118, 120, 118),
+            "c": Box(140, ROW_GAP + 118, 120, 118),
+            "d": Box(280, ROW_GAP + 118, 120, 118),
+            "e": Box(420, ROW_GAP + 118, 120, 118),
+        }
+        boxes = {"a": source, **targets}
+        spec2 = Spec(
+            title="",
+            direction="TB",
+            provider="generic",
+            nodes=[Node("a", "A"), *(Node(k, k.upper()) for k in targets)],
+            zones=[],
+            edges=[Edge("a", k) for k in targets],
+        )
+        routed = route_edges(spec2, boxes)
+        target_row_top = min(b.y for b in targets.values())
+        for r in routed:
+            points = [
+                tuple(float(v) for v in tok.split(","))
+                for tok in r.path_d.replace("M", "L").split("L")
+                if tok.strip()
+            ]
+            assert len(points) == 4, f"expected a bent 4-point path, got {r.path_d}"
+            corridor_y = points[1][1]  # the horizontal jog's height
+            assert corridor_y < target_row_top, (
+                f"edge {r.edge.src}->{r.edge.dst} corridor (y={corridor_y}) reaches into the "
+                f"target row (top={target_row_top}): {r.path_d}"
+            )
+
+    def test_dense_fan_out_corridor_stays_within_the_gap_lr(self) -> None:
+        """Same regression, LR direction: corridor x-offsets must sit
+        strictly left of the target column."""
+        source = Box(0, 1000, 120, 118)  # deliberately y-misaligned with every target
+        targets = {
+            k: Box(COL_GAP + 120, i * 140, 120, 118)
+            for i, k in enumerate("bcdefghi")  # 8 targets: guarantees overflow
+        }  # against COL_GAP even under the old unclamped-lane-offset formula
+        boxes = {"a": source, **targets}
+        spec2 = Spec(
+            title="",
+            direction="LR",
+            provider="generic",
+            nodes=[Node("a", "A"), *(Node(k, k.upper()) for k in targets)],
+            zones=[],
+            edges=[Edge("a", k) for k in targets],
+        )
+        routed = route_edges(spec2, boxes)
+        target_col_left = min(b.x for b in targets.values())
+        for r in routed:
+            points = [
+                tuple(float(v) for v in tok.split(","))
+                for tok in r.path_d.replace("M", "L").split("L")
+                if tok.strip()
+            ]
+            assert len(points) == 4, f"expected a bent 4-point path, got {r.path_d}"
+            corridor_x = points[1][0]  # the vertical jog's position
+            assert corridor_x < target_col_left, (
+                f"edge {r.edge.src}->{r.edge.dst} corridor (x={corridor_x}) reaches into the "
+                f"target column (left={target_col_left}): {r.path_d}"
+            )
 
 
 class TestEditabilityCheck:


### PR DESCRIPTION
## Summary

Real bug found while using the newly-shipped v2.0.0 skill to build 4 showcase diagrams: any node with 3+ same-rank targets — a common real pattern, e.g. one service fanning out to a database, a queue, and a secrets store — produced edges whose parallel lane offset grew past `ROW_GAP`/`COL_GAP` and drew the horizontal/vertical jog segment straight through the target row's node bodies. Visually, labels like "query" and "fetch secrets" rendered on top of unrelated icons instead of routing around them — exactly the failure mode `check_layout`'s own docstring says the renderer should prevent.

## Root cause

`route_edges` assigned lane offsets in a single pass, adding a fixed 10px per parallel edge sharing a corridor with no upper bound. Four edges fanning out from one source: offsets 24/34/44/54 against `ROW_GAP=32` — the last two were already past the target row's top edge before this fix.

## Fix

Two-pass routing. First pass counts how many edges actually share each corridor; second pass sizes lane spacing to fit inside the real available gap regardless of edge count (`min(8, 16/(n-1))` for TB, `min(10, 40/(n-1))` for LR), so the stack can never grow past the row/column it's routing through.

Also widened `COL_GAP` (64→90) and `ROW_GAP` (32→44) — a separate issue found in the same pass: even after the corridor fix, short typical edge labels ("publish", "stream", "scrape") were clipping into adjacent icon boundaries because the gap was barely wider than the label text at the old spacing. No test depends on the exact constant values.

## Regression coverage — verified, not assumed

Two new tests reproduce the exact failure geometry (one source, 4–8 same-rank targets, deliberately misaligned so every edge bends) and assert the corridor's jog coordinate never reaches the target row/column.

Verified both tests actually catch the bug: reverted `route_edges` to the old unclamped formula locally, confirmed both tests fail against it (TB needed only 4 targets to overflow `ROW_GAP=44`; LR needed 8 targets to overflow the wider `COL_GAP=90`), then restored the fix and confirmed both pass. Caught a real bug in my own first draft of these tests along the way — an inverted boundary condition (`y <= target - 2 or y >= target`) that was trivially permissive; fixed to extract and check the actual corridor coordinate directly.

## Validation

- `uv run --with pytest --with pyyaml pytest skills/architecture-diagram/tests/` — 123 passed (121 unchanged + 2 new)
- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — clean
- `scripts/evaluate_package.py --path skills/architecture-diagram` — 100/100, unaffected
- `manifest.yaml` unchanged (no frontmatter touched by this fix)
- Visual: all 4 showcase diagrams (AWS, Azure, GCP, generic) re-rendered clean, no crossings, no clipped labels
