### PR TITLE
fix(architecture-diagram): anchor edges and labels on true icon center

### DIFF
--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -273,6 +273,26 @@ class Box:
         )
 
 
+def icon_box(box: Box) -> Box:
+    """The node's *visible icon square* — 64x64, horizontally centered
+    within the wider label-reserving node box, flush against its top edge
+    (icon on top, label lines below).
+
+    `Box` (NODE_W x NODE_H) exists to reserve room for label text that's
+    almost always wider than the 64px icon; it is correct for layout
+    spacing (compute_zone_boxes, node-overlap checks) but was previously
+    also used directly for label centering and edge-routing anchor points.
+    Since the icon isn't centered within that wider box by default, those
+    anchors landed off the icon's true center — edges rode along the
+    icon's bottom edge in LR diagrams and its right side in TB diagrams
+    instead of passing through its middle, and labels centered ~28px to
+    the right of their own icon. Every caller that needs "where does this
+    node visually connect" — routing, label centering, the no-icon
+    placeholder glyph — must go through this helper instead of `Box`
+    directly."""
+    return Box(box.x + (NODE_W - ICON) / 2, box.y, ICON, ICON)
+
+
 def compute_positions(
     spec: Spec, rank: dict[str, int], order: dict[str, int]
 ) -> dict[str, Box]:
@@ -353,7 +373,7 @@ def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
     available gap regardless of how many edges share it."""
     corridor_of: dict[int, tuple[float, str]] = {}
     for i, e in enumerate(spec.edges):
-        a, b = node_boxes[e.src], node_boxes[e.dst]
+        a, b = icon_box(node_boxes[e.src]), icon_box(node_boxes[e.dst])
         if spec.direction == "TB":
             ax, bx = a.x + a.w / 2, b.x + b.w / 2
             if abs(ax - bx) >= 1:
@@ -370,7 +390,7 @@ def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
     lane_index: dict[tuple[float, str], int] = {}
     routed = []
     for i, e in enumerate(spec.edges):
-        a, b = node_boxes[e.src], node_boxes[e.dst]
+        a, b = icon_box(node_boxes[e.src]), icon_box(node_boxes[e.dst])
         if spec.direction == "TB":
             ax, ay = a.x + a.w / 2, a.y2
             bx, by = b.x + b.w / 2, b.y
@@ -513,13 +533,14 @@ class CompositeIconLookup:
 
 def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -> str:
     parts = [f'<g id="node-{_escape(node.id)}">']
+    icon_pos = icon_box(box)
     parts.append(
-        f'<rect x="{box.x:g}" y="{box.y:g}" width="{ICON:g}" height="{ICON:g}" rx="10" fill="{node.color}"/>'
+        f'<rect x="{icon_pos.x:g}" y="{icon_pos.y:g}" width="{ICON:g}" height="{ICON:g}" rx="10" fill="{node.color}"/>'
     )
     if icon is not None:
         inset = 9
         parts.append(
-            f'<svg x="{box.x + inset:g}" y="{box.y + inset:g}" width="{ICON - inset * 2:g}" '
+            f'<svg x="{icon_pos.x + inset:g}" y="{icon_pos.y + inset:g}" width="{ICON - inset * 2:g}" '
             f'height="{ICON - inset * 2:g}" viewBox="{icon.view_box}" color="#FFFFFF">{icon.body}</svg>'
         )
     else:
@@ -527,7 +548,7 @@ def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -
             warnings.append(
                 f"no icon for node {node.id!r} (service={node.service!r}, provider={node.provider!r})"
             )
-        cx, cy = box.x + ICON / 2, box.y + ICON / 2
+        cx, cy = icon_pos.x + ICON / 2, icon_pos.y + ICON / 2
         initial = _escape(node.label[:1].upper() or "?")
         parts.append(
             f'<text x="{cx:g}" y="{cy + 6:g}" font-size="22" font-weight="700" text-anchor="middle" fill="#FFFFFF">{initial}</text>'

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -10,6 +10,7 @@ import pytest
 import render
 from render import (
     COL_GAP,
+    ICON,
     ROW_GAP,
     Box,
     Edge,
@@ -22,6 +23,7 @@ from render import (
     check_layout,
     compute_positions,
     compute_zone_boxes,
+    icon_box,
     load_spec,
     order_within_ranks,
     route_edges,
@@ -390,6 +392,63 @@ class TestRouting:
                 f"target column (left={target_col_left}): {r.path_d}"
             )
 
+    def test_lr_edge_anchors_at_icon_vertical_center_not_full_box_center(
+        self,
+    ) -> None:
+        """Regression test for a real bug found while building showcase
+        diagrams: the icon is drawn 64x64 flush against the top of its
+        wider 120x118 node box (icon + two label lines below it), but
+        route_edges anchored on the *full* box's vertical center
+        (box.y + box.h/2), which sits 27px below the icon's true center —
+        on the icon's bottom edge, not through its middle. Edges must
+        anchor on the icon's own center, derived via `icon_box`."""
+        boxes = {"a": Box(0, 0, 120, 118), "b": Box(200, 0, 120, 118)}
+        spec2 = Spec(
+            title="",
+            direction="LR",
+            provider="generic",
+            nodes=[Node("a", "A"), Node("b", "B")],
+            zones=[],
+            edges=[Edge("a", "b")],
+        )
+        routed = route_edges(spec2, boxes)
+        expected_y = icon_box(boxes["a"]).y + ICON / 2
+        assert expected_y == icon_box(boxes["b"]).y + ICON / 2
+        for tok in routed[0].path_d.replace("M", "L").split("L"):
+            if not tok.strip():
+                continue
+            y = float(tok.split(",")[1])
+            assert y == pytest.approx(expected_y), (
+                f"edge should ride through the icon's vertical center "
+                f"({expected_y}), not the full box's ({boxes['a'].y + boxes['a'].h / 2}): {routed[0].path_d}"
+            )
+
+    def test_tb_edge_anchors_at_icon_horizontal_center_not_full_box_center(
+        self,
+    ) -> None:
+        """TB counterpart: the icon is horizontally centered within the
+        wider node box (to match its centered label), so edges must anchor
+        on that centered x, which happens to coincide with the full box's
+        center too — assert route_edges uses `icon_box`'s x, confirming
+        the LR/TB anchor logic is symmetric on the axis each direction
+        actually needs to get right."""
+        boxes = {"a": Box(0, 0, 120, 118), "b": Box(0, 200, 120, 118)}
+        spec2 = Spec(
+            title="",
+            direction="TB",
+            provider="generic",
+            nodes=[Node("a", "A"), Node("b", "B")],
+            zones=[],
+            edges=[Edge("a", "b")],
+        )
+        routed = route_edges(spec2, boxes)
+        expected_x = icon_box(boxes["a"]).x + ICON / 2
+        for tok in routed[0].path_d.replace("M", "L").split("L"):
+            if not tok.strip():
+                continue
+            x = float(tok.split(",")[0])
+            assert x == pytest.approx(expected_x)
+
 
 class TestEditabilityCheck:
     def test_clean_svg_has_no_violations(self) -> None:
@@ -489,6 +548,28 @@ class TestEndToEndRender:
         vb_m = re.search(r'viewBox="0 0 ([\d.]+) ', result.svg)
         assert width_m and vb_m
         assert float(width_m.group(1)) == pytest.approx(float(vb_m.group(1)))
+
+    def test_node_icon_and_label_share_the_same_horizontal_center(self) -> None:
+        """Regression test for a real bug found while showcasing the
+        tool: the icon rect was drawn flush at the node box's left edge
+        while the label text centered on the full (wider) box, so every
+        label rendered ~28px right of its own icon. Extract the icon
+        rect's true center and the label's x from real SVG output — not
+        just internal layout structs — to catch this even if a future
+        change reintroduces the mismatch through a different code path."""
+        spec = load_spec("nodes:\n  - id: a\n    label: A\n")
+        result = do_render(spec, _icon_lookup)
+        rect_m = re.search(
+            r'<rect x="([\d.]+)" y="([\d.]+)" width="64" height="64" rx="10"',
+            result.svg,
+        )
+        label_m = re.search(
+            r'<text x="([\d.]+)"[^>]*font-weight="600"[^>]*>A<', result.svg
+        )
+        assert rect_m and label_m
+        icon_center_x = float(rect_m.group(1)) + 32
+        label_x = float(label_m.group(1))
+        assert label_x == pytest.approx(icon_center_x)
 
 
 class TestZoneOverlapAssertion:


### PR DESCRIPTION
## Summary

Reported after shipping v2.0.0's showcase examples: arrows connect to one side of each node's box rather than through its center.

## Root cause

The 64x64 icon rect is drawn flush at the node box's top-left corner, but the box itself is 120x118 (icon + two label lines below). `route_edges` computed anchor points from the *full* box's center (`box.y + box.h / 2` for LR, `box.x + box.w / 2` for TB) — 27-28px off the icon's true center, since the icon only occupies the box's top-left 64x64.

Measured on a minimal two-node spec before the fix:

| | Before | After |
|---|---|---|
| LR edge y-anchor | 135 (icon bottom edge) | 108 (icon true center) |
| Source-side edge start gap | 56px dead space before icon's right edge | 0px, flush against it |
| Label x vs icon center x | 92 vs 64 (28px off) | 92 vs 92 (exact) |

The label offset is a separate but same-root-cause symptom: label text centers on the full box width, while the icon it labels didn't.

## Fix

Added `icon_box(box) -> Box` — the single source of truth for "where a node's icon actually is": 64x64, horizontally centered within the wider label-reserving box, flush against its top edge. `route_edges` and `_node_svg`'s icon draw position both now go through it instead of reading `Box` fields directly. Label/sublabel centering already used `box.x + box.w / 2`, which now coincides with the icon's centered x — the icon needed to move, not the label.

## Verification

- **Numeric**: re-extracted real SVG coordinates for both LR and TB single-edge specs — icon center, label x, and edge path coordinates now coincide exactly.
- **Visual**: re-rendered all 4 showcase diagrams (AWS, Azure, GCP, on-prem) — arrows pass through icon centers in every one, no more edge-of-box hugging or asymmetric gaps.
- **Regression tests, mutation-verified**: reverted `icon_box` to an identity function (exactly reproducing the pre-fix anchor math) and confirmed all 3 new tests fail with the precise offsets recorded above, then restored the fix and confirmed they pass.

126 tests total (123 unchanged + 3 new). `ruff check` / `ruff format --check` / `mypy --strict` clean. `evaluate_package.py` unaffected at 100/100. `manifest.yaml` unchanged (no frontmatter touched by this fix).
