### PR TITLE
fix(decision-map): store local maps under docs

### DIFF
--- a/commands/decision-map/COMMAND.md
+++ b/commands/decision-map/COMMAND.md
@@ -3,7 +3,7 @@ name: decision-map
 type: command
 description: 'Slash-command wrapper for the decision-map skill. `/decision-map chart` plus a loose idea opens a decision map for an effort too big for one session; `/decision-map work` plus an optional map reference claims and resolves exactly one frontier ticket, then stops. Triggers on: "/decision-map", "decision-map chart", "decision-map work", "chart this effort as a map", "work the next decision ticket", "what is on the frontier", "wayfinder". Use this command when a user wants a two-mode argument surface over a tracker-backed decision map, delegating map format, ticket typing, claim arbitration, and tracker operations to skills/decision-map.'
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   category: development
   tags: [planning, issue-tracker, decisions, slash-command, discovery]
   difficulty: advanced
@@ -23,8 +23,8 @@ Thin slash-command entry point for the `decision-map` skill. This command owns a
 
 1. Parse the first token as the mode. `chart` sends the remaining text as a loose idea to Mode A. `work` selects Mode B.
 2. For a bare invocation, treat a map URL or `#N` as `work`; treat free text as `chart`; when neither exists, ask which mode the user intends.
-3. In work mode, resolve the reference with `gh issue view N --json number,title,url,labels,state`. Require the `decision-map:map` label before handing off.
-4. When work mode has no reference, locate open maps. If exactly one open `decision-map:map` issue exists, use it. If several exist, list their linked titles and stop; never select one silently.
+3. In work mode with an explicit GitHub reference, resolve it with `gh issue view N --json number,title,url,labels,state`. Require the `decision-map:map` label before handing off.
+4. When work mode has no reference, defer map discovery to the skill's selected backend. If several maps are eligible, list their linked titles and stop; never select one silently.
 5. Load `skills/decision-map`, hand it the resolved mode and map identity, then begin that mode at step 1.
 6. Return the skill's report unchanged. Do not add a second selection, a plan, tracker calls, or claim logic after handoff.
 
@@ -40,7 +40,7 @@ Thin slash-command entry point for the `decision-map` skill. This command owns a
 | `/decision-map MAP-URL` | Work | Resolve the referenced map URL |
 | `/decision-map IDEA` | Chart | Treat non-reference text as the loose idea |
 
-A `MAP` is a GitHub issue number, `#N`, or issue URL. Tracker selection after handoff follows the skill's documented backend ladder. The command does not provide a separate local-file argument: local map selection is part of the skill's tracker-backed workflow, not a rival command contract.
+A `MAP` is a GitHub issue number, `#N`, or issue URL; supplying one explicitly selects GitHub. `chart` uses the local `.docs/decision-maps/<effort>/` backend unless the user expressly selects GitHub or `.docs/agents/issue-tracker.md` specifies another backend. The command does not provide a separate local-file argument: local map selection is part of the skill's tracker-backed workflow, not a rival command contract.
 
 ## Argument Rules
 
@@ -52,7 +52,7 @@ A `MAP` is a GitHub issue number, `#N`, or issue URL. Tracker selection after ha
 | `work` with several open maps | List all linked titles | Stop for selection |
 | Bare command with no argument | Ask for `chart` or `work` | Do not infer intent |
 
-Use `gh issue view` to resolve explicit GitHub references. When the skill's configured backend is local, the handoff resolves the local map using its documented selection process. This command never duplicates the tracker capability probe or degraded-path parsing.
+Use `gh issue view` to resolve explicit GitHub references. Otherwise, hand off map selection to the skill's documented backend process; it uses `.docs/decision-maps/` unless `.docs/agents/issue-tracker.md` specifies another backend. This command never duplicates the tracker capability probe or degraded-path parsing.
 
 ## Output
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -320,7 +320,7 @@ packages:
     difficulty: intermediate
     phase: build
   - name: decision-map
-    version: 1.0.0
+    version: 1.0.1
     description: 'Maps the unresolved architecture, policy, and scope decisions that must be answered before planning can
       start: one durable decision ticket per question on the issue tracker, typed and blocker-linked under a parent map, with
       fog-of-war, out-of-scope, a computed frontier, and one decision resolved per invocation. Triggers on: "map the decisions",
@@ -2032,7 +2032,7 @@ packages:
     difficulty: beginner
   commands:
   - name: decision-map
-    version: 1.0.0
+    version: 1.0.1
     description: 'Slash-command wrapper for the decision-map skill. `/decision-map chart` plus a loose idea opens a decision
       map for an effort too big for one session; `/decision-map work` plus an optional map reference claims and resolves exactly
       one frontier ticket, then stops. Triggers on: "/decision-map", "decision-map chart", "decision-map work", "chart this

--- a/skills/decision-map/SKILL.md
+++ b/skills/decision-map/SKILL.md
@@ -2,7 +2,7 @@
 name: decision-map
 description: 'Maps the unresolved architecture, policy, and scope decisions that must be answered before planning can start: one durable decision ticket per question on the issue tracker, typed and blocker-linked under a parent map, with fog-of-war, out-of-scope, a computed frontier, and one decision resolved per invocation. Triggers on: "map the decisions", "what do we need to decide", "identify the unknowns", "not ready to plan yet", "decision map", "chart this effort", "work the next decision ticket", "wayfinder". Use when the destination is still uncertain. NOT for implementation slices of a known feature, use task-decomposer. NOT for milestone plans, use plan-prompts.'
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   category: development
   tags: [planning, issue-tracker, decisions, discovery, frontier, pre-planning]
   difficulty: advanced
@@ -42,8 +42,7 @@ A ticket holds one question, exactly one type label, exactly one interaction lab
 
 ## Prerequisites
 
-Use `gh --version` and require `gh` 2.96.0 or newer for native GitHub relationships. Verify authentication with `gh auth status`. `frontier.py` requires Python 3.12 and only the standard library. `docs/agents/issue-tracker.md`, when present, is the authoritative backend choice. Otherwise choose GitHub only when a GitHub remote exists and `gh auth status` succeeds; choose local markdown in every other case. Report the selected backend once and mention `project-context-setup` when the choice should be persisted.
-
+Use `gh --version` and require `gh` 2.96.0 or newer only when the user explicitly selects GitHub as the tracker. Verify authentication with `gh auth status` before that path. `frontier.py` requires Python 3.12 and only the standard library. `.docs/agents/issue-tracker.md`, when present, is the authoritative backend choice. Otherwise store maps locally in `.docs/decision-maps/<effort>/`; select GitHub only when the user expressly asks for it. Do not infer GitHub selection from a remote or authentication. Report the selected backend once and mention `project-context-setup` when the choice should be persisted.
 Probe GitHub capability before using native relationships. When older GitHub Enterprise or an older CLI rejects `blockedBy`, take the degraded path: generated child links in the map and `Blocked by: #N` lines in ticket bodies. The degraded index exists only to emulate absent tracker relationships.
 
 ## Workflow
@@ -95,7 +94,7 @@ An empty frontier does not mean completion. Evaluate the ordered ladder: actiona
 
 | Failure | Diagnose | Corrective action |
 |---|---|---|
-| Tracker document absent | inspect `docs/agents/issue-tracker.md` | use the backend ladder and report it |
+| Tracker document absent | inspect `.docs/agents/issue-tracker.md` | use the local `.docs/decision-maps/` backend unless the user selected GitHub |
 | Native relationship unsupported | `gh issue view <map> --json blockedBy` | use degraded generated links and body blockers |
 | Label schema absent | `gh label list` | bootstrap labels idempotently before ticket creation |
 | Two sessions claim one ticket | re-read comments and database comment identifiers | lowest fresh identifier wins; loser withdraws |
@@ -127,7 +126,7 @@ Confirm all five map sections exist; every open ticket is a child of the map and
 ```bash
 uv run python skills/decision-map/scripts/frontier.py --map 42
 uv run python skills/decision-map/scripts/frontier.py --map 42 --degraded
-uv run python skills/decision-map/scripts/frontier.py --local .scratch/billing
+uv run python skills/decision-map/scripts/frontier.py --local .docs/decision-maps/billing
 ```
 
 ## References

--- a/skills/decision-map/references/claim-protocol.md
+++ b/skills/decision-map/references/claim-protocol.md
@@ -20,4 +20,4 @@ This is advisory ownership plus optimistic arbitration, not a lock. A claim olde
 
 ## Local exclusion
 
-Write the complete session identifier and timestamp to a private temporary file, then atomically link it to `.scratch/<effort>/claims/<ticket>.lock`. The link is exclusive: a second creator fails rather than arbitrating, and the visible lock is always complete. Apply the same TTL before a documented stale-lock preemption and remove the lock when resolution is recorded.
+Write the complete session identifier and timestamp to a private temporary file, then atomically link it to `.docs/decision-maps/<effort>/claims/<ticket>.lock`. The link is exclusive: a second creator fails rather than arbitrating, and the visible lock is always complete. Apply the same TTL before a documented stale-lock preemption and remove the lock when resolution is recorded.

--- a/skills/decision-map/references/tracker-operations.md
+++ b/skills/decision-map/references/tracker-operations.md
@@ -35,4 +35,4 @@ Use a generated task list in the map for children and `Blocked by: #N` body line
 
 ## Local path
 
-Store `.scratch/<effort>/map.md`, one numbered child file with `Type:`, `Interaction:`, `Status:`, and `Blocked by:` headers, and a `claims/` directory. Write resolution pointers back to the map. Backend selection is: obey `docs/agents/issue-tracker.md`; otherwise GitHub remote plus working `gh auth`; otherwise local markdown. Report the choice and suggest `project-context-setup` when it should become repo policy.
+Store `.docs/decision-maps/<effort>/map.md`, one numbered child file with `Type:`, `Interaction:`, `Status:`, and `Blocked by:` headers, and a `claims/` directory. Write resolution pointers back to the map. Backend selection is: obey `.docs/agents/issue-tracker.md`; otherwise use local markdown. Use GitHub only when the user explicitly selects it and `gh auth status` succeeds; do not infer that choice from a remote or authentication. Report the choice and suggest `project-context-setup` when it should become repo policy.

--- a/skills/decision-map/scripts/frontier.py
+++ b/skills/decision-map/scripts/frontier.py
@@ -474,7 +474,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--map", type=int, help="GitHub decision-map issue number")
-    source.add_argument("--local", type=Path, help="Local .scratch effort directory")
+    source.add_argument("--local", type=Path, help="Local .docs/decision-maps effort directory")
     parser.add_argument("--degraded", action="store_true", help="Parse generated child and blocker links")
     parser.add_argument("--afk", action="store_true", help="Show only AFK frontier tickets")
     return parser

--- a/skills/decision-map/tests/test_frontier.py
+++ b/skills/decision-map/tests/test_frontier.py
@@ -6,10 +6,12 @@ import json
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
 
 from frontier import (  # noqa: E402
+    _build_parser,
     Claim,
     Ticket,
     compute_frontier,
@@ -24,7 +26,7 @@ NOW = datetime(2026, 8, 16, 10, tzinfo=UTC)
 
 
 def _fixture(name: str) -> list[dict[str, object]]:
-    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+    return cast(list[dict[str, object]], json.loads((FIXTURES / name).read_text(encoding="utf-8")))
 
 
 def _ticket(
@@ -117,3 +119,7 @@ def test_local_normalization_reads_headers_and_fog() -> None:
     assert [ticket.number for ticket in tickets] == [1, 2]
     assert tickets[1].blocker_numbers == (1,)
     assert "Regional retention rules" in fog
+
+
+def test_local_argument_documents_docs_storage() -> None:
+    assert ".docs/decision-maps" in _build_parser().format_help()


### PR DESCRIPTION
## Summary

Changes `decision-map` local persistence from `.scratch/<effort>/` to `.docs/decision-maps/<effort>/`.

- Local storage is the default when `.docs/agents/issue-tracker.md` does not define a backend.
- GitHub is selected only by an explicit user request or explicit tracker configuration; a remote and authenticated `gh` no longer imply GitHub storage.
- Updates local claims, command handoff, CLI help, references, versions, and generated manifest metadata.
- Adds a regression test that pins the documented `--local` storage location.

## Verification

```text
uv run ruff check skills/decision-map/scripts/frontier.py skills/decision-map/tests/test_frontier.py
uv run mypy --strict skills/decision-map/scripts/frontier.py skills/decision-map/tests/test_frontier.py
uv run pytest skills/decision-map/tests -q
# 15 passed

uv run python scripts/validate_frontmatter.py
uv run python scripts/validate_references.py
uv run python scripts/validate_evals.py
uv run python scripts/evaluate_package.py --path skills/decision-map --threshold 70
# 100/100
uv run python scripts/evaluate_package.py --path commands/decision-map --threshold 70
# 96/100
```

## Checklist

- [x] Local decision-map artifacts default to `.docs/decision-maps/`.
- [x] Explicit external backend selection remains available.
- [x] Existing evaluator and package-validation gates pass.
- [x] Generated `manifest.yaml` records both package version bumps.
