### PR TITLE
docs(readme): add planning lifecycle and catalog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # armory
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![packages: 135](https://img.shields.io/badge/packages-135-informational)](manifest.yaml)
+[![packages: 137](https://img.shields.io/badge/packages-137-informational)](manifest.yaml)
 [![evals: 100%](https://img.shields.io/badge/eval_coverage-100%25-success)](skills/)
 [![GitHub stars](https://img.shields.io/github/stars/Mathews-Tom/armory?style=social)](https://github.com/Mathews-Tom/armory/stargazers)
 [![catalog](https://img.shields.io/badge/catalog-browse_packages-58a6ff)](https://mathews-tom.github.io/armory/)
@@ -18,7 +18,27 @@ Curated, production-grade skills, agents, hooks, rules, commands, utilities, and
 
 Intended for developers who treat AI coding agents as a serious part of their workflow.
 
+## Planning Lifecycle
+
+Use the planning packages in sequence, not as interchangeable formats:
+
+```text
+unknown destination → decision-map → known design → plan-prompts → task-decomposer / plan-review → milestone-runner → stacked-prs
+```
+
+| Situation | Package | Output |
+|---|---|---|
+| Destination or design is unresolved | [decision-map](skills/decision-map/) | Tracker-backed decision map, frontier, and recorded decisions |
+| Design is known and needs milestones | [plan-prompts](skills/plan-prompts/) | `DEVELOPMENT_PLAN.md` and `EXECUTION_PROMPTS.md` |
+| Feature is specified and needs implementation slices | [task-decomposer](skills/task-decomposer/) | Phased task board with dependencies and test matrix |
+| Existing plan needs a pre-implementation challenge | [plan-review](skills/plan-review/) | Severity-ranked plan review |
+| Approved plan needs execution across sessions | [milestone-runner](skills/milestone-runner/) | Reviewed, merged milestone PR stack |
+
+`decision-map` stops at resolved decisions. It recommends `plan-prompts` after a complete map and never creates implementation milestones or tasks.
+
 ---
+
+
 
 ## Package Catalog
 
@@ -68,6 +88,7 @@ Orchestrator agents compose skills and other agents into multi-phase workflows. 
 | [project-context-setup](skills/project-context-setup/) | Scaffold repo-local agent context — issue tracker rules, triage labels, domain glossary layout, ADR lookup, agent brief conventions                  |
 | [stacked-prs](skills/stacked-prs/)               | Manage dependent branch stacks and stacked pull requests — inspect, split, publish, sync, validate, merge, and clean up stack topology                      |
 | [plan-prompts](skills/plan-prompts/)             | Generate adaptive development plans, execution prompts, and an ignored local design-evidence ledger from source docs |
+| [decision-map](skills/decision-map/)             | Map unresolved architecture, policy, and scope decisions before implementation planning begins |
 | [milestone-runner](skills/milestone-runner/)     | Run milestones through serialized design reconciliation, reviewed PR gates, CI, cleanup, and release preparation |
 | [to-markdown](skills/to-markdown/)               | Convert any file or URL to clean Markdown via MarkItDown — PDF, DOCX, XLSX, PPTX, HTML, images, audio, CSV, JSON, XML, YouTube, EPub                        |
 | [web-fetch](skills/web-fetch/)                   | Web content fetching via curl and WebFetch — replaces the Fetch MCP server with native HTTP operations and jq parsing                                       |
@@ -213,6 +234,7 @@ Skills below are superseded by base model capabilities. They remain installable 
 | [handoff](commands/handoff/)             | Refresh or scaffold `.docs/handoff.md` |
 | [route](commands/route/)                 | Package discovery and task-to-package routing |
 | [stack-pr](commands/stack-pr/)           | Stacked PR workflow command surface |
+| [decision-map](commands/decision-map/)           | Slash-command surface for charting and working decision maps |
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

Documents the planning lifecycle, adds both `decision-map` catalog entries, and updates the package badge from 135 to 137.

## Stack

Stack-Id: `decision-map-20260816`  
Base: `test/decision-map-routing`  
Position: 5/5

1. #97
2. #98
3. #99
4. #100
5. `docs/decision-map-lifecycle` → this PR

Depends on: #100  
Upstack: none

## Full Validation

```text
uv run python scripts/validate_frontmatter.py                                          PASS
uv run python scripts/validate_references.py                                           PASS
uv run python scripts/validate_evals.py                                                PASS
uv run python scripts/evaluate_package.py --path skills/decision-map --threshold 70    PASS (100%; no findings)
uv run python scripts/evaluate_package.py --path commands/decision-map --threshold 70  PASS (96%; no findings)
uv run pytest skills/decision-map/tests -q                                             PASS (14 passed)
uv run scripts/generate_manifest.py && git diff --exit-code manifest.yaml             PASS
uv run python scripts/generate_adapters.py --validate                                  PASS
relative-path sweep                                                                     PASS (no `../`)
table-format sweep                                                                      PASS (no `| -` separator rows)
```

The upstream-name sweep is contained in `references/upstream/provenance.md` plus the required verbatim MIT license's copyright line. The license occurrence is mandatory provenance, not a package cross-reference.

## Manual Verification

1. **Local chart — PASS.** Created `/tmp/decision-map-manual-active` for the ledger-retention redesign with all five map sections, three tickets with one type and one interaction label each, blocker `#2 → #1`, one fog entry, and `frontier.py` state `ACTIVE`.
2. **Local work — PASS.** Acquired and re-read the `O_EXCL` claim for ticket `#1` before resolution; closed exactly `#1`, recorded its resolution and map pointer in `Decisions so far`, released the lock, and confirmed ticket `#2` remained open and unclaimed.
3. **GitHub chart/work — HUMAN GATE.** No repository matching `scratch` exists under `Mathews-Tom`; no production repository was used for destructive tracker verification. Native-probe and `--degraded` verification remain explicitly unexecuted.
4. **Concurrency — PASS.** Concurrent `work` claim attempts on ticket `#2` produced exactly one winner (`session-a`) and one withdrawal (`session-b`); the loser then claimed ticket `#3`.
5. **Completion — PASS.** A closed-ticket local map with empty fog printed `state: COMPLETE`. The work report handed off to `plan-prompts`; no implementation plan or task list was generated.

## Scope

Documentation only. `manifest.yaml` is unchanged because this PR changes no package definition.