### PR TITLE
test(routing): add reciprocal decision-map boundary cases

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -917,10 +917,11 @@ packages:
     difficulty: advanced
     phase: build
   - name: plan-prompts
-    version: 1.3.0
+    version: 1.3.1
     description: Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update
       DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository
-      design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.
+      design. Not for discovering an uncertain destination or unresolved decisions; use decision-map. Not for auditing an
+      existing plan; use plan-review. Not for executing a stack; use stacked-prs.
     path: skills/plan-prompts
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/plan-prompts/SKILL.md
     complements:
@@ -1261,12 +1262,16 @@ packages:
     difficulty: advanced
     phase: verify
   - name: task-decomposer
-    version: 1.1.1
+    version: 1.1.2
     description: 'Produces phased task boards from feature requests: dependency-mapped work items, parallelization flags,
       risk flags, edge cases, test matrices. Triggers on: "decompose this feature", "task breakdown with dependencies", "phased
-      implementation plan", "work breakdown structure". NOT for effort estimates, use estimate-calibrator.'
+      implementation plan", "work breakdown structure". NOT for discovering which decisions are still open, use decision-map.
+      NOT for effort estimates, use estimate-calibrator.'
     path: skills/task-decomposer
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/task-decomposer/SKILL.md
+    complements:
+    - decision-map
+    - plan-prompts
     tags:
     - task-breakdown
     - dependencies
@@ -1275,9 +1280,6 @@ packages:
     category: development
     difficulty: intermediate
     phase: plan
-    complements:
-    - decision-map
-    - plan-prompts
   - name: tavily
     version: 1.1.1
     description: 'AI-optimized web search via Tavily API when no URL is provided. Returns clean AI-ready snippets for current

--- a/skills/plan-prompts/SKILL.md
+++ b/skills/plan-prompts/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: plan-prompts
-description: 'Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository design. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.'
+description: 'Use when asked to "create a development plan", "generate execution prompts", "replan a milestone", "update DEVELOPMENT_PLAN.md", "start M5", or "adapt future milestones" after predecessor work changes the current repository design. Not for discovering an uncertain destination or unresolved decisions; use decision-map. Not for auditing an existing plan; use plan-review. Not for executing a stack; use stacked-prs.'
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   category: development
   tags: [planning, execution-prompts, milestones, adaptive-planning, stacked-prs, release-management, docs]
   difficulty: advanced
@@ -12,6 +12,7 @@ metadata:
     - stacked-prs
     - plan-review
     - task-decomposer
+    - decision-map
 ---
 
 # Development Plan and Execution Prompts
@@ -23,6 +24,13 @@ Convert source documents into a plan that remains valid as milestones merge:
 - `.docs/DEVELOPMENT_PLAN_HISTORY.md` — the single local, append-only design-evidence ledger. It must be gitignored.
 
 This skill plans from documents only. Do not implement product code, create branches, open PRs, or execute the generated prompts.
+
+## Scope Boundary
+
+| Situation | Package |
+|---|---|
+| Destination or the decisions needed to define it remain uncertain | `decision-map` |
+
 
 ## Inputs
 

--- a/skills/plan-prompts/evals/cases.yaml
+++ b/skills/plan-prompts/evals/cases.yaml
@@ -229,3 +229,9 @@ cases:
       - type: matches_regex
         target: "(do not tag|do not publish|without source evidence)"
         weight: 0.8
+  - id: negative_unresolved_destination
+    prompt: "The destination itself is still unclear. Identify the questions we must resolve."
+    fixtures: []
+    rubric:
+      - "Does not activate; unresolved pre-planning decisions belong to decision-map"
+    trigger_expected: false

--- a/skills/task-decomposer/SKILL.md
+++ b/skills/task-decomposer/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: task-decomposer
-description: 'Produces phased task boards from feature requests: dependency-mapped work items, parallelization flags, risk flags, edge cases, test matrices. Triggers on: "decompose this feature", "task breakdown with dependencies", "phased implementation plan", "work breakdown structure". NOT for effort estimates, use estimate-calibrator.'
+description: 'Produces phased task boards from feature requests: dependency-mapped work items, parallelization flags, risk flags, edge cases, test matrices. Triggers on: "decompose this feature", "task breakdown with dependencies", "phased implementation plan", "work breakdown structure". NOT for discovering which decisions are still open, use decision-map. NOT for effort estimates, use estimate-calibrator.'
 metadata:
-  version: 1.1.1
+  version: 1.1.2
   category: development
   tags: [task-breakdown, dependencies, planning, phased]
   difficulty: intermediate
   phase: plan
+  complements:
+    - decision-map
 ---
 
 # Task Decomposer
@@ -223,3 +225,4 @@ Push back if:
 - The task is already atomic (single function, single file change) — just do it
 - The user wants time estimates, not task breakdown — use estimate-calibrator instead
 - The feature is exploratory (research, prototype) — decomposition assumes known scope
+- The destination or the decisions needed to define it are still unknown — use decision-map

--- a/skills/task-decomposer/evals/cases.yaml
+++ b/skills/task-decomposer/evals/cases.yaml
@@ -66,3 +66,9 @@ cases:
     rubric:
       - "code review is outside task decomposition scope"
     trigger_expected: false
+  - id: negative_unresolved_decisions
+    prompt: "We do not know what architecture we want yet. Map the decisions first."
+    fixtures: []
+    rubric:
+      - "Does not activate; unresolved architecture decisions belong to decision-map"
+    trigger_expected: false


### PR DESCRIPTION
## Summary

Adds reciprocal routing boundaries: `plan-prompts` and `task-decomposer` now route unresolved destinations and decision discovery to `decision-map`, with inbound negative eval cases, complements, and patch-version updates.

## Stack

Stack-Id: `decision-map-20260816`  
Base: `feat/decision-map-command`  
Position: 4/5

1. #97
2. #98
3. #99
4. `test/decision-map-routing` → this PR
5. `docs/decision-map-lifecycle` → planned

Depends on: #99  
Upstack: planned `docs/decision-map-lifecycle`

## Validation

```text
uv run python scripts/validate_frontmatter.py  PASS
uv run python scripts/validate_evals.py        PASS
uv run scripts/generate_manifest.py            regenerated manifest.yaml
uv run python scripts/evaluate_package.py --path skills/plan-prompts --threshold 70      PASS (96%)
uv run python scripts/evaluate_package.py --path skills/task-decomposer --threshold 70   PASS (89%)
```

## Scope

Only `plan-prompts`, `task-decomposer`, and generated `manifest.yaml` changed. The two new negative cases are the inbound half of the routing contract; `skills/decision-map/evals/cases.yaml` carries the outbound half.
