### PR TITLE
feat(decision-map): add pre-planning decision map skill

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,6 +16,8 @@ packages:
     category: operations
     difficulty: intermediate
     phase: plan
+    complements:
+    - decision-map
   - name: agent-builder
     version: 1.1.1
     description: 'Build AI agents and automate Claude Code programmatically via the Claude Agent SDK and headless CLI mode.
@@ -317,6 +319,32 @@ packages:
     category: development
     difficulty: intermediate
     phase: build
+  - name: decision-map
+    version: 1.0.0
+    description: 'Maps the unresolved architecture, policy, and scope decisions that must be answered before planning can
+      start: one durable decision ticket per question on the issue tracker, typed and blocker-linked under a parent map, with
+      fog-of-war, out-of-scope, a computed frontier, and one decision resolved per invocation. Triggers on: "map the decisions",
+      "what do we need to decide", "identify the unknowns", "not ready to plan yet", "decision map", "chart this effort",
+      "work the next decision ticket", "wayfinder". Use when the destination is still uncertain. NOT for implementation slices
+      of a known feature, use task-decomposer. NOT for milestone plans, use plan-prompts.'
+    path: skills/decision-map
+    source: https://github.com/Mathews-Tom/armory/blob/main/skills/decision-map/SKILL.md
+    complements:
+    - plan-prompts
+    - task-decomposer
+    - project-context-setup
+    - adr-writer
+    - plan-review
+    tags:
+    - planning
+    - issue-tracker
+    - decisions
+    - discovery
+    - frontier
+    - pre-planning
+    category: development
+    difficulty: advanced
+    phase: define
   - name: dependency-audit
     version: 1.1.1
     description: 'Audits direct and transitive dependencies for license compliance, maintenance health, CVEs, abandoned packages,
@@ -900,6 +928,7 @@ packages:
     - stacked-prs
     - plan-review
     - task-decomposer
+    - decision-map
     tags:
     - planning
     - execution-prompts
@@ -926,6 +955,7 @@ packages:
     category: review
     difficulty: intermediate
     complements:
+    - decision-map
     - plan-prompts
   - name: pr-review
     version: 1.1.1
@@ -994,6 +1024,8 @@ packages:
     category: development
     difficulty: intermediate
     phase: define
+    complements:
+    - decision-map
   - name: prompt-lab
     version: 1.1.1
     description: 'LLM prompt engineering: analyzes failure modes, generates variants (direct, few-shot, CoT), designs rubrics,
@@ -1244,6 +1276,7 @@ packages:
     difficulty: intermediate
     phase: plan
     complements:
+    - decision-map
     - plan-prompts
   - name: tavily
     version: 1.1.1

--- a/skills/decision-map/SKILL.md
+++ b/skills/decision-map/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: decision-map
+description: 'Maps the unresolved architecture, policy, and scope decisions that must be answered before planning can start: one durable decision ticket per question on the issue tracker, typed and blocker-linked under a parent map, with fog-of-war, out-of-scope, a computed frontier, and one decision resolved per invocation. Triggers on: "map the decisions", "what do we need to decide", "identify the unknowns", "not ready to plan yet", "decision map", "chart this effort", "work the next decision ticket", "wayfinder". Use when the destination is still uncertain. NOT for implementation slices of a known feature, use task-decomposer. NOT for milestone plans, use plan-prompts.'
+metadata:
+  version: 1.0.0
+  category: development
+  tags: [planning, issue-tracker, decisions, discovery, frontier, pre-planning]
+  difficulty: advanced
+  phase: define
+  complements:
+    - plan-prompts
+    - task-decomposer
+    - project-context-setup
+    - adr-writer
+    - plan-review
+---
+
+# Decision Map
+
+## Scope and Trigger Boundary
+
+Ask one discriminator before creating anything: **Do we know what should be built?** If no, map unresolved decisions. If yes, route known design into milestones with `plan-prompts` or implementation-sized work with `task-decomposer`. A decision map produces decisions and evidence, never implementation deliverables.
+
+| Situation | Package |
+|---|---|
+| Destination or design still unclear; decisions would have to be invented | `decision-map` |
+| Design known; needs milestones and execution prompts | `plan-prompts` |
+| Feature specified; needs implementation slices, tests, risks | `task-decomposer` |
+| Plan exists; needs a pre-implementation audit | `plan-review` |
+| Plan approved; needs execution across sessions | `milestone-runner` |
+| Repo audit needs standalone remediation plans, optionally as issues | `codebase-advisor --issues` |
+| One decision needs a durable record | `adr-writer` |
+| Session state must survive a handoff | `handoff` |
+
+Do not turn vague hopes into implementation tasks merely to make progress appear orderly. A sharp but currently unanswered question is a ticket. A question that cannot yet be stated sharply is fog.
+
+## Data Model
+
+A map is one parent tracker item with five sections: `Destination`, `Notes`, `Decisions so far`, `Not yet specified`, and `Out of scope`. It is an index, not a duplicate store. A decision exists in exactly one ticket; the map holds only resolution pointers and scope boundaries.
+
+A ticket holds one question, exactly one type label, exactly one interaction label, blockers, visible owner, session claim, and closure state. Refer to maps and tickets by linked title, never a bare identifier. Type labels are `decision-map:discussion`, `decision-map:research`, `decision-map:prototype`, and `decision-map:unblock`. Interaction labels are authoritative: exactly one of `decision-map:hitl` or `decision-map:afk`; ticket bodies must not restate the interaction mode.
+
+## Prerequisites
+
+Use `gh --version` and require `gh` 2.96.0 or newer for native GitHub relationships. Verify authentication with `gh auth status`. `frontier.py` requires Python 3.12 and only the standard library. `docs/agents/issue-tracker.md`, when present, is the authoritative backend choice. Otherwise choose GitHub only when a GitHub remote exists and `gh auth status` succeeds; choose local markdown in every other case. Report the selected backend once and mention `project-context-setup` when the choice should be persisted.
+
+Probe GitHub capability before using native relationships. When older GitHub Enterprise or an older CLI rejects `blockedBy`, take the degraded path: generated child links in the map and `Blocked by: #N` lines in ticket bodies. The degraded index exists only to emulate absent tracker relationships.
+
+## Workflow
+
+### Mode A — Chart the Map
+
+1. Name the destination before discussing its route. Use one concrete either-or question at a time and reuse the effort's vocabulary.
+2. Sweep breadth-first for policy, architecture, scope, evidence, access, and design questions. If no fog surfaces, stop: the effort needs no decision map.
+3. Ensure labels and the selected backend schema exist. Create the map with all five sections.
+4. Create every question already sharp enough to ticket. Give every ticket exactly one type label and exactly one interaction label.
+5. Wire blocker edges only after ticket creation, because the backend needs ticket identifiers before it can connect them.
+6. Put the remaining unformulated uncertainty in `Not yet specified`; record conscious exclusions with a reason in `Out of scope`.
+7. Compute the frontier and map state with `frontier.py`; report created topology and stop.
+
+Charting resolves nothing, runs no research, implements nothing, and never collapses uncertainty to look tidy. Report the AFK-ready frontier separately: those tickets may be advanced by that many independent `work` invocations, each resolving at most one ticket.
+
+### Mode B — Work Through the Map
+
+1. Load only the map body, select the requested frontier ticket or the first item returned by `frontier.py`, and establish visible ownership.
+2. Acquire and verify the session claim before substantive work. Follow `references/claim-protocol.md`; do not infer exclusivity from assignment.
+3. Resolve exactly one ticket by its type. A HITL ticket requires the human's judgment; an agent answering it alone has broken the ticket.
+4. Record one closure path: `RESOLVED`, `OUT_OF_SCOPE`, or `INVALIDATED`. Write the decision or evidence in the ticket, close it with the matching backend path, and add only a pointer in `Decisions so far` or `Out of scope`.
+5. Create newly surfaced sharp questions, graduate them out of fog, and remove only the graduated fog patch. Recompute frontier and state.
+6. Report and stop without selecting another ticket.
+
+`unblock` work is restricted to evidence, access, measurement, setup, or a minimal experiment that makes a decision answerable. It never implements a product feature.
+
+## Output
+
+### Chart Output
+
+Report map title and identifier, tickets with type and interaction labels, blocker edges, current frontier, remaining fog, computed map state, and the stop condition. Include the AFK-ready frontier count and state that each item requires a separate `work` invocation.
+
+### Work Output
+
+Report the resolved ticket, closure path, recorded decision or evidence, new tickets, changed blocker edges, resulting frontier, state, and stop condition. When the state is `COMPLETE`, recommend `plan-prompts` for implementation planning. Do not create an inline plan.
+
+## Claim Protocol
+
+Visible ownership and session claim are separate requirements. On GitHub, a claim comment begins with `decision-map claim`, includes `session:` and `claimed-at:`, and is re-read before work. The lowest non-stale database comment identifier, encoded in the issue-comment URL, wins. A loser withdraws, removes its assignee if it added one, recomputes the frontier, and selects another ticket. A claim older than the map's configured TTL, default 24 hours, can be preempted with a recorded reason.
+
+Local maps use an exclusive claims lock. See `references/claim-protocol.md` for exact arbitration, stale-claim, and release rules.
+
+## Map States
+
+An empty frontier does not mean completion. Evaluate the ordered ladder: actionable unclaimed ticket means `ACTIVE`; otherwise any claimed open ticket means `WAITING`; otherwise any open ticket means `BLOCKED`; otherwise non-empty fog means `FOGGY`; otherwise no open tickets, no fog, and no `Unresolved contradiction:` entry in `Notes` means `COMPLETE`.
+
+## Error Handling and Troubleshooting
+
+| Failure | Diagnose | Corrective action |
+|---|---|---|
+| Tracker document absent | inspect `docs/agents/issue-tracker.md` | use the backend ladder and report it |
+| Native relationship unsupported | `gh issue view <map> --json blockedBy` | use degraded generated links and body blockers |
+| Label schema absent | `gh label list` | bootstrap labels idempotently before ticket creation |
+| Two sessions claim one ticket | re-read comments and database comment identifiers | lowest fresh identifier wins; loser withdraws |
+| Claim belongs to dead session | compare timestamp to map TTL | record preemption, then claim |
+| Empty frontier with open tickets | run `frontier.py` | report `WAITING` or `BLOCKED`, never complete |
+| Map and tickets drift | inspect map pointers and backend graph | repair generated degraded index or resolution pointers |
+| Malformed local claim lock | inspect the lock contents | stop; preserve it for diagnosis rather than overwriting it |
+
+Fail loudly when the map label is absent, a ticket has missing or multiple type or interaction labels, the capability probe is ambiguous, or claim verification fails. Do not silently create a replacement map.
+
+## Rationalizations
+
+Reject these statements:
+
+- “I'll resolve two; they are small.” One invocation resolves one ticket.
+- “I'll pre-slice fog while I am here.” Fog is deliberately not a task list.
+- “I know the answer, so no human is needed.” That violates a HITL ticket.
+- “I'll just build it; it is faster.” Implementation is outside this package.
+- “The frontier is empty, so we are done.” The state ladder decides that.
+
+## Red Flags
+
+Bare issue numbers in narration, maps that repeat ticket content, sharp questions left in fog, closed tickets without resolution comments, scope boundaries listed as decisions, or substantive work before claim verification all signal a broken map.
+
+## Verification
+
+Confirm all five map sections exist; every open ticket is a child of the map and has exactly one type and interaction label; every blocker edge is native or documented as degraded; ownership and claim were verified before substantive action; each closure used one valid path and reached the correct map section; and the reported state matches `frontier.py`.
+
+```bash
+uv run python skills/decision-map/scripts/frontier.py --map 42
+uv run python skills/decision-map/scripts/frontier.py --map 42 --degraded
+uv run python skills/decision-map/scripts/frontier.py --local .scratch/billing
+```
+
+## References
+
+| Reference | Purpose |
+|---|---|
+| `references/map-format.md` | Map schema, template, and index rules |
+| `references/ticket-types.md` | Types, labels, and closure boundaries |
+| `references/claim-protocol.md` | GitHub arbitration and local exclusion |
+| `references/map-states.md` | Ordered state ladder |
+| `references/tracker-operations.md` | GitHub, degraded, and local backend operations |
+| `references/elicitation.md` | Discovery questions and vocabulary discipline |
+| `references/research-resolution.md` | Self-contained AFK research protocol |
+| `scripts/frontier.py` | Normalized frontier and state computation |

--- a/skills/decision-map/evals/cases.yaml
+++ b/skills/decision-map/evals/cases.yaml
@@ -1,0 +1,64 @@
+cases:
+  - id: map_unresolved_sso_decisions
+    prompt: "We want organization SSO but still have major design choices — map what we need to decide."
+    fixtures: []
+    rubric:
+      - "Creates a decision map rather than implementation tasks"
+      - "Identifies unresolved questions, fog, ticket types, interaction labels, and blocker edges"
+      - "Stops after charting topology without resolving a ticket"
+    trigger_expected: true
+    assertions:
+      - type: contains
+        target: "decision-map"
+        weight: 1.0
+  - id: map_before_architecture_plan
+    prompt: "Before creating a plan, identify all unresolved architecture questions."
+    fixtures: []
+    rubric:
+      - "Routes pre-planning uncertainty to a decision map"
+      - "Preserves fog instead of inventing milestones"
+    trigger_expected: true
+  - id: work_next_unblocked_ticket
+    prompt: "Work through the map, take the next unblocked ticket."
+    fixtures: []
+    rubric:
+      - "Claims and verifies one frontier ticket before substantive work"
+      - "Resolves at most one ticket and reports the resulting state"
+    trigger_expected: true
+  - id: inspect_auth_map_frontier
+    prompt: "What's on the frontier of the auth map?"
+    fixtures: []
+    rubric:
+      - "Computes actionable unclaimed tickets and map state"
+      - "Does not advance or resolve a ticket"
+    trigger_expected: true
+  - id: known_design_to_milestones
+    prompt: "The architecture doc is signed off — turn it into DEVELOPMENT_PLAN.md and EXECUTION_PROMPTS.md."
+    fixtures: []
+    rubric:
+      - "Does not activate; a known design needing milestones belongs to plan-prompts"
+    trigger_expected: false
+  - id: specified_feature_to_tasks
+    prompt: "The architecture is final. Break this checkout feature into PR-sized tasks with a test matrix."
+    fixtures: []
+    rubric:
+      - "Does not activate; specified feature work belongs to task-decomposer"
+    trigger_expected: false
+  - id: execute_existing_milestones
+    prompt: "Run milestone M4 and merge the stack."
+    fixtures: []
+    rubric:
+      - "Does not activate; executing approved milestones belongs to milestone-runner"
+    trigger_expected: false
+  - id: review_existing_plan
+    prompt: "Review this development plan for flaws."
+    fixtures: []
+    rubric:
+      - "Does not activate; existing plans belong to plan-review"
+    trigger_expected: false
+  - id: audit_to_plan_issues
+    prompt: "Audit the repo and publish each remediation plan as a GitHub issue."
+    fixtures: []
+    rubric:
+      - "Does not activate; audit remediation planning belongs to codebase-advisor --issues"
+    trigger_expected: false

--- a/skills/decision-map/references/claim-protocol.md
+++ b/skills/decision-map/references/claim-protocol.md
@@ -1,0 +1,23 @@
+# Claim Protocol
+
+```text
+Owner        = visible tracker ownership
+SessionClaim = concurrency arbitration
+```
+
+A ticket requires both visible ownership and an uncontested session claim before substantive work. Assignment alone is not exclusive because multiple sessions can share the same GitHub identity.
+
+## GitHub arbitration
+
+1. Select one frontier ticket.
+2. Add visible ownership with `gh issue edit N --add-assignee @me`.
+3. Post a comment whose first line is `decision-map claim`, followed by `session: <id>` and `claimed-at: <ISO-8601>`.
+4. Re-read comments and assignees with `gh issue view N --json comments,assignees`.
+5. Ignore malformed and stale claim comments. Derive the database comment identifier from the `#issuecomment-N` suffix of the comment URL; the lowest remaining database identifier wins because it is server-assigned and monotonic.
+6. The winner works. The loser posts a one-line withdrawal, removes its own assignee when it added one, recomputes the frontier, and chooses another ticket.
+
+This is advisory ownership plus optimistic arbitration, not a lock. A claim older than 24 hours, or the `Claim TTL` configured in map Notes, is stale. A successor can preempt it only by recording the stale session identifier and the preemption reason in its claim comment.
+
+## Local exclusion
+
+Write the complete session identifier and timestamp to a private temporary file, then atomically link it to `.scratch/<effort>/claims/<ticket>.lock`. The link is exclusive: a second creator fails rather than arbitrating, and the visible lock is always complete. Apply the same TTL before a documented stale-lock preemption and remove the lock when resolution is recorded.

--- a/skills/decision-map/references/elicitation.md
+++ b/skills/decision-map/references/elicitation.md
@@ -1,0 +1,7 @@
+# Elicitation
+
+Name the destination before the route. Ask one concrete question at a time; prefer a constrained either-or choice to a broad prompt when the relevant alternatives are known. Capture the effort's vocabulary and reuse it in map and ticket titles.
+
+Charting is breadth-first: inspect policy, architecture, scope, evidence, access, and behavior without attempting resolution. Working is depth-first: resolve only the selected ticket. Stop asking when the next answer would require implementation rather than human judgment or evidence.
+
+A HITL ticket is a question for a human with authority or context. An agent must not answer it on the human's behalf. Use `devils-advocate` for adversarial pressure when useful and `adr-writer` when a resolution merits a durable decision record.

--- a/skills/decision-map/references/map-format.md
+++ b/skills/decision-map/references/map-format.md
@@ -1,0 +1,26 @@
+# Map Format
+
+A decision map is a tracker parent and an index of resolved decisions. It never stores a ticket's question, evidence, or resolution text. Open tickets are discovered from tracker relationships rather than copied into the map.
+
+```markdown
+# Decision Map — Billing migration
+
+## Destination
+Choose a safe billing migration approach that preserves subscriptions and reporting.
+
+## Notes
+Claim TTL: 24h. The migration must retain auditability. `Unresolved contradiction:` is absent.
+
+## Decisions so far
+- [Payment history retention](https://example.invalid/issues/12) — retain immutable ledger rows.
+
+## Not yet specified
+- Whether regulatory retention differs by region.
+
+## Out of scope
+- [Tax engine replacement](https://example.invalid/issues/9) — separate programme; it does not unblock this migration.
+```
+
+`Not yet specified` contains only questions that cannot yet be phrased precisely. Remove a patch when it becomes a ticket, decision, or deliberate scope boundary. `Out of scope` contains a reason and a link to a closed ticket; it never appears in `Decisions so far` because a boundary is not progress on the route.
+
+Native tracker mode keeps no child index in the map. A degraded backend maintains a `## Generated child index` section solely to emulate missing parent-child relationships; parse child identifiers only from that section, mark it generated, and do not add decision content to it.

--- a/skills/decision-map/references/map-states.md
+++ b/skills/decision-map/references/map-states.md
@@ -1,0 +1,13 @@
+# Map States
+
+Evaluate these conditions in order. `frontier.py` computes and prints the selected state.
+
+| Order | State | Condition | Meaning |
+|---|---|---|---|
+| 1 | `ACTIVE` | frontier is non-empty | Actionable decision available now |
+| 2 | `WAITING` | open tickets exist and any is claimed | Actionable work is in flight elsewhere |
+| 3 | `BLOCKED` | open tickets exist, none actionable or claimed | Every path has an unresolved blocker |
+| 4 | `FOGGY` | no open tickets and fog remains | Unspecified questions remain |
+| 5 | `COMPLETE` | no open tickets, no fog, and no `Unresolved contradiction:` entry in map Notes | Hand off to `plan-prompts` |
+
+The key invariant is `frontier empty != map complete`. The order resolves overlap: when one ticket is claimed and another is blocked, `WAITING` outranks `BLOCKED`. `COMPLETE` is only a recommendation to begin implementation planning; it does not produce a plan.

--- a/skills/decision-map/references/research-resolution.md
+++ b/skills/decision-map/references/research-resolution.md
@@ -1,0 +1,12 @@
+# Research Resolution
+
+An AFK research ticket resolves a fact the decision waits on, not a recommendation disguised as research.
+
+1. State the precise fact that blocks the decision.
+2. Identify authoritative sources appropriate to that fact.
+3. Gather evidence with citations and preserve source links.
+4. Record confidence, limits, and contradictions.
+5. Write findings to one linked artifact; never paste the findings into the ticket.
+6. Close the ticket with the fact learned, artifact link, and closure path.
+
+When `agents/research-analyst` is installed, dispatch it as an optional accelerator. This protocol remains the correctness baseline, including when that agent is unavailable.

--- a/skills/decision-map/references/ticket-types.md
+++ b/skills/decision-map/references/ticket-types.md
@@ -1,0 +1,21 @@
+# Ticket Types
+
+Every ticket body contains only its question. Type and interaction are labels, not body metadata.
+
+```markdown
+## Question
+Which immutable record layout preserves subscription history through the migration?
+```
+
+| Type | Label | Typical interaction | Resolution path |
+|---|---|---|---|
+| `discussion` | `decision-map:discussion` | HITL | Ask the human using `references/elicitation.md`. |
+| `research` | `decision-map:research` | AFK | Use `references/research-resolution.md`; link findings. |
+| `prototype` | `decision-map:prototype` | HITL | Link a cheap outline, stub, or sketch artifact. |
+| `unblock` | `decision-map:unblock` | Either | Produce minimal evidence, access, measurement, setup, or experiment. |
+
+Interaction is exactly one authoritative label: `decision-map:hitl` or `decision-map:afk`. Never repeat it in the body.
+
+An `unblock` ticket exists only to make a decision answerable. Good: obtain sandbox credentials to evaluate authentication approaches; measure table cardinality before selecting a migration method. Bad: implement OAuth login; build the database migration. Feature implementation belongs outside a decision map.
+
+Ticket a question once it is sharp, even when another ticket blocks its answer. Keep it in fog only when the question cannot yet be stated precisely. Never pre-slice fog into speculative work.

--- a/skills/decision-map/references/tracker-operations.md
+++ b/skills/decision-map/references/tracker-operations.md
@@ -1,0 +1,38 @@
+# Tracker Operations
+
+Use nine operations: 0 ensure schema, 1 create map, 2 create ticket, 3 set type and interaction labels, 4 establish parent-child, 5 add blocker edge, 6 query frontier and state, 7 claim, 8 resolve.
+
+## GitHub native path
+
+```bash
+# 0 — idempotent schema bootstrap
+gh label create decision-map:map        --force --color 0E8A16 --description "Decision map root"
+gh label create decision-map:discussion --force --color 1D76DB
+gh label create decision-map:research   --force --color 5319E7
+gh label create decision-map:prototype  --force --color FBCA04
+gh label create decision-map:unblock    --force --color D93F0B
+gh label create decision-map:hitl       --force --color 0052CC
+gh label create decision-map:afk        --force --color 006B75
+
+# 1/2/4 — map and children
+gh issue create --title "<name>" --label decision-map:map --body-file map.md
+gh issue create --title "<question>" --parent <map-number> --label decision-map:discussion --label decision-map:hitl --body-file ticket.md
+
+# 5 — blockers after tickets exist
+gh issue edit <child-number> --add-blocked-by <blocker-number>
+
+# 7/8 — visible ownership and closure
+gh issue edit <number> --add-assignee @me
+gh issue close <number> --reason completed
+gh issue close <number> --reason "not planned"
+```
+
+Before native reads, probe once with `gh issue view <map-number> --json blockedBy`. On an unknown-field error, choose degraded mode. Native reads request `parent` and `blockedBy`; degraded reads request only portable issue fields, generated children from `## Generated child index`, and body blockers. Do not use GraphQL.
+
+## Degraded path
+
+Use a generated task list in the map for children and `Blocked by: #N` body lines for dependencies. Parse them only with `frontier.py --degraded`. This fallback is for missing capability, not a second source of truth on native GitHub.
+
+## Local path
+
+Store `.scratch/<effort>/map.md`, one numbered child file with `Type:`, `Interaction:`, `Status:`, and `Blocked by:` headers, and a `claims/` directory. Write resolution pointers back to the map. Backend selection is: obey `docs/agents/issue-tracker.md`; otherwise GitHub remote plus working `gh auth`; otherwise local markdown. Report the choice and suggest `project-context-setup` when it should become repo policy.

--- a/skills/decision-map/references/upstream/LICENSE
+++ b/skills/decision-map/references/upstream/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/decision-map/references/upstream/provenance.md
+++ b/skills/decision-map/references/upstream/provenance.md
@@ -1,0 +1,39 @@
+# Upstream Provenance
+
+## Source
+
+- Repository: https://github.com/mattpocock/skills
+- Pinned commit: `068b6e0c62393147daf03530149cdce209c93da8`, obtained with `git rev-parse HEAD` from a fresh clone on 2026-08-16.
+- License: MIT.
+- Copyright holder: Copyright (c) 2026 Matt Pocock.
+
+## What was vendored
+
+- `skills/engineering/wayfinder/SKILL.md`.
+- The GitHub and local tracker-operation sections from `skills/engineering/setup-matt-pocock-skills/issue-tracker-github.md` and `skills/engineering/setup-matt-pocock-skills/issue-tracker-local.md`.
+
+## What was adapted
+
+- Renamed the package from `wayfinder` to `decision-map` because armory package names and descriptions must expose the triggerable outcome.
+- Replaced the `wayfinder:*` label namespace with `decision-map:*` to avoid importing an upstream-specific namespace.
+- Renamed `grilling` to `discussion` and `task` to `unblock` because the target catalog has no corresponding sibling and task decomposition is a distinct downstream concern.
+- Promoted interaction mode to authoritative labels so the tracker can query it without a second body-metadata source of truth.
+- Replaced assignee-as-claim with visible ownership plus arbitrated session claims because shared GitHub identities cannot provide exclusive ownership.
+- Moved research dispatch out of charting so charting changes topology without resolving tickets.
+- Added a five-state map model to prevent empty-frontier false completion.
+- Rejected GraphQL in favour of native `gh` relationship flags available in the verified CLI.
+- Rewrote frontmatter for armory metadata and trigger routing.
+- Split operational detail into local references so the package is self-contained.
+- Replaced absent sibling pointers with in-package elicitation and research guidance, an inlined prototype instruction, and `project-context-setup` guidance.
+- Added explicit trigger boundaries against `plan-prompts`, `task-decomposer`, and `milestone-runner` to prevent planning-surface collisions.
+
+## What was skipped
+
+- `agents/openai.yaml` because it is upstream harness metadata.
+- The GitLab adapter because armory has no GitLab operating surface.
+- `grill-with-docs`, `triage-labels.md`, `to-tickets`, and `to-spec` because they are not required for this package's self-contained contract.
+- Newsletter, donation, installer, and marketing content because it is not operational guidance.
+
+## Re-sync policy
+
+Do not auto-sync. Compare future upstream changes against the pinned commit, preserve the license, and re-run armory validation before adopting any change.


### PR DESCRIPTION
## Summary

Adds the `decision-map` pre-planning discovery skill. It maps unresolved decisions into a tracker-backed topology, preserves fog, enforces one decision per invocation, and routes known design work downstream without implementation planning.

## Stack

Stack-Id: `decision-map-20260816`  
Base: `main`  
Position: 1/5

1. `feat/decision-map-skill` → this PR
2. `feat/decision-map-tooling` → planned
3. `feat/decision-map-command` → planned
4. `test/decision-map-routing` → planned
5. `docs/decision-map-lifecycle` → planned

Depends on: none  
Upstack: planned `feat/decision-map-tooling`

## Skill Evaluator Results

```text
Package: decision-map (skill)
  D1 Frontmatter Quality:            20/20
  D2 Trigger Coverage:               18/18
  D3 Structural Completeness:        20/20
  D4 Content Depth:                  22/22
  D5 Consistency:                    12/12
  D6 Compliance:                       8/8
  Overall:                          100/100 (100%)
  Status: PASS

Summary: 1 packages evaluated, 1 passed, 0 failed
```

## Validation

```text
uv run python scripts/validate_frontmatter.py  PASS
uv run python scripts/validate_references.py   PASS
uv run python scripts/validate_evals.py        PASS
uv run python scripts/evaluate_package.py --path skills/decision-map --threshold 70  PASS (100%)
uv run scripts/generate_manifest.py            regenerated manifest.yaml
```

## Checklist

- [x] `SKILL.md` has valid YAML frontmatter with `name` and `description`
- [x] Skill name is kebab-case, under 64 characters
- [x] Description is 200-1024 characters with trigger phrases and "Use when" clause
- [x] No angle brackets or pushy language in description
- [x] No secrets, credentials, or internal URLs in any file
- [x] All file references in `SKILL.md` resolve to existing files
- [x] Skill evaluator score is 70% or above
- [x] No CRITICAL or HIGH findings from skill evaluator
