### PR TITLE
feat(decision-map): add frontier, state and claim tooling

### DIFF
--- a/skills/decision-map/scripts/frontier.py
+++ b/skills/decision-map/scripts/frontier.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Compute a decision-map frontier from GitHub or local tracker data.
+
+The adapters normalize external tracker shapes. Frontier and state computation below
+that boundary are pure functions over ``Ticket`` instances, so tests do not need a
+network connection or a GitHub CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+TYPE_LABELS: frozenset[str] = frozenset(
+    {
+        "decision-map:discussion",
+        "decision-map:research",
+        "decision-map:prototype",
+        "decision-map:unblock",
+    }
+)
+INTERACTION_LABELS: frozenset[str] = frozenset(
+    {"decision-map:hitl", "decision-map:afk"}
+)
+_CLAIM_FIRST_LINE = "decision-map claim"
+_CLAIM_FIELD = re.compile(r"^(session|claimed-at):\s*(.+?)\s*$", re.MULTILINE)
+_BLOCKED_BY = re.compile(r"^Blocked by:\s*((?:#\d+(?:\s*,\s*)?)*)\s*$", re.MULTILINE)
+_CHILD_REFERENCE = re.compile(r"#(\d+)")
+_ISSUE_COMMENT_ID = re.compile(r"#issuecomment-(\d+)$")
+_LOCAL_HEADER = re.compile(r"^(Type|Interaction|Status|Blocked by):\s*(.*?)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A valid, non-arbitrated claim comment."""
+
+    comment_id: int
+    session: str
+    claimed_at: datetime
+
+
+@dataclass(frozen=True)
+class Ticket:
+    """Backend-neutral state for one decision ticket."""
+
+    number: int
+    title: str
+    open: bool
+    type: str
+    interaction: str
+    blocker_numbers: tuple[int, ...]
+    owner: str | None
+    claim: Claim | None
+
+    @property
+    def claimed(self) -> bool:
+        return self.claim is not None
+
+
+def parse_claims(
+    comments: Iterable[dict[str, Any]],
+    *,
+    now: datetime,
+    ttl: timedelta = timedelta(hours=24),
+) -> tuple[Claim, ...]:
+    """Return syntactically valid, fresh claims sorted by server comment id."""
+
+    claims: list[Claim] = []
+    for comment in comments:
+        body = comment.get("body")
+        comment_id = _database_comment_id(comment)
+        if not isinstance(body, str) or comment_id is None:
+            continue
+        if body.splitlines()[:1] != [_CLAIM_FIRST_LINE]:
+            continue
+        fields = {name: value for name, value in _CLAIM_FIELD.findall(body)}
+        session = fields.get("session")
+        raw_timestamp = fields.get("claimed-at")
+        if not session or not raw_timestamp:
+            continue
+        try:
+            claimed_at = _parse_timestamp(raw_timestamp)
+        except ValueError:
+            continue
+        if now - claimed_at > ttl:
+            continue
+        claims.append(Claim(comment_id, session, claimed_at))
+    return tuple(sorted(claims, key=lambda claim: claim.comment_id))
+
+
+def winning_claim(
+    comments: Iterable[dict[str, Any]],
+    *,
+    now: datetime,
+    ttl: timedelta = timedelta(hours=24),
+) -> Claim | None:
+    """Return the lowest-id fresh claim, which is the deterministic winner."""
+
+    claims = parse_claims(comments, now=now, ttl=ttl)
+    return claims[0] if claims else None
+
+
+def normalize_github_issues(
+    issues: Iterable[dict[str, Any]],
+    *,
+    map_number: int,
+    now: datetime,
+    degraded: bool = False,
+) -> tuple[Ticket, ...]:
+    """Normalize GitHub issue JSON without invoking GitHub.
+
+    Native mode selects issues whose parent is the requested map. Degraded mode
+    selects numbers listed in the map body's generated child index and derives
+    blockers from ``Blocked by: #N`` ticket-body lines.
+    """
+
+    materialized = tuple(issues)
+    map_issue = next(
+        (
+            issue
+            for issue in materialized
+            if isinstance(issue.get("number"), int) and issue["number"] == map_number
+        ),
+        None,
+    )
+    degraded_children = (
+        frozenset(_CHILD_REFERENCE.findall(str(map_issue.get("body", ""))))
+        if degraded and map_issue is not None
+        else frozenset()
+    )
+    tickets: list[Ticket] = []
+    for issue in materialized:
+        number = issue.get("number")
+        if not isinstance(number, int) or number == map_number:
+            continue
+        if degraded:
+            selected = str(number) in degraded_children
+        else:
+            parent = issue.get("parent")
+            selected = isinstance(parent, dict) and parent.get("number") == map_number
+        if not selected:
+            continue
+        tickets.append(_normalize_issue(issue, now=now, degraded=degraded))
+    return tuple(tickets)
+
+
+def normalize_local_map(root: Path, *, now: datetime) -> tuple[tuple[Ticket, ...], str]:
+    """Normalize local map files and their O_EXCL claim locks."""
+
+    map_path = root / "map.md"
+    if not map_path.is_file():
+        raise FileNotFoundError(f"Local map is missing: {map_path}")
+    fog = _section_text(map_path.read_text(encoding="utf-8"), "Not yet specified")
+    tickets: list[Ticket] = []
+    for path in sorted(root.glob("*.md")):
+        if path.name == "map.md":
+            continue
+        text = path.read_text(encoding="utf-8")
+        fields = {name: value for name, value in _LOCAL_HEADER.findall(text)}
+        number = _ticket_number(path)
+        ticket_type = fields.get("Type")
+        interaction = fields.get("Interaction")
+        status = fields.get("Status")
+        if ticket_type not in TYPE_LABELS:
+            raise ValueError(f"{path}: expected exactly one decision-map type")
+        if interaction not in INTERACTION_LABELS:
+            raise ValueError(f"{path}: expected exactly one decision-map interaction")
+        if status is None:
+            raise ValueError(f"{path}: missing Status header")
+        blockers = tuple(int(value) for value in _CHILD_REFERENCE.findall(fields.get("Blocked by", "")))
+        lock = _read_local_claim(root / "claims" / f"{number}.lock", now=now)
+        title = _title_from_text(text, fallback=path.stem)
+        tickets.append(
+            Ticket(
+                number=number,
+                title=title,
+                open=status.strip().upper() == "OPEN",
+                type=ticket_type,
+                interaction=interaction,
+                blocker_numbers=blockers,
+                owner=None,
+                claim=lock,
+            )
+        )
+    return tuple(tickets), fog
+
+
+def compute_frontier(tickets: Sequence[Ticket], *, afk_only: bool = False) -> tuple[Ticket, ...]:
+    """Return open, unclaimed tickets with no open blockers in input order."""
+
+    by_number = {ticket.number: ticket for ticket in tickets}
+    frontier: list[Ticket] = []
+    for ticket in tickets:
+        if not ticket.open or ticket.claimed:
+            continue
+        if afk_only and ticket.interaction != "decision-map:afk":
+            continue
+        if any(by_number.get(blocker, _closed_ticket(blocker)).open for blocker in ticket.blocker_numbers):
+            continue
+        frontier.append(ticket)
+    return tuple(frontier)
+
+
+def compute_state(
+    tickets: Sequence[Ticket],
+    *,
+    fog: str,
+    unresolved_contradiction: bool = False,
+) -> str:
+    """Compute the ordered five-state map ladder.
+
+    A map-level contradiction outside the five modeled states is an error, not a
+    silent COMPLETE result.
+    """
+
+    if compute_frontier(tickets):
+        return "ACTIVE"
+    open_tickets = tuple(ticket for ticket in tickets if ticket.open)
+    if open_tickets and any(ticket.claimed for ticket in open_tickets):
+        return "WAITING"
+    if open_tickets:
+        return "BLOCKED"
+    if fog.strip():
+        return "FOGGY"
+    if unresolved_contradiction:
+        raise ValueError("Map has an unresolved contradiction and cannot be COMPLETE")
+    return "COMPLETE"
+
+
+def acquire_local_claim(
+    claims_dir: Path,
+    ticket_number: int,
+    *,
+    session: str,
+    now: datetime,
+    ttl: timedelta = timedelta(hours=24),
+) -> Claim:
+    """Create an exclusive local lock, preempting only a documented stale lock."""
+
+    claims_dir.mkdir(parents=True, exist_ok=True)
+    path = claims_dir / f"{ticket_number}.lock"
+    existing = _read_local_claim(path, now=now, ttl=ttl)
+    if existing is not None:
+        raise FileExistsError(f"Ticket {ticket_number} already has a fresh local claim")
+    if path.exists():
+        path.unlink()
+    payload = f"session: {session}\nclaimed-at: {now.isoformat()}\n"
+    descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        os.write(descriptor, payload.encode("utf-8"))
+    finally:
+        os.close(descriptor)
+    return Claim(ticket_number, session, now)
+
+
+def release_local_claim(claims_dir: Path, ticket_number: int) -> None:
+    """Release a local lock after its ticket resolution is recorded."""
+
+    (claims_dir / f"{ticket_number}.lock").unlink()
+
+
+def format_report(tickets: Sequence[Ticket], *, fog: str, afk_only: bool = False) -> str:
+    """Format frontier entries and a non-silent empty-frontier explanation."""
+
+    frontier = compute_frontier(tickets, afk_only=afk_only)
+    state = compute_state(tickets, fog=fog)
+    lines = [
+        f"#{ticket.number} — {ticket.title} [{ticket.type.removeprefix('decision-map:')}/{ticket.interaction.removeprefix('decision-map:')}]"
+        for ticket in frontier
+    ]
+    if not lines:
+        unfiltered_frontier = compute_frontier(tickets)
+        open_tickets = tuple(ticket for ticket in tickets if ticket.open)
+        if afk_only and unfiltered_frontier:
+            hitl_count = sum(
+                ticket.interaction == "decision-map:hitl"
+                for ticket in unfiltered_frontier
+            )
+            lines.append(
+                f"frontier: empty — no AFK-ready tickets; {hitl_count} HITL tickets are actionable"
+            )
+        elif open_tickets and any(ticket.claimed for ticket in open_tickets):
+            lines.append("frontier: empty — all actionable tickets are claimed or blocked")
+        elif open_tickets:
+            lines.append("frontier: empty — all open tickets are blocked")
+        elif fog.strip():
+            lines.append("frontier: empty — no open tickets; fog remains")
+        else:
+            lines.append("frontier: empty — no open tickets or fog remain")
+    lines.append(f"state: {state}")
+    return "\n".join(lines)
+
+
+def _normalize_issue(issue: dict[str, Any], *, now: datetime, degraded: bool) -> Ticket:
+    labels: set[str] = set()
+    for label in issue.get("labels", []):
+        if isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                labels.add(name)
+    types = sorted(labels & TYPE_LABELS)
+    interactions = sorted(labels & INTERACTION_LABELS)
+    number = issue.get("number")
+    title = issue.get("title")
+    if not isinstance(number, int) or not isinstance(title, str):
+        raise ValueError("Issue requires integer number and string title")
+    if len(types) != 1:
+        raise ValueError(f"#{number}: expected exactly one decision-map type label")
+    if len(interactions) != 1:
+        raise ValueError(f"#{number}: expected exactly one decision-map interaction label")
+    if degraded:
+        blockers = tuple(int(value) for value in _CHILD_REFERENCE.findall(_blocked_by_body(issue)))
+    else:
+        blockers = tuple(
+            blocker["number"]
+            for blocker in issue.get("blockedBy", [])
+            if isinstance(blocker, dict) and isinstance(blocker.get("number"), int)
+        )
+    assignees = issue.get("assignees", [])
+    owner = next(
+        (
+            assignee.get("login")
+            for assignee in assignees
+            if isinstance(assignee, dict) and isinstance(assignee.get("login"), str)
+        ),
+        None,
+    )
+    state = issue.get("state")
+    if not isinstance(state, str):
+        raise ValueError(f"#{number}: missing state")
+    return Ticket(
+        number=number,
+        title=title,
+        open=state.upper() == "OPEN",
+        type=types[0],
+        interaction=interactions[0],
+        blocker_numbers=blockers,
+        owner=owner,
+        claim=winning_claim(issue.get("comments", []), now=now),
+    )
+
+
+def _run_gh(arguments: Sequence[str]) -> Any:
+    completed = subprocess.run(["gh", *arguments], capture_output=True, text=True)
+    if completed.returncode:
+        raise RuntimeError(
+            f"gh {' '.join(arguments)} failed: {completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"gh {' '.join(arguments)} returned invalid JSON") from error
+
+
+def _read_github_map(map_number: int, *, degraded: bool) -> tuple[tuple[Ticket, ...], str]:
+    map_issue = _run_gh(["issue", "view", str(map_number), "--json", "number,title,body"])
+    if not degraded:
+        probe = subprocess.run(
+            ["gh", "issue", "view", str(map_number), "--json", "blockedBy"],
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0:
+            degraded = True
+    fields = ["number", "title", "state", "assignees", "labels", "comments", "body"]
+    if not degraded:
+        fields.extend(["parent", "blockedBy"])
+    issues = _run_gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "1000",
+            "--json",
+            ",".join(fields),
+        ]
+    )
+    materialized = (map_issue, *issues)
+    now = datetime.now(UTC)
+    return (
+        normalize_github_issues(
+            materialized, map_number=map_number, now=now, degraded=degraded
+        ),
+        _section_text(str(map_issue.get("body", "")), "Not yet specified"),
+    )
+
+
+def _database_comment_id(comment: dict[str, Any]) -> int | None:
+    """Return GitHub's monotonic database comment id from a comment URL."""
+
+    url = comment.get("url")
+    if isinstance(url, str):
+        match = _ISSUE_COMMENT_ID.search(url)
+        if match is not None:
+            return int(match.group(1))
+    legacy_id = comment.get("id")
+    return legacy_id if isinstance(legacy_id, int) else None
+
+
+def _parse_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone")
+    return parsed.astimezone(UTC)
+
+
+def _blocked_by_body(issue: dict[str, Any]) -> str:
+    match = _BLOCKED_BY.search(str(issue.get("body", "")))
+    return match.group(1) if match else ""
+
+
+def _section_text(text: str, title: str) -> str:
+    match = re.search(
+        rf"^##\s+{re.escape(title)}\s*$\n(.*?)(?=^##\s+|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def _ticket_number(path: Path) -> int:
+    match = re.match(r"(\d+)-", path.name)
+    if match is None:
+        raise ValueError(f"Ticket file must start with a number: {path}")
+    return int(match.group(1))
+
+
+def _title_from_text(text: str, *, fallback: str) -> str:
+    match = re.search(r"^#\s+(.+?)\s*$", text, flags=re.MULTILINE)
+    return match.group(1) if match else fallback
+
+
+def _read_local_claim(
+    path: Path,
+    *,
+    now: datetime,
+    ttl: timedelta = timedelta(hours=24),
+) -> Claim | None:
+    if not path.exists():
+        return None
+    fields = {name: value for name, value in _CLAIM_FIELD.findall(path.read_text(encoding="utf-8"))}
+    session = fields.get("session")
+    raw_timestamp = fields.get("claimed-at")
+    if not session or not raw_timestamp:
+        raise ValueError(f"Claim lock is malformed: {path}")
+    try:
+        claimed_at = _parse_timestamp(raw_timestamp)
+    except ValueError as error:
+        raise ValueError(f"Claim lock is malformed: {path}") from error
+    if now - claimed_at > ttl:
+        return None
+    try:
+        ticket_number = int(path.stem)
+    except ValueError as error:
+        raise ValueError(f"Claim lock has invalid ticket name: {path}") from error
+    return Claim(ticket_number, session, claimed_at)
+
+
+def _closed_ticket(number: int) -> Ticket:
+    return Ticket(number, "external closed blocker", False, "", "", (), None, None)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--map", type=int, help="GitHub decision-map issue number")
+    source.add_argument("--local", type=Path, help="Local .scratch effort directory")
+    parser.add_argument("--degraded", action="store_true", help="Parse generated child and blocker links")
+    parser.add_argument("--afk", action="store_true", help="Show only AFK frontier tickets")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    now = datetime.now(UTC)
+    if args.local is not None:
+        tickets, fog = normalize_local_map(args.local, now=now)
+    else:
+        tickets, fog = _read_github_map(args.map, degraded=args.degraded)
+    print(format_report(tickets, fog=fog, afk_only=args.afk))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/decision-map/tests/fixtures/github_issues.json
+++ b/skills/decision-map/tests/fixtures/github_issues.json
@@ -1,0 +1,77 @@
+[
+  {
+    "number": 42,
+    "title": "Billing migration decisions",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:map"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Destination\nChoose the migration.\n\n## Notes\nClaim TTL: 24h\n\n## Decisions so far\n\n## Not yet specified\n- Regional retention rules.\n\n## Out of scope\n"
+  },
+  {
+    "number": 7,
+    "title": "Choose immutable record shape",
+    "state": "OPEN",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:discussion"}, {"name": "decision-map:hitl"}],
+    "assignees": [],
+    "blockedBy": [],
+    "comments": [],
+    "body": "## Question\nWhich record shape preserves history?\n"
+  },
+  {
+    "number": 8,
+    "title": "Research retention rules",
+    "state": "OPEN",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:research"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "blockedBy": [{"number": 7}],
+    "comments": [],
+    "body": "## Question\nWhat retention rules apply?\n"
+  },
+  {
+    "number": 9,
+    "title": "Measure ledger cardinality",
+    "state": "CLOSED",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:unblock"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "blockedBy": [],
+    "comments": [],
+    "body": "## Question\nHow large is the ledger?\n"
+  },
+  {
+    "number": 10,
+    "title": "Sketch cutover experience",
+    "state": "OPEN",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:prototype"}, {"name": "decision-map:hitl"}],
+    "assignees": [{"login": "shared-agent"}],
+    "blockedBy": [],
+    "comments": [],
+    "body": "## Question\nHow should cutover be presented?\n"
+  },
+  {
+    "number": 11,
+    "title": "Claimed policy decision",
+    "state": "OPEN",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:discussion"}, {"name": "decision-map:hitl"}],
+    "assignees": [{"login": "shared-agent"}],
+    "blockedBy": [],
+    "comments": [{"id": "IC_kwDO120", "url": "https://github.com/owner/repo/issues/42#issuecomment-120", "body": "decision-map claim\nsession: first\nclaimed-at: 2026-08-16T09:00:00+00:00"}],
+    "body": "## Question\nWho approves the policy?\n"
+  },
+  {
+    "number": 12,
+    "title": "Publish measurement evidence",
+    "state": "OPEN",
+    "parent": {"number": 42},
+    "labels": [{"name": "decision-map:unblock"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "blockedBy": [{"number": 9}],
+    "comments": [],
+    "body": "## Question\nWhere should measurements be published?\n"
+  }
+]

--- a/skills/decision-map/tests/fixtures/github_issues_degraded.json
+++ b/skills/decision-map/tests/fixtures/github_issues_degraded.json
@@ -1,0 +1,65 @@
+[
+  {
+    "number": 42,
+    "title": "Billing migration decisions",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:map"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Destination\nChoose the migration.\n\n## Notes\nClaim TTL: 24h\n\n## Decisions so far\n\n## Not yet specified\n- Regional retention rules.\n\n## Generated child index\n- [ ] #7\n- [ ] #8\n- [ ] #9\n- [ ] #10\n- [ ] #11\n- [ ] #12\n\n## Out of scope\n"
+  },
+  {
+    "number": 7,
+    "title": "Choose immutable record shape",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:discussion"}, {"name": "decision-map:hitl"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Question\nWhich record shape preserves history?\n"
+  },
+  {
+    "number": 8,
+    "title": "Research retention rules",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:research"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Question\nWhat retention rules apply?\n\nBlocked by: #7\n"
+  },
+  {
+    "number": 9,
+    "title": "Measure ledger cardinality",
+    "state": "CLOSED",
+    "labels": [{"name": "decision-map:unblock"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Question\nHow large is the ledger?\n"
+  },
+  {
+    "number": 10,
+    "title": "Sketch cutover experience",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:prototype"}, {"name": "decision-map:hitl"}],
+    "assignees": [{"login": "shared-agent"}],
+    "comments": [],
+    "body": "## Question\nHow should cutover be presented?\n"
+  },
+  {
+    "number": 11,
+    "title": "Claimed policy decision",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:discussion"}, {"name": "decision-map:hitl"}],
+    "assignees": [{"login": "shared-agent"}],
+    "comments": [{"id": "IC_kwDO120", "url": "https://github.com/owner/repo/issues/42#issuecomment-120", "body": "decision-map claim\nsession: first\nclaimed-at: 2026-08-16T09:00:00+00:00"}],
+    "body": "## Question\nWho approves the policy?\n"
+  },
+  {
+    "number": 12,
+    "title": "Publish measurement evidence",
+    "state": "OPEN",
+    "labels": [{"name": "decision-map:unblock"}, {"name": "decision-map:afk"}],
+    "assignees": [],
+    "comments": [],
+    "body": "## Question\nWhere should measurements be published?\n\nBlocked by: #9\n"
+  }
+]

--- a/skills/decision-map/tests/fixtures/local_map/001-pick-the-store.md
+++ b/skills/decision-map/tests/fixtures/local_map/001-pick-the-store.md
@@ -1,0 +1,9 @@
+# Pick the store
+
+Type: decision-map:discussion
+Interaction: decision-map:hitl
+Status: OPEN
+Blocked by:
+
+## Question
+Which store preserves the ledger?

--- a/skills/decision-map/tests/fixtures/local_map/002-schema-shape.md
+++ b/skills/decision-map/tests/fixtures/local_map/002-schema-shape.md
@@ -1,0 +1,9 @@
+# Schema shape
+
+Type: decision-map:research
+Interaction: decision-map:afk
+Status: OPEN
+Blocked by: #1
+
+## Question
+What immutable shape satisfies retention rules?

--- a/skills/decision-map/tests/fixtures/local_map/map.md
+++ b/skills/decision-map/tests/fixtures/local_map/map.md
@@ -1,0 +1,14 @@
+# Decision Map — Billing migration
+
+## Destination
+Choose a safe billing migration.
+
+## Notes
+Claim TTL: 24h
+
+## Decisions so far
+
+## Not yet specified
+- Regional retention rules.
+
+## Out of scope

--- a/skills/decision-map/tests/test_claims.py
+++ b/skills/decision-map/tests/test_claims.py
@@ -1,0 +1,110 @@
+"""Tests for deterministic GitHub arbitration and local O_EXCL claims."""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
+
+from frontier import (  # noqa: E402
+    acquire_local_claim,
+    parse_claims,
+    release_local_claim,
+    winning_claim,
+)
+
+NOW = datetime(2026, 8, 16, 10, tzinfo=UTC)
+
+
+def _claim(comment_id: int, *, session: str, claimed_at: datetime) -> dict[str, object]:
+    return {
+        "id": f"IC_kwDO{comment_id}",
+        "url": f"https://github.com/owner/repo/issues/1#issuecomment-{comment_id}",
+        "body": (
+            "decision-map claim\n"
+            f"session: {session}\n"
+            f"claimed-at: {claimed_at.isoformat()}"
+        ),
+    }
+
+
+def test_lowest_fresh_comment_id_wins_claim_arbitration() -> None:
+    winner = winning_claim(
+        [
+            _claim(28, session="later", claimed_at=NOW - timedelta(minutes=1)),
+            _claim(17, session="first", claimed_at=NOW - timedelta(minutes=2)),
+        ],
+        now=NOW,
+    )
+
+    assert winner is not None
+    assert winner.comment_id == 17
+    assert winner.session == "first"
+
+
+def test_malformed_claim_comment_is_ignored() -> None:
+    claims = parse_claims(
+        [
+            {"id": 1, "body": "decision-map claim\nsession: missing-timestamp"},
+            {"id": 2, "body": "wrong first line\nsession: ignored\nclaimed-at: 2026-08-16T09:59:00+00:00"},
+            _claim(3, session="valid", claimed_at=NOW),
+        ],
+        now=NOW,
+    )
+
+    assert [claim.comment_id for claim in claims] == [3]
+
+
+def test_stale_claim_is_preemptable_but_fresh_claim_is_not() -> None:
+    stale = _claim(1, session="crashed", claimed_at=NOW - timedelta(hours=25))
+    fresh = _claim(2, session="alive", claimed_at=NOW - timedelta(hours=23, minutes=59))
+
+    assert winning_claim([stale], now=NOW) is None
+    fresh_winner = winning_claim([fresh], now=NOW)
+    assert fresh_winner is not None
+    assert fresh_winner.session == "alive"
+
+
+def test_local_o_excl_rejects_second_acquisition_and_releases_on_resolution(tmp_path: Path) -> None:
+    claims_dir = tmp_path / "claims"
+    acquired = acquire_local_claim(claims_dir, 7, session="first", now=NOW)
+
+    assert acquired.session == "first"
+    with pytest.raises(FileExistsError, match="already has a fresh local claim"):
+        acquire_local_claim(claims_dir, 7, session="second", now=NOW)
+
+    release_local_claim(claims_dir, 7)
+
+    replacement = acquire_local_claim(claims_dir, 7, session="second", now=NOW)
+    assert replacement.session == "second"
+
+
+def test_local_stale_lock_can_be_preempted(tmp_path: Path) -> None:
+    claims_dir = tmp_path / "claims"
+    claims_dir.mkdir()
+    lock = claims_dir / "9.lock"
+    lock.write_text(
+        "session: crashed\nclaimed-at: 2026-08-15T08:00:00+00:00\n",
+        encoding="utf-8",
+    )
+
+    replacement = acquire_local_claim(claims_dir, 9, session="replacement", now=NOW)
+
+    assert replacement.session == "replacement"
+    assert "replacement" in lock.read_text(encoding="utf-8")
+
+
+def test_local_malformed_lock_is_rejected_without_overwrite(tmp_path: Path) -> None:
+    claims_dir = tmp_path / "claims"
+    claims_dir.mkdir()
+    lock = claims_dir / "11.lock"
+    lock.write_text("session: interrupted\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="malformed"):
+        acquire_local_claim(claims_dir, 11, session="replacement", now=NOW)
+
+    assert lock.read_text(encoding="utf-8") == "session: interrupted\n"

--- a/skills/decision-map/tests/test_frontier.py
+++ b/skills/decision-map/tests/test_frontier.py
@@ -1,0 +1,119 @@
+"""Tests for pure decision-map graph normalization and state computation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
+
+from frontier import (  # noqa: E402
+    Claim,
+    Ticket,
+    compute_frontier,
+    compute_state,
+    format_report,
+    normalize_github_issues,
+    normalize_local_map,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+NOW = datetime(2026, 8, 16, 10, tzinfo=UTC)
+
+
+def _fixture(name: str) -> list[dict[str, object]]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _ticket(
+    number: int,
+    *,
+    open: bool = True,
+    blockers: tuple[int, ...] = (),
+    claim: Claim | None = None,
+    interaction: str = "decision-map:hitl",
+) -> Ticket:
+    return Ticket(
+        number=number,
+        title=f"Ticket {number}",
+        open=open,
+        type="decision-map:discussion",
+        interaction=interaction,
+        blocker_numbers=blockers,
+        owner=None,
+        claim=claim,
+    )
+
+
+def test_frontier_keeps_unblocked_unclaimed_and_assigned_unclaimed() -> None:
+    tickets = normalize_github_issues(_fixture("github_issues.json"), map_number=42, now=NOW)
+
+    frontier = compute_frontier(tickets)
+
+    assert [ticket.number for ticket in frontier] == [7, 10, 12]
+    assert next(ticket for ticket in tickets if ticket.number == 10).owner == "shared-agent"
+
+
+def test_frontier_drops_claimed_and_open_blocked_tickets() -> None:
+    tickets = normalize_github_issues(_fixture("github_issues.json"), map_number=42, now=NOW)
+
+    frontier_numbers = {ticket.number for ticket in compute_frontier(tickets)}
+
+    assert 8 not in frontier_numbers
+    assert 11 not in frontier_numbers
+
+
+def test_frontier_keeps_closed_blocker_and_drops_closed_ticket() -> None:
+    tickets = normalize_github_issues(_fixture("github_issues.json"), map_number=42, now=NOW)
+
+    frontier_numbers = {ticket.number for ticket in compute_frontier(tickets)}
+
+    assert 12 in frontier_numbers
+    assert 9 not in frontier_numbers
+
+
+def test_state_ladder_reaches_all_five_states() -> None:
+    claim = Claim(10, "session", NOW)
+
+    assert compute_state([_ticket(1)], fog="") == "ACTIVE"
+    assert compute_state([_ticket(1, claim=claim)], fog="") == "WAITING"
+    assert compute_state([_ticket(1, blockers=(2,)), _ticket(2, blockers=(1,))], fog="") == "BLOCKED"
+    assert compute_state([], fog="A question is still vague.") == "FOGGY"
+    assert compute_state([], fog="") == "COMPLETE"
+
+
+def test_degraded_normalization_matches_native_logical_graph() -> None:
+    native = normalize_github_issues(_fixture("github_issues.json"), map_number=42, now=NOW)
+    degraded = normalize_github_issues(
+        _fixture("github_issues_degraded.json"), map_number=42, now=NOW, degraded=True
+    )
+
+    assert [(ticket.number, ticket.blocker_numbers, ticket.claimed) for ticket in degraded] == [
+        (ticket.number, ticket.blocker_numbers, ticket.claimed) for ticket in native
+    ]
+    assert [ticket.number for ticket in compute_frontier(degraded)] == [7, 10, 12]
+
+
+def test_afk_filter_preserves_only_actionable_afk_tickets() -> None:
+    tickets = normalize_github_issues(_fixture("github_issues.json"), map_number=42, now=NOW)
+
+    frontier = compute_frontier(tickets, afk_only=True)
+
+    assert [ticket.number for ticket in frontier] == [12]
+
+
+def test_empty_frontier_report_explains_reason_and_state() -> None:
+    report = format_report([_ticket(1, claim=Claim(10, "session", NOW))], fog="")
+
+    assert "frontier: empty" in report
+    assert "state: WAITING" in report
+
+
+def test_local_normalization_reads_headers_and_fog() -> None:
+    tickets, fog = normalize_local_map(FIXTURES / "local_map", now=NOW)
+
+    assert [ticket.number for ticket in tickets] == [1, 2]
+    assert tickets[1].blocker_numbers == (1,)
+    assert "Regional retention rules" in fog


### PR DESCRIPTION
## Summary

Adds the stdlib-only `frontier.py` operational surface and tests for normalized tracker graphs, state precedence, GitHub claim arbitration, stale-claim handling, degraded parsing, and local `O_EXCL` exclusion.

## Stack

Stack-Id: `decision-map-20260816`  
Base: `feat/decision-map-skill`  
Position: 2/5

1. #97
2. `feat/decision-map-tooling` → this PR
3. #99
4. #100
5. #101

Depends on: #97  
Upstack: #99

## Validation

```text
uv run pytest skills/decision-map/tests -q  PASS (14 passed)
uv run python skills/decision-map/scripts/frontier.py --local skills/decision-map/tests/fixtures/local_map
  #1 — Pick the store [discussion/hitl]
  state: ACTIVE
LSP diagnostics: skills/decision-map/scripts/frontier.py  PASS
```

## Checklist

- [x] Adapter normalization is separate from pure frontier/state computation
- [x] Tests do not invoke network or GraphQL
- [x] State and claim failures are explicit
- [x] Malformed local locks fail rather than being overwritten
- [x] Local claims use `O_EXCL` exclusion and release after resolution
