### PR TITLE
refactor(evals): separate conformance from effectiveness

### DIFF
--- a/scripts/evaluate_package.py
+++ b/scripts/evaluate_package.py
@@ -1,323 +1,206 @@
 #!/usr/bin/env python3
-"""Standalone CI-compatible package quality evaluator.
+"""Report static package conformance without claiming live effectiveness."""
 
-Scores packages across 6 dimensions and fails if the score is below
-threshold or any CRITICAL finding exists.
-"""
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
+from typing import cast
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-import yaml
 
-from scripts.frontmatter import extract_body, extract_version, parse_frontmatter, validate_version
-from scripts.package_types import REPO_ROOT, TYPES, PackageType
+import yaml  # noqa: E402
 
-DIMENSION_NAMES = [
-    "D1 Frontmatter Quality",
-    "D2 Trigger Coverage",
-    "D3 Structural Completeness",
-    "D4 Content Depth",
-    "D5 Consistency",
-    "D6 Compliance",
-]
+from scripts.frontmatter import extract_version, parse_frontmatter, validate_version  # noqa: E402
+from scripts.package_types import REPO_ROOT, TYPES, PackageType, detect_type_from_path  # noqa: E402
 
-MAX_SCORES: dict[str, int] = {
-    "D1 Frontmatter Quality": 20,
-    "D2 Trigger Coverage": 18,
-    "D3 Structural Completeness": 20,
-    "D4 Content Depth": 22,
-    "D5 Consistency": 12,
-    "D6 Compliance": 8,
+REPORT_VERSION = 2
+EFFECTIVENESS_DIMENSIONS: dict[str, tuple[str, ...]] = {
+    "skill": ("routing", "task outcome"),
+    "agent": ("routing", "task outcome"),
+    "hook": ("event handling", "observable side effect"),
+    "rule": ("routing", "constraint adherence"),
+    "command": ("command invocation", "task outcome"),
+    "utility": ("utility invocation", "task outcome"),
+    "preset": ("preset loading", "configuration effect"),
 }
 
 
-def _count_quoted_triggers(description: str) -> int:
-    """Count quoted trigger phrases like "some trigger" in description."""
-    return len(re.findall(r'"[^"]{2,}"', description))
-
-
-def _has_trigger_phrases(description: str) -> bool:
-    """Check if description contains 'Trigger' or quoted trigger patterns."""
-    if "Trigger" in description:
-        return True
-    return _count_quoted_triggers(description) > 0
-
-
-def _has_use_clause(description: str) -> bool:
-    """Check for 'Use this' or 'Use when' clause."""
-    return bool(re.search(r"Use\s+(this|when)", description))
-
-
-def _body_word_count(body: str) -> int:
-    return len(body.split())
-
-
-def _has_heading_pattern(body: str, pattern: str) -> bool:
-    return bool(re.search(rf"^#+\s+.*({pattern})", body, re.MULTILINE | re.IGNORECASE))
-
-
-def _has_code_blocks(body: str) -> bool:
-    return "```" in body
-
-
-def _has_tables(body: str) -> bool:
-    return bool(re.search(r"\|---", body))
-
-
-def _has_numbered_lists(body: str) -> bool:
-    return bool(re.search(r"^\s*\d+\.\s+", body, re.MULTILINE))
-
-
 def _is_kebab_case(name: str) -> bool:
-    return bool(re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name))
+    """Return whether a package directory name has the required format."""
+    return all(
+        part and part.replace("-", "").isalnum() and part == part.lower()
+        for part in name.split("-")
+    )
 
 
-def _has_cross_package_refs(body: str) -> bool:
-    return "../" in body
+def _finding(severity: str, message: str) -> dict[str, str]:
+    """Create a machine-readable conformance finding."""
+    return {"severity": severity, "message": message}
 
 
-def _has_references_dir(pkg_dir: Path) -> bool:
-    ref_dir = pkg_dir / "references"
-    if not ref_dir.is_dir():
-        return False
-    return any(ref_dir.iterdir())
+def evaluate_package(pkg_dir: Path, pkg_type: PackageType) -> dict[str, object]:
+    """Report type-specific static conformance for one package.
 
-
-def evaluate_package(
-    pkg_dir: Path, pkg_type: PackageType,
-) -> dict[str, object]:
-    """Evaluate a single package and return scoring results."""
+    Static checks establish installable package integrity only. They do not
+    estimate activation quality or instruction effectiveness; those are
+    measured by ``scripts.run_evals`` against declared cases.
+    """
     name = pkg_dir.name
     definition = pkg_dir / pkg_type.definition_file
-
-    scores: dict[str, int] = {d: 0 for d in DIMENSION_NAMES}
     findings: list[dict[str, str]] = []
-
-    # --- Parse frontmatter and body ---
+    requirements = [
+        "definition file",
+        "valid YAML frontmatter",
+        "type-required frontmatter",
+        "matching package name",
+        "kebab-case package directory",
+    ]
     meta: dict[str, object] | None = None
-    body = ""
-    description = ""
-    version_str = ""
-    yaml_valid = False
 
     if not definition.exists():
-        findings.append({"severity": "CRITICAL", "message": f"Missing definition file {pkg_type.definition_file}"})
+        findings.append(
+            _finding("CRITICAL", f"Missing definition file {pkg_type.definition_file}")
+        )
     else:
-        content = definition.read_text(encoding="utf-8")
         try:
-            meta = parse_frontmatter(content)
-            yaml_valid = True
-            body = extract_body(content)
-            description = str(meta.get("description", "")) if isinstance(meta, dict) else ""
-            version_str = extract_version(meta) if isinstance(meta, dict) else ""
+            parsed = parse_frontmatter(definition.read_text(encoding="utf-8"))
         except (ValueError, yaml.YAMLError) as exc:
-            findings.append({"severity": "CRITICAL", "message": f"Invalid YAML frontmatter: {exc}"})
+            findings.append(_finding("CRITICAL", f"Invalid YAML frontmatter: {exc}"))
+        else:
+            if isinstance(parsed, dict):
+                meta = parsed
+            else:
+                findings.append(_finding("CRITICAL", "Frontmatter must be a mapping"))
 
-    # Check required frontmatter fields
-    if meta is not None and isinstance(meta, dict):
+    if meta is not None:
         for field in pkg_type.required_frontmatter:
             if not meta.get(field):
-                findings.append({"severity": "CRITICAL", "message": f"Missing required frontmatter field: {field}"})
+                findings.append(
+                    _finding("CRITICAL", f"Missing required frontmatter field: {field}")
+                )
 
-    # ========== D1: Frontmatter Quality (20) ==========
-    desc_len = len(description)
-    if 200 <= desc_len <= 1024:
-        scores["D1 Frontmatter Quality"] += 10
-    elif 50 <= desc_len < 200:
-        scores["D1 Frontmatter Quality"] += 5
-    else:
-        findings.append({"severity": "HIGH", "message": f"Description length {desc_len} outside ideal range (200-1024)"})
+        frontmatter_name = str(meta.get("name", ""))
+        if frontmatter_name != name:
+            findings.append(
+                _finding(
+                    "CRITICAL",
+                    f"Frontmatter name '{frontmatter_name}' does not match directory '{name}'",
+                )
+            )
 
-    if _has_trigger_phrases(description):
-        scores["D1 Frontmatter Quality"] += 5
-    else:
-        findings.append({"severity": "HIGH", "message": "No trigger phrases in description"})
+        version = extract_version(meta)
+        if version and not validate_version(version):
+            findings.append(_finding("CRITICAL", f"Invalid package version: {version}"))
 
-    if _has_use_clause(description):
-        scores["D1 Frontmatter Quality"] += 5
+    if not _is_kebab_case(name):
+        findings.append(
+            _finding("CRITICAL", f"Package directory '{name}' is not kebab-case")
+        )
 
-    # ========== D2: Trigger Coverage (18) ==========
-    trigger_count = _count_quoted_triggers(description)
-    if trigger_count >= 6:
-        scores["D2 Trigger Coverage"] = 18
-    elif trigger_count >= 3:
-        scores["D2 Trigger Coverage"] = 12
-    elif trigger_count >= 1:
-        scores["D2 Trigger Coverage"] = 6
-    else:
-        findings.append({"severity": "HIGH", "message": "No quoted trigger phrases found"})
-
-    # ========== D3: Structural Completeness (20) ==========
-    if _has_heading_pattern(body, r"Step|Phase|Workflow|Stage"):
-        scores["D3 Structural Completeness"] += 8
-    else:
-        findings.append({"severity": "HIGH", "message": "No workflow/phases section found"})
-
-    if _has_heading_pattern(body, r"Error|Troubleshoot"):
-        scores["D3 Structural Completeness"] += 4
-
-    if _has_heading_pattern(body, r"Output"):
-        scores["D3 Structural Completeness"] += 4
-
-    if _has_references_dir(pkg_dir):
-        scores["D3 Structural Completeness"] += 4
-
-    # ========== D4: Content Depth (22) ==========
-    wc = _body_word_count(body)
-    if wc > 500:
-        scores["D4 Content Depth"] += 10
-    elif wc > 200:
-        scores["D4 Content Depth"] += 5
-
-    if _has_code_blocks(body):
-        scores["D4 Content Depth"] += 4
-
-    if _has_tables(body):
-        scores["D4 Content Depth"] += 4
-
-    if _has_numbered_lists(body):
-        scores["D4 Content Depth"] += 4
-
-    # ========== D5: Consistency & Integrity (12) ==========
-    fm_name = str(meta.get("name", "")) if isinstance(meta, dict) else ""
-    if fm_name == name:
-        scores["D5 Consistency"] += 6
-    else:
-        findings.append({"severity": "CRITICAL", "message": f"Frontmatter name '{fm_name}' does not match directory '{name}'"})
-
-    if not _has_cross_package_refs(body):
-        scores["D5 Consistency"] += 3
-
-    if version_str and validate_version(version_str):
-        scores["D5 Consistency"] += 3
-
-    # ========== D6: CONTRIBUTING Compliance (8) ==========
-    if _is_kebab_case(name):
-        scores["D6 Compliance"] += 4
-
-    if len(name) <= 64:
-        scores["D6 Compliance"] += 2
-
-    if yaml_valid:
-        scores["D6 Compliance"] += 2
-
-    # --- Compute totals ---
-    total = sum(scores.values())
-    max_total = sum(MAX_SCORES.values())
-
-    has_critical = any(f["severity"] == "CRITICAL" for f in findings)
-    if has_critical:
-        capped = int(max_total * 0.4)
-        total = min(total, capped)
-
-    percentage = int(total / max_total * 100)
-
+    status = "FAIL" if findings else "PASS"
     return {
+        "report_version": REPORT_VERSION,
         "name": name,
         "type": pkg_type.key,
-        "scores": scores,
-        "max_scores": dict(MAX_SCORES),
-        "total": total,
-        "percentage": percentage,
-        "status": "FAIL" if has_critical else "PASS",
+        "static_conformance": {
+            "status": status,
+            "requirements": requirements,
+            "findings": findings,
+        },
+        "live_effectiveness": {
+            "status": "NOT_MEASURED",
+            "runner": "scripts/run_evals.py",
+            "dimensions": list(EFFECTIVENESS_DIMENSIONS[pkg_type.key]),
+        },
+        "status": status,
         "findings": findings,
     }
 
 
-def evaluate_all(threshold: int) -> list[dict[str, object]]:
-    """Evaluate all packages across all types."""
-    results: list[dict[str, object]] = []
+def _package_directories() -> list[tuple[Path, PackageType]]:
+    """Return every active package definition with its type contract."""
+    packages: list[tuple[Path, PackageType]] = []
     for pkg_type in TYPES.values():
-        type_dir = pkg_type.repo_dir
-        if not type_dir.exists():
+        if not pkg_type.repo_dir.exists():
             continue
-        for pkg_dir in sorted(type_dir.iterdir()):
+        for pkg_dir in sorted(pkg_type.repo_dir.iterdir()):
             if not pkg_dir.is_dir() or pkg_dir.name.startswith("."):
                 continue
-            definition = pkg_dir / pkg_type.definition_file
-            if not definition.exists():
-                continue
-            result = evaluate_package(pkg_dir, pkg_type)
-            if result["percentage"] < threshold:  # type: ignore[operator]
-                result["status"] = "FAIL"
-            results.append(result)
-    return results
+            if (pkg_dir / pkg_type.definition_file).exists():
+                packages.append((pkg_dir, pkg_type))
+    return packages
 
 
-def evaluate_single(path: str, threshold: int) -> list[dict[str, object]]:
-    """Evaluate a single package by path."""
-    from scripts.package_types import detect_type_from_path
+def evaluate_all() -> list[dict[str, object]]:
+    """Report static conformance for every active package."""
+    return [
+        evaluate_package(pkg_dir, pkg_type)
+        for pkg_dir, pkg_type in _package_directories()
+    ]
 
+
+def evaluate_single(path: str) -> list[dict[str, object]]:
+    """Report static conformance for a single package path."""
     pkg_dir = Path(path).resolve()
     if not pkg_dir.is_dir():
         pkg_dir = REPO_ROOT / path
     if not pkg_dir.is_dir():
-        print(f"Error: path '{path}' is not a valid directory", file=sys.stderr)
-        sys.exit(1)
-
-    pkg_type = detect_type_from_path(pkg_dir)
-    result = evaluate_package(pkg_dir, pkg_type)
-    if result["percentage"] < threshold:  # type: ignore[operator]
-        result["status"] = "FAIL"
-    return [result]
+        msg = f"Error: path '{path}' is not a valid directory"
+        raise ValueError(msg)
+    return [evaluate_package(pkg_dir, detect_type_from_path(pkg_dir))]
 
 
 def print_text(results: list[dict[str, object]]) -> None:
-    """Print results in human-readable text format."""
-    for r in results:
-        scores = r["scores"]
-        max_scores = r["max_scores"]
-        assert isinstance(scores, dict)
-        assert isinstance(max_scores, dict)
-
-        print(f"Package: {r['name']} ({r['type']})")
-        for dim in DIMENSION_NAMES:
-            label = f"  {dim}:"
-            value = f"{scores[dim]}/{max_scores[dim]}"
-            print(f"{label:<36s}{value:>6s}")
-        print(f"  {'Overall:':<34s}{r['total']}/{sum(max_scores.values())} ({r['percentage']}%)")
-        print(f"  Status: {r['status']}")
-        if r["findings"]:
-            findings = r["findings"]
-            assert isinstance(findings, list)
-            for f in findings:
-                assert isinstance(f, dict)
-                print(f"    [{f['severity']}] {f['message']}")
+    """Print static conformance and live-effectiveness status distinctly."""
+    for result in results:
+        conformance = cast(dict[str, object], result["static_conformance"])
+        effectiveness = cast(dict[str, object], result["live_effectiveness"])
+        dimensions = cast(list[str], effectiveness["dimensions"])
+        findings = cast(list[dict[str, str]], conformance["findings"])
+        print(f"Package: {result['name']} ({result['type']})")
+        print(f"  Static conformance: {conformance['status']}")
+        print(f"  Live effectiveness: {effectiveness['status']}")
+        print(f"  Effectiveness dimensions: {', '.join(dimensions)}")
+        for finding in findings:
+            print(f"    [{finding['severity']}] {finding['message']}")
         print()
 
-    passed = sum(1 for r in results if r["status"] == "PASS")
-    failed = len(results) - passed
-    print(f"Summary: {len(results)} packages evaluated, {passed} passed, {failed} failed")
+    passed = sum(1 for result in results if result["status"] == "PASS")
+    print(
+        f"Summary: {len(results)} packages evaluated, {passed} conformant, {len(results) - passed} failed"
+    )
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Evaluate package quality")
+    """Run the static conformance report."""
+    parser = argparse.ArgumentParser(description="Report static package conformance")
     parser.add_argument("--path", type=str, help="Evaluate a single package by path")
-    parser.add_argument("--threshold", type=int, default=70, help="Minimum passing score (default: 70)")
-    parser.add_argument("--json", action="store_true", dest="json_output", help="Output JSON instead of text")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output JSON instead of text",
+    )
     args = parser.parse_args()
 
-    if args.path:
-        results = evaluate_single(args.path, args.threshold)
-    else:
-        results = evaluate_all(args.threshold)
+    try:
+        results = evaluate_single(args.path) if args.path else evaluate_all()
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
 
     if args.json_output:
         print(json.dumps(results, indent=2))
     else:
         print_text(results)
 
-    has_failure = any(r["status"] == "FAIL" for r in results)
-    return 1 if has_failure else 0
+    return 1 if any(result["status"] == "FAIL" for result in results) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -10,11 +10,13 @@ Usage:
     uv run python scripts/run_evals.py --all --timeout-per-case 120
     uv run python scripts/run_evals.py --package skills/immune --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -27,11 +29,32 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-import yaml
 
-from scripts.eval_assertions import run_all_assertions
-from scripts.package_types import TYPES
-from scripts.task_signature import task_signature
+import yaml  # noqa: E402
+
+from scripts.eval_assertions import AssertionResult, run_all_assertions  # noqa: E402
+from scripts.package_types import TYPES  # noqa: E402
+from scripts.task_signature import task_signature  # noqa: E402
+
+
+_ROUTE_PATTERN = re.compile(r"(?m)^ARMORY_EVAL_ROUTE:\s*(engaged|inactive)\s*$")
+
+
+def _evaluation_prompt(prompt: str) -> str:
+    """Append the declared-routing receipt required by the eval harness."""
+    return (
+        f"{prompt}\n\n"
+        "Evaluation receipt: append exactly one final line in this form after answering:\n"
+        "ARMORY_EVAL_ROUTE: engaged|inactive\n"
+        "Use engaged only when the package supplied for this evaluation materially guided "
+        "your response. Use inactive when it did not."
+    )
+
+
+def _declared_route(output: str) -> str | None:
+    """Return the unambiguous routing declaration emitted by an eval run."""
+    routes = _ROUTE_PATTERN.findall(output)
+    return routes[0] if len(routes) == 1 else None
 
 
 @dataclass
@@ -81,12 +104,28 @@ def load_cases(pkg_dir: Path) -> list[dict] | None:
     return data["cases"]
 
 
+def _assertion_details(results: list[AssertionResult]) -> list[dict[str, object]]:
+    """Serialize assertion results for the stable eval receipt."""
+    return [
+        {
+            "type": result.assertion_type,
+            "target": result.target,
+            "passed": result.passed,
+            "weight": result.weight,
+            "detail": result.detail,
+        }
+        for result in results
+    ]
+
+
 def _git_untracked_files(repo_root: Path) -> set[str]:
     """List untracked files in a git repo via git status --porcelain."""
     try:
         result = subprocess.run(
             ["git", "status", "--porcelain"],
-            capture_output=True, text=True, cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
         )
         files: set[str] = set()
         for line in result.stdout.strip().splitlines():
@@ -146,10 +185,21 @@ def execute_case(
         result = subprocess.run(
             [
                 "claude",
-                "-p", prompt,
-                "--add-dir", str(pkg_dir),
-                "--output-format", "text",
-                "--allowedTools", "Read", "Glob", "Grep", "Write", "Edit", "Bash",
+                "-p",
+                _evaluation_prompt(prompt),
+                "--add-dir",
+                str(pkg_dir),
+                "--output-format",
+                "text",
+                "--strict-mcp-config",
+                "--no-session-persistence",
+                "--allowedTools",
+                "Read",
+                "Glob",
+                "Grep",
+                "Write",
+                "Edit",
+                "Bash",
             ],
             capture_output=True,
             text=True,
@@ -212,21 +262,35 @@ def execute_case(
     shutil.rmtree(tmpdir, ignore_errors=True)
     elapsed_ms = (time.monotonic_ns() // 1_000_000) - start_ms
 
-    # For negative cases (trigger_expected: false), pass if no substantial output
-    # or the agent did not engage with the package's domain
     if not trigger_expected:
-        verdict = "pass"  # Negative cases are validated by the schema, not execution
+        route = _declared_route(output)
+        assertions_passed = True
+        assertion_details: list[dict[str, object]] = []
+        weighted_score = 1.0
+        if assertions:
+            assertions_passed, weighted_score, results = run_all_assertions(
+                output, assertions
+            )
+            assertion_details = _assertion_details(results)
+        passed = exit_code == 0 and route == "inactive" and assertions_passed
+        if passed:
+            error = None
+        elif route == "engaged":
+            error = "negative route reported package engagement"
+        else:
+            error = "missing or ambiguous routing declaration"
         return CaseResult(
             case_id=case_id,
             prompt=prompt,
             trigger_expected=trigger_expected,
-            oracle_verdict=verdict,
-            weighted_score=1.0,
-            assertion_details=[],
+            oracle_verdict="pass" if passed else "fail",
+            weighted_score=weighted_score if passed else 0.0,
+            assertion_details=assertion_details,
             execution_time_ms=elapsed_ms,
+            error=error,
         )
 
-    # For positive cases: check assertions if present, otherwise pass on non-zero output
+    # Positive cases without assertions retain the existing non-empty-output oracle.
     if not assertions:
         verdict = "pass" if (exit_code == 0 and len(output.strip()) > 0) else "fail"
         return CaseResult(
@@ -240,16 +304,7 @@ def execute_case(
         )
 
     all_passed, weighted_score, results = run_all_assertions(output, assertions)
-    assertion_details = [
-        {
-            "type": r.assertion_type,
-            "target": r.target,
-            "passed": r.passed,
-            "weight": r.weight,
-            "detail": r.detail,
-        }
-        for r in results
-    ]
+    assertion_details = _assertion_details(results)
 
     return CaseResult(
         case_id=case_id,
@@ -287,7 +342,9 @@ def run_package_evals(
     failed = sum(1 for r in results if r.oracle_verdict == "fail")
     skipped = sum(1 for r in results if r.oracle_verdict == "skipped")
     total = len(results)
-    aggregate_score = sum(r.weighted_score for r in results) / total if total > 0 else 0.0
+    aggregate_score = (
+        sum(r.weighted_score for r in results) / total if total > 0 else 0.0
+    )
 
     return PackageResult(
         package_name=pkg_dir.name,
@@ -392,15 +449,31 @@ def write_history(results: list[PackageResult], history_path: Path) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Execute eval cases against live Claude sessions")
+    parser = argparse.ArgumentParser(
+        description="Execute eval cases against live Claude sessions"
+    )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--package", help="Path to a single package (relative to repo root)")
+    group.add_argument(
+        "--package", help="Path to a single package (relative to repo root)"
+    )
     group.add_argument("--all", action="store_true", help="Run evals for all packages")
-    parser.add_argument("--timeout-per-case", type=int, default=120, help="Timeout per case in seconds")
-    parser.add_argument("--output", default="evals/results.json", help="Output file path")
-    parser.add_argument("--history", default="evals/history.jsonl", help="Append-only history log path")
-    parser.add_argument("--no-history", action="store_true", help="Skip appending to the history log")
-    parser.add_argument("--dry-run", action="store_true", help="Skip actual execution, validate structure only")
+    parser.add_argument(
+        "--timeout-per-case", type=int, default=120, help="Timeout per case in seconds"
+    )
+    parser.add_argument(
+        "--output", default="evals/results.json", help="Output file path"
+    )
+    parser.add_argument(
+        "--history", default="evals/history.jsonl", help="Append-only history log path"
+    )
+    parser.add_argument(
+        "--no-history", action="store_true", help="Skip appending to the history log"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip actual execution, validate structure only",
+    )
     args = parser.parse_args()
 
     packages = collect_all_packages() if args.all else [args.package]
@@ -412,7 +485,9 @@ def main() -> int:
         if result is not None:
             results.append(result)
             status = "PASS" if result.failed == 0 else "FAIL"
-            print(f"  {status}: {result.passed}/{result.total_cases} passed (score: {result.aggregate_score:.2f})")
+            print(
+                f"  {status}: {result.passed}/{result.total_cases} passed (score: {result.aggregate_score:.2f})"
+            )
 
     output_path = _REPO_ROOT / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_evaluation_contracts.py
+++ b/tests/test_evaluation_contracts.py
@@ -1,0 +1,124 @@
+"""Regression tests for static conformance and executable routing evidence."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import cast
+import pytest
+
+from scripts.evaluate_package import evaluate_package
+from scripts.package_types import TYPES
+from scripts.run_evals import execute_case
+
+
+def _write_skill(package_dir: Path, *, description: str = "Short description.") -> None:
+    package_dir.mkdir()
+    (package_dir / "SKILL.md").write_text(
+        f"---\nname: sample-skill\ndescription: {description}\n---\n\n# Sample\n",
+        encoding="utf-8",
+    )
+
+
+def test_static_conformance_does_not_reward_body_shape(tmp_path: Path) -> None:
+    package_dir = tmp_path / "sample-skill"
+    _write_skill(package_dir, description="Tiny.")
+
+    result = evaluate_package(package_dir, TYPES["skill"])
+    static_conformance = cast(dict[str, object], result["static_conformance"])
+    live_effectiveness = cast(dict[str, object], result["live_effectiveness"])
+    assert result["report_version"] == 2
+    assert result["status"] == "PASS"
+    assert static_conformance["status"] == "PASS"
+    assert live_effectiveness["status"] == "NOT_MEASURED"
+
+
+def test_static_conformance_reports_type_specific_frontmatter(tmp_path: Path) -> None:
+    package_dir = tmp_path / "sample-hook"
+    package_dir.mkdir()
+    (package_dir / "HOOK.md").write_text(
+        "---\nname: sample-hook\ndescription: Test hook.\n---\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate_package(package_dir, TYPES["hook"])
+
+    findings = cast(list[dict[str, str]], result["findings"])
+    live_effectiveness = cast(dict[str, object], result["live_effectiveness"])
+    messages = [finding["message"] for finding in findings]
+    assert result["status"] == "FAIL"
+    assert "Missing required frontmatter field: hook" in messages
+    assert live_effectiveness["dimensions"] == [
+        "event handling",
+        "observable side effect",
+    ]
+
+
+def test_negative_case_fails_when_route_reports_engagement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "scripts.run_evals.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, "Package engaged\nARMORY_EVAL_ROUTE: engaged", ""
+        ),
+    )
+    package_dir = tmp_path / "sample-skill"
+    package_dir.mkdir()
+    case = {
+        "id": "negative-routing",
+        "prompt": "Unrelated request",
+        "trigger_expected": False,
+    }
+
+    result = execute_case(case, package_dir, timeout_seconds=1)
+
+    assert result.oracle_verdict == "fail"
+    assert result.weighted_score == 0.0
+    assert result.error == "negative route reported package engagement"
+
+
+def test_negative_case_passes_when_route_reports_inactive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "scripts.run_evals.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, "Direct answer\nARMORY_EVAL_ROUTE: inactive", ""
+        ),
+    )
+    package_dir = tmp_path / "sample-skill"
+    package_dir.mkdir()
+    case = {
+        "id": "negative-routing",
+        "prompt": "Unrelated request",
+        "trigger_expected": False,
+    }
+
+    result = execute_case(case, package_dir, timeout_seconds=1)
+
+    assert result.oracle_verdict == "pass"
+    assert result.error is None
+
+
+def test_negative_case_without_route_marker_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "scripts.run_evals.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, "Direct answer", ""
+        ),
+    )
+    package_dir = tmp_path / "sample-skill"
+    package_dir.mkdir()
+    case = {
+        "id": "negative-routing",
+        "prompt": "Unrelated request",
+        "trigger_expected": False,
+    }
+
+    result = execute_case(case, package_dir, timeout_seconds=1)
+
+    assert result.oracle_verdict == "fail"
+    assert result.error == "missing or ambiguous routing declaration"


### PR DESCRIPTION
## Summary

- replaces static length, formatting, and trigger-count scoring with a versioned type-specific static-conformance report
- labels live effectiveness as `NOT_MEASURED` and declares the relevant dimensions per package type
- requires every live negative routing case to declare one `engaged` or `inactive` routing receipt; absent, ambiguous, or engaged results fail
- isolates live evaluator sessions from ambient MCP configuration and session persistence

The routing receipt is explicit model-provided evidence, not a claim of client-native activation telemetry. M2 remains responsible for discovering and recording client-native disclosure capability.

## Stack

Stack-Id: `m1-evaluation-integrity-20260823`
Base: `main`
Position: 1/2

1. `refactor/evals-type-valid-contracts` -> this PR
2. coverage and CI enforcement -> pending child branch

Depends on: none
Upstack: pending

## Validation

- `uv run ruff check scripts/evaluate_package.py scripts/run_evals.py tests/test_evaluation_contracts.py`
- `uv run ruff format --check scripts/evaluate_package.py scripts/run_evals.py tests/test_evaluation_contracts.py`
- `uv run pytest tests/test_evaluation_contracts.py tests/test_run_evals_history.py tests/test_package_types.py`
- `uv run python scripts/validate_evals.py`
- `uv run python scripts/evaluate_package.py --path skills/task-decomposer`

No release artifacts changed; the local M1 plan defers version and changelog work until its release-train trigger.