### PR TITLE
test(routing): add package boundary regression harness

### DIFF
--- a/scripts/validate_routing.py
+++ b/scripts/validate_routing.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Validate deterministic routing boundaries between selected armory packages.
+
+The harness scores only each fixture's expected package and explicit non-winners.
+It does not change package routing; it detects when package descriptions stop
+separating a declared boundary prompt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.frontmatter import parse_frontmatter  # noqa: E402
+from scripts.package_types import TYPES  # noqa: E402
+
+_TOKEN = re.compile(r"[a-z0-9][a-z0-9-]*")
+_QUOTED_TRIGGER = re.compile(r'"([^"]+)"')
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "into",
+        "is",
+        "it",
+        "md",
+        "of",
+        "on",
+        "or",
+        "the",
+        "this",
+        "to",
+        "use",
+        "when",
+        "with",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RoutingCase:
+    """One expected routing result and its explicit competitors."""
+
+    identifier: str
+    prompt: str
+    expected: str
+    non_winners: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RoutingResult:
+    """One evaluated routing fixture."""
+
+    case: RoutingCase
+    scores: tuple[tuple[str, float], ...]
+
+    @property
+    def winner(self) -> str:
+        return self.scores[0][0]
+
+
+def tokenize(text: str) -> tuple[str, ...]:
+    """Return meaningful, normalized tokens in deterministic source order."""
+    return tuple(
+        token
+        for token in _TOKEN.findall(text.lower())
+        if token not in _STOP_WORDS and len(token) > 1
+    )
+
+
+def score(prompt: str, description: str) -> float:
+    """Score normalized term overlap and complete declared trigger matches."""
+    prompt_tokens = set(tokenize(prompt))
+    description_tokens = set(tokenize(description))
+    union = prompt_tokens | description_tokens
+    overlap = len(prompt_tokens & description_tokens) / len(union) if union else 0.0
+    trigger_bonus = sum(
+        1.0
+        for trigger in _QUOTED_TRIGGER.findall(description)
+        if trigger.lower() in prompt.lower()
+    )
+    return overlap + trigger_bonus
+
+
+def load_cases(path: Path) -> tuple[RoutingCase, ...]:
+    """Load and validate routing fixtures from YAML."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"Cannot read valid YAML from {path}: {error}") from error
+
+    if not isinstance(raw, dict) or not isinstance(raw.get("cases"), list):
+        raise ValueError(f"{path}: expected a top-level 'cases' list")
+
+    cases: list[RoutingCase] = []
+    identifiers: set[str] = set()
+    for index, item in enumerate(raw["cases"], start=1):
+        prefix = f"{path} case #{index}"
+        if not isinstance(item, dict):
+            raise ValueError(f"{prefix}: expected a mapping")
+        unknown_fields = set(item) - {"id", "prompt", "expected", "non_winners"}
+        if unknown_fields:
+            raise ValueError(
+                f"{prefix}: unknown field(s): {', '.join(sorted(unknown_fields))}"
+            )
+        identifier = item.get("id")
+        prompt = item.get("prompt")
+        expected = item.get("expected")
+        non_winners = item.get("non_winners", [])
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError(f"{prefix}: 'id' must be a non-empty string")
+        if identifier in identifiers:
+            raise ValueError(f"{prefix}: duplicate id '{identifier}'")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError(f"{prefix}: 'prompt' must be a non-empty string")
+        if not isinstance(expected, str) or not expected:
+            raise ValueError(f"{prefix}: 'expected' must be a non-empty string")
+        if not isinstance(non_winners, list) or not all(
+            isinstance(name, str) and name for name in non_winners
+        ):
+            raise ValueError(
+                f"{prefix}: 'non_winners' must be a list of non-empty strings"
+            )
+        if len(set(non_winners)) != len(non_winners):
+            raise ValueError(f"{prefix}: 'non_winners' must not contain duplicates")
+        if expected in non_winners:
+            raise ValueError(f"{prefix}: expected package cannot be a non-winner")
+        identifiers.add(identifier)
+        cases.append(RoutingCase(identifier, prompt, expected, tuple(non_winners)))
+    if not cases:
+        raise ValueError(f"{path}: 'cases' must not be empty")
+    return tuple(cases)
+
+
+def load_descriptions(repo_root: Path, package_paths: Iterable[str]) -> dict[str, str]:
+    """Load requested package descriptions, rejecting invalid package definitions."""
+    requested = set(package_paths)
+    descriptions: dict[str, str] = {}
+    for package_type in TYPES.values():
+        package_root = repo_root / package_type.dir_name
+        if not package_root.exists():
+            continue
+        for package_dir in package_root.iterdir():
+            package_path = f"{package_type.dir_name}/{package_dir.name}"
+            if package_path not in requested:
+                continue
+            definition = package_dir / package_type.definition_file
+            if not definition.is_file():
+                raise ValueError(
+                    f"{package_path}: missing {package_type.definition_file}"
+                )
+            try:
+                metadata = parse_frontmatter(definition.read_text(encoding="utf-8"))
+            except (OSError, ValueError, yaml.YAMLError) as error:
+                raise ValueError(
+                    f"Cannot read valid frontmatter from {definition}: {error}"
+                ) from error
+            if not isinstance(metadata, dict):
+                raise ValueError(f"{definition}: frontmatter must be a mapping")
+            description = metadata.get("description")
+            if not isinstance(description, str) or not description.strip():
+                raise ValueError(
+                    f"{definition}: package description must be a non-empty string"
+                )
+            descriptions[package_path] = description
+    missing = sorted(requested - descriptions.keys())
+    if missing:
+        raise ValueError(
+            f"Routing fixtures reference unknown package path(s): {', '.join(missing)}"
+        )
+    return descriptions
+
+
+def evaluate(
+    cases: Iterable[RoutingCase], descriptions: dict[str, str]
+) -> tuple[RoutingResult, ...]:
+    """Rank each fixture's expected package and explicit non-winners."""
+    results: list[RoutingResult] = []
+    for case in cases:
+        candidates = (case.expected, *case.non_winners)
+        scores = tuple(
+            sorted(
+                ((name, score(case.prompt, descriptions[name])) for name in candidates),
+                key=lambda entry: (-entry[1], entry[0]),
+            )
+        )
+        results.append(RoutingResult(case, scores))
+    return tuple(results)
+
+
+def failures(results: Iterable[RoutingResult]) -> tuple[str, ...]:
+    """Return routing contract failures, including zero-score and tied winners."""
+    errors: list[str] = []
+    for result in results:
+        expected_score = dict(result.scores)[result.case.expected]
+        highest_score = result.scores[0][1]
+        tied = [
+            name
+            for name, candidate_score in result.scores
+            if candidate_score == highest_score
+        ]
+        if expected_score == 0:
+            errors.append(f"{result.case.identifier}: expected package has zero score")
+        if result.winner != result.case.expected:
+            errors.append(
+                f"{result.case.identifier}: expected {result.case.expected}, got {result.winner}"
+            )
+        if len(tied) > 1:
+            errors.append(
+                f"{result.case.identifier}: top score {highest_score:.3f} ties {', '.join(tied)}"
+            )
+    return tuple(errors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixtures",
+        type=Path,
+        default=_REPO_ROOT / "tests/fixtures/routing_cases.yaml",
+        help="YAML routing fixtures (default: tests/fixtures/routing_cases.yaml)",
+    )
+    args = parser.parse_args()
+
+    try:
+        cases = load_cases(args.fixtures)
+        package_paths = {case.expected for case in cases}
+        package_paths.update(name for case in cases for name in case.non_winners)
+        descriptions = load_descriptions(_REPO_ROOT, package_paths)
+        results = evaluate(cases, descriptions)
+    except ValueError as error:
+        print(f"FAILED: {error}", file=sys.stderr)
+        return 1
+
+    for result in results:
+        ranking = ", ".join(
+            f"{name}={candidate_score:.3f}" for name, candidate_score in result.scores
+        )
+        print(f"{result.case.identifier}: {ranking}")
+    errors = failures(results)
+    if errors:
+        print("FAILED:", file=sys.stderr)
+        for failure in errors:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(f"Validated {len(results)} routing cases — all passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/routing_cases.yaml
+++ b/tests/fixtures/routing_cases.yaml
@@ -1,0 +1,19 @@
+cases:
+  - id: unresolved_destination
+    prompt: "Map the decisions we must settle before implementation planning starts."
+    expected: skills/decision-map
+    non_winners:
+      - skills/plan-prompts
+      - skills/task-decomposer
+  - id: approved_design_to_milestones
+    prompt: "Create a development plan and execution prompts from signed-off design documents."
+    expected: skills/plan-prompts
+    non_winners:
+      - skills/decision-map
+      - skills/task-decomposer
+  - id: known_feature_to_work_items
+    prompt: "Decompose this feature into dependency-mapped work items, edge cases, and a test matrix."
+    expected: skills/task-decomposer
+    non_winners:
+      - skills/decision-map
+      - skills/plan-prompts

--- a/tests/test_validate_routing.py
+++ b/tests/test_validate_routing.py
@@ -1,0 +1,194 @@
+"""Tests for deterministic package-description routing validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_routing import (
+    RoutingCase,
+    evaluate,
+    failures,
+    load_cases,
+    load_descriptions,
+    main,
+    score,
+    tokenize,
+)
+
+
+def test_tokenize_removes_common_words_and_file_extensions() -> None:
+    assert tokenize("Map the architecture decisions from README.md") == (
+        "map",
+        "architecture",
+        "decisions",
+        "readme",
+    )
+
+
+def test_score_rewards_exact_quoted_trigger() -> None:
+    description = 'Triggers on: "map the decisions".'
+    assert score("Please map the decisions", description) > score(
+        "Please map this", description
+    )
+
+
+def test_load_cases_allows_no_non_winners(tmp_path: Path) -> None:
+    fixture = tmp_path / "cases.yaml"
+    fixture.write_text(
+        "cases:\n  - id: solo\n    prompt: route this\n    expected: skills/example\n",
+        encoding="utf-8",
+    )
+
+    assert load_cases(fixture) == (
+        RoutingCase("solo", "route this", "skills/example", ()),
+    )
+
+
+def test_load_cases_rejects_unknown_fields(tmp_path: Path) -> None:
+    fixture = tmp_path / "cases.yaml"
+    fixture.write_text(
+        "cases:\n"
+        "  - id: invalid\n    prompt: prompt\n    expected: skills/example\n"
+        "    non-winners: [skills/other]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unknown field"):
+        load_cases(fixture)
+
+
+def test_load_cases_rejects_duplicate_ids(tmp_path: Path) -> None:
+    fixture = tmp_path / "cases.yaml"
+    fixture.write_text(
+        "cases:\n"
+        "  - id: duplicate\n    prompt: first\n    expected: skills/a\n    non_winners: []\n"
+        "  - id: duplicate\n    prompt: second\n    expected: skills/b\n    non_winners: []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate id"):
+        load_cases(fixture)
+
+
+def test_load_cases_rejects_duplicate_non_winners(tmp_path: Path) -> None:
+    fixture = tmp_path / "cases.yaml"
+    fixture.write_text(
+        "cases:\n  - id: duplicate\n    prompt: prompt\n    expected: skills/a\n"
+        "    non_winners: [skills/b, skills/b]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        load_cases(fixture)
+
+
+def test_load_cases_rejects_expected_non_winner(tmp_path: Path) -> None:
+    fixture = tmp_path / "cases.yaml"
+    fixture.write_text(
+        "cases:\n"
+        "  - id: invalid\n    prompt: prompt\n    expected: skills/decision-map\n"
+        "    non_winners: [skills/decision-map]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cannot be a non-winner"):
+        load_cases(fixture)
+
+
+def test_load_descriptions_reads_requested_package(tmp_path: Path) -> None:
+    definition = tmp_path / "skills" / "example" / "SKILL.md"
+    definition.parent.mkdir(parents=True)
+    definition.write_text(
+        "---\nname: example\ndescription: Example routing description\n---\n",
+        encoding="utf-8",
+    )
+
+    assert load_descriptions(tmp_path, {"skills/example"}) == {
+        "skills/example": "Example routing description"
+    }
+
+
+def test_load_descriptions_rejects_missing_definition(tmp_path: Path) -> None:
+    (tmp_path / "skills" / "example").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="missing SKILL.md"):
+        load_descriptions(tmp_path, {"skills/example"})
+
+
+def test_load_descriptions_rejects_malformed_frontmatter(tmp_path: Path) -> None:
+    definition = tmp_path / "skills" / "example" / "SKILL.md"
+    definition.parent.mkdir(parents=True)
+    definition.write_text("---\n[\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Cannot read valid frontmatter"):
+        load_descriptions(tmp_path, {"skills/example"})
+
+
+def test_load_descriptions_rejects_missing_package(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown package path"):
+        load_descriptions(tmp_path, {"skills/missing"})
+
+
+def test_failures_rejects_non_winner_that_outranks_expected() -> None:
+    case = RoutingCase(
+        "boundary", "plan work", "skills/decision-map", ("skills/plan-prompts",)
+    )
+    results = evaluate(
+        (case,),
+        {
+            "skills/decision-map": "map unresolved decisions",
+            "skills/plan-prompts": "plan work",
+        },
+    )
+
+    assert failures(results) == (
+        "boundary: expected package has zero score",
+        "boundary: expected skills/decision-map, got skills/plan-prompts",
+    )
+
+
+def test_failures_rejects_top_score_tie() -> None:
+    case = RoutingCase("tie", "plan", "skills/expected", ("skills/other",))
+    results = evaluate(
+        (case,),
+        {"skills/expected": "plan", "skills/other": "plan"},
+    )
+
+    assert failures(results) == (
+        "tie: top score 1.000 ties skills/expected, skills/other",
+    )
+
+
+def test_main_reports_repository_fixture(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["validate_routing.py"])
+
+    assert main() == 0
+    assert "routing cases — all passed" in capsys.readouterr().out
+
+
+def test_main_reports_invalid_fixture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = tmp_path / "invalid.yaml"
+    fixture.write_text("cases: not-a-list\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["validate_routing.py", "--fixtures", str(fixture)]
+    )
+
+    assert main() == 1
+    assert "FAILED:" in capsys.readouterr().err
+
+
+def test_repository_routing_cases_pass() -> None:
+    fixture = Path(__file__).parent / "fixtures" / "routing_cases.yaml"
+    cases = load_cases(fixture)
+    paths = {case.expected for case in cases}
+    paths.update(name for case in cases for name in case.non_winners)
+    descriptions = load_descriptions(Path(__file__).parent.parent, paths)
+
+    assert failures(evaluate(cases, descriptions)) == ()


### PR DESCRIPTION
## Summary

Adds a deterministic regression harness for routing boundaries between `decision-map`, `plan-prompts`, and `task-decomposer`.

- Reads expected package paths and explicit non-winners from `tests/fixtures/routing_cases.yaml`.
- Scores normalized frontmatter-description overlap plus complete declared trigger matches.
- Fails loudly on malformed fixtures, unknown fixture fields, duplicate competitors, missing package definitions, invalid frontmatter, zero-score expected winners, and top-score ties.
- Adds CLI and focused unit coverage without changing package descriptions or runtime routing behavior.

Closes #102

## Verification

```text
uv run ruff format --check scripts/validate_routing.py tests/test_validate_routing.py
uv run ruff check scripts/validate_routing.py tests/test_validate_routing.py
uv run pytest tests/test_validate_routing.py tests/test_build_router_index.py -q
# 31 passed

uv run python scripts/validate_routing.py
# 3 routing cases passed

uv run mypy --strict --follow-imports=skip --disable-error-code import-untyped scripts/validate_routing.py tests/test_validate_routing.py
# Success: no issues found in 2 source files
```

## Checklist

- [x] Existing package descriptions and routing behavior remain unchanged.
- [x] Boundary fixtures cover all three packages as winner and competitor.
- [x] The harness has deterministic local output and nonzero failure exits.
- [x] Two focused review passes found no blocking issues.
