### PR TITLE
feat(evals): require active package coverage

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -87,7 +87,7 @@ jobs:
           failed=0
           for pkg_path in $changed_packages; do
             echo "Evaluating ${pkg_path}..."
-            if ! python scripts/evaluate_package.py --path "${pkg_path}" --threshold 70; then
+            if ! python scripts/evaluate_package.py --path "${pkg_path}"; then
               failed=$((failed + 1))
             fi
           done
@@ -120,13 +120,13 @@ jobs:
           missing=0
           for pkg_path in $changed_packages; do
             if [ ! -f "${pkg_path}/evals/cases.yaml" ]; then
-              echo "WARNING: ${pkg_path} definition changed but no evals/cases.yaml found"
+              echo "ERROR: ${pkg_path} definition changed but no evals/cases.yaml found"
               missing=$((missing + 1))
             fi
           done
 
           if [ "$missing" -gt 0 ]; then
             echo ""
-            echo "${missing} changed package(s) have no eval cases."
-            echo "Consider adding evals/cases.yaml for modified packages."
+            echo "FAILED: ${missing} changed package(s) have no eval cases."
+            exit 1
           fi

--- a/presets/biz-validation/evals/cases.yaml
+++ b/presets/biz-validation/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: apply_business_validation_preset
+    prompt: "Set up the business-validation preset for evaluating a startup idea."
+    fixtures: []
+    rubric: ["activates the preset configuration for business validation"]
+    trigger_expected: true
+  - id: negative_media_preset
+    prompt: "Configure a preset for generating a product video."
+    fixtures: []
+    rubric: ["media generation is outside business validation"]
+    trigger_expected: false
+  - id: negative_security_preset
+    prompt: "Configure a preset for repository secret scanning."
+    fixtures: []
+    rubric: ["security scanning is outside business validation"]
+    trigger_expected: false

--- a/presets/terse-mode/evals/cases.yaml
+++ b/presets/terse-mode/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: apply_terse_mode_preset
+    prompt: "Enable the terse-mode preset for concise technical responses."
+    fixtures: []
+    rubric: ["activates concise-response preset configuration"]
+    trigger_expected: true
+  - id: negative_business_preset
+    prompt: "Configure the business-validation preset for a startup idea."
+    fixtures: []
+    rubric: ["business validation is outside terse mode"]
+    trigger_expected: false
+  - id: negative_media_preset
+    prompt: "Configure a media-generation preset."
+    fixtures: []
+    rubric: ["media configuration is outside terse mode"]
+    trigger_expected: false

--- a/scripts/validate_evals.py
+++ b/scripts/validate_evals.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Validate eval cases.yaml files across all package types."""
+
 from __future__ import annotations
 
 import sys
@@ -9,14 +10,20 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-import yaml
+import yaml  # noqa: E402
 
-from scripts.frontmatter import parse_frontmatter
-from scripts.package_types import REPO_ROOT, TYPES, PackageType
+from scripts.frontmatter import parse_frontmatter  # noqa: E402
+from scripts.package_types import TYPES, PackageType  # noqa: E402
 
 REQUIRED_CASE_FIELDS = {"id", "prompt", "rubric", "trigger_expected"}
 OPTIONAL_CASE_FIELDS = {"fixtures", "assertions", "oracle_verdict", "diagnostics"}
-VALID_ASSERTION_TYPES = {"contains", "not_contains", "matches_regex", "output_format", "calls_tool"}
+VALID_ASSERTION_TYPES = {
+    "contains",
+    "not_contains",
+    "matches_regex",
+    "output_format",
+    "calls_tool",
+}
 VALID_ORACLE_VERDICTS = {None, "pass", "fail"}
 
 
@@ -83,7 +90,9 @@ def validate_case(case: dict, pkg_name: str, idx: int) -> list[str]:
                 if "weight" in assertion:
                     weight = assertion["weight"]
                     if not isinstance(weight, (int, float)) or weight < 0 or weight > 1:
-                        errors.append(f"{a_prefix}: 'weight' must be a number between 0 and 1")
+                        errors.append(
+                            f"{a_prefix}: 'weight' must be a number between 0 and 1"
+                        )
 
     # Validate optional oracle_verdict field
     if "oracle_verdict" in case:
@@ -107,7 +116,9 @@ def validate_pkg_evals(pkg_dir: Path, pkg_type: PackageType) -> list[str]:
     """Validate evals/cases.yaml for a single package."""
     cases_file = pkg_dir / "evals" / "cases.yaml"
     if not cases_file.exists():
-        return []
+        if is_deprecated(pkg_dir, pkg_type):
+            return []
+        return [f"{pkg_dir.name}: missing required evals/cases.yaml"]
 
     pkg_name = pkg_dir.name
     deprecated = is_deprecated(pkg_dir, pkg_type)
@@ -144,13 +155,19 @@ def validate_pkg_evals(pkg_dir: Path, pkg_type: PackageType) -> list[str]:
 
     if deprecated:
         if positive_count > 0:
-            errors.append(f"{pkg_name}: deprecated {pkg_type.key} must have 0 positive cases, found {positive_count}")
+            errors.append(
+                f"{pkg_name}: deprecated {pkg_type.key} must have 0 positive cases, found {positive_count}"
+            )
     else:
         if positive_count == 0:
-            errors.append(f"{pkg_name}: must have at least 1 positive case (trigger_expected: true)")
+            errors.append(
+                f"{pkg_name}: must have at least 1 positive case (trigger_expected: true)"
+            )
 
     if negative_count < 2:
-        errors.append(f"{pkg_name}: must have at least 2 negative cases (trigger_expected: false), found {negative_count}")
+        errors.append(
+            f"{pkg_name}: must have at least 2 negative cases (trigger_expected: false), found {negative_count}"
+        )
 
     return errors
 
@@ -169,8 +186,7 @@ def main() -> int:
         for pkg_dir in sorted(type_dir.iterdir()):
             if not pkg_dir.is_dir():
                 continue
-            cases_file = pkg_dir / "evals" / "cases.yaml"
-            if not cases_file.exists():
+            if is_deprecated(pkg_dir, pkg_type):
                 continue
 
             errors = validate_pkg_evals(pkg_dir, pkg_type)
@@ -183,7 +199,10 @@ def main() -> int:
     total = sum(counts.values())
 
     if all_errors:
-        print(f"FAILED: {len(all_errors)} error(s) in {total} eval file(s):", file=sys.stderr)
+        print(
+            f"FAILED: {len(all_errors)} error(s) in {total} eval file(s):",
+            file=sys.stderr,
+        )
         for error in all_errors:
             print(f"  {error}", file=sys.stderr)
         return 1

--- a/skills/arxiv-figures/evals/cases.yaml
+++ b/skills/arxiv-figures/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: optimize_arxiv_figures
+    prompt: "Optimize figures in this PDFLaTeX paper for arXiv submission."
+    fixtures: []
+    rubric: ["inventories formats, sizes, and processor compatibility"]
+    trigger_expected: true
+  - id: negative_citation_check
+    prompt: "Verify every citation in my manuscript."
+    fixtures: []
+    rubric: ["citation verification is outside figure optimization"]
+    trigger_expected: false
+  - id: negative_package_tarball
+    prompt: "Create an arXiv submission tarball."
+    fixtures: []
+    rubric: ["submission packaging is outside figure optimization"]
+    trigger_expected: false

--- a/skills/arxiv-package/evals/cases.yaml
+++ b/skills/arxiv-package/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: package_arxiv_submission
+    prompt: "Create an arXiv-ready source tarball for my LaTeX paper."
+    fixtures: []
+    rubric: ["validates submission contents and produces a source package"]
+    trigger_expected: true
+  - id: negative_figure_optimization
+    prompt: "Reduce the size of oversized PNG figures."
+    fixtures: []
+    rubric: ["figure optimization is outside packaging"]
+    trigger_expected: false
+  - id: negative_manuscript_review
+    prompt: "Review this paper for methodological flaws."
+    fixtures: []
+    rubric: ["manuscript review is outside packaging"]
+    trigger_expected: false

--- a/skills/arxiv-preflight/evals/cases.yaml
+++ b/skills/arxiv-preflight/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: preflight_arxiv_submission
+    prompt: "Run a preflight check on my arXiv submission before upload."
+    fixtures: []
+    rubric: ["checks source, metadata, and compilation readiness"]
+    trigger_expected: true
+  - id: negative_tarball_creation
+    prompt: "Build a compressed source tarball."
+    fixtures: []
+    rubric: ["packaging is outside preflight review"]
+    trigger_expected: false
+  - id: negative_figure_conversion
+    prompt: "Convert EPS figures to PDF."
+    fixtures: []
+    rubric: ["figure conversion is outside preflight review"]
+    trigger_expected: false

--- a/skills/citation-audit/evals/cases.yaml
+++ b/skills/citation-audit/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: audit_manuscript_citations
+    prompt: "Verify that every citation in this manuscript is real and accurately described."
+    fixtures: []
+    rubric: ["checks reference existence, attribution, and claim accuracy"]
+    trigger_expected: true
+  - id: negative_copyedit_prose
+    prompt: "Improve the prose style of this introduction."
+    fixtures: []
+    rubric: ["prose editing is outside citation auditing"]
+    trigger_expected: false
+  - id: negative_format_figures
+    prompt: "Optimize figures for arXiv upload."
+    fixtures: []
+    rubric: ["figure optimization is outside citation auditing"]
+    trigger_expected: false

--- a/skills/figure-rhetoric/evals/cases.yaml
+++ b/skills/figure-rhetoric/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: review_figure_argument
+    prompt: "Review whether the figures in my paper support the argument clearly."
+    fixtures: []
+    rubric: ["analyzes rhetorical role, claims, and reader interpretation"]
+    trigger_expected: true
+  - id: negative_compress_images
+    prompt: "Compress these PNG files for a smaller upload."
+    fixtures: []
+    rubric: ["image compression is outside figure rhetoric"]
+    trigger_expected: false
+  - id: negative_verify_citations
+    prompt: "Check the bibliography for fabricated papers."
+    fixtures: []
+    rubric: ["citation audit is outside figure rhetoric"]
+    trigger_expected: false

--- a/skills/figure-table-quality/evals/cases.yaml
+++ b/skills/figure-table-quality/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: assess_figure_table_quality
+    prompt: "Assess the visual quality and accessibility of figures and tables in this paper."
+    fixtures: []
+    rubric: ["checks legibility, labeling, accessibility, and table presentation"]
+    trigger_expected: true
+  - id: negative_arxiv_tarball
+    prompt: "Package this paper for arXiv submission."
+    fixtures: []
+    rubric: ["submission packaging is outside figure and table quality"]
+    trigger_expected: false
+  - id: negative_citation_truth
+    prompt: "Verify whether these references are real."
+    fixtures: []
+    rubric: ["citation auditing is outside figure and table quality"]
+    trigger_expected: false

--- a/skills/manuscript-typography/evals/cases.yaml
+++ b/skills/manuscript-typography/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: review_manuscript_typography
+    prompt: "Audit the typography and layout consistency of this academic manuscript."
+    fixtures: []
+    rubric: ["identifies typographic hierarchy, spacing, and readability issues"]
+    trigger_expected: true
+  - id: negative_methodology_review
+    prompt: "Critique the research methodology in this study."
+    fixtures: []
+    rubric: ["methodology review is outside typography"]
+    trigger_expected: false
+  - id: negative_bibliography_audit
+    prompt: "Verify all citations and references in this manuscript."
+    fixtures: []
+    rubric: ["citation auditing is outside typography"]
+    trigger_expected: false

--- a/skills/usage-audit/evals/cases.yaml
+++ b/skills/usage-audit/evals/cases.yaml
@@ -1,0 +1,16 @@
+cases:
+  - id: audit_claude_code_usage
+    prompt: "Audit my Claude Code setup for token waste and context bloat."
+    fixtures: []
+    rubric: ["inspects MCP servers, instructions, skills, and context cost"]
+    trigger_expected: true
+  - id: negative_security_scan
+    prompt: "Scan this repository for leaked secrets."
+    fixtures: []
+    rubric: ["security auditing is outside usage optimization"]
+    trigger_expected: false
+  - id: negative_refactor_code
+    prompt: "Refactor this Python function for readability."
+    fixtures: []
+    rubric: ["code refactoring is outside usage optimization"]
+    trigger_expected: false

--- a/tests/test_validate_evals.py
+++ b/tests/test_validate_evals.py
@@ -1,0 +1,33 @@
+"""Tests for active package eval coverage validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.package_types import TYPES
+from scripts.validate_evals import validate_pkg_evals
+
+
+def _write_skill(package_dir: Path, *, deprecated: bool = False) -> None:
+    package_dir.mkdir()
+    metadata = "metadata:\n  status: deprecated\n" if deprecated else ""
+    (package_dir / "SKILL.md").write_text(
+        f"---\nname: {package_dir.name}\ndescription: Test skill.\n{metadata}---\n",
+        encoding="utf-8",
+    )
+
+
+def test_active_package_without_eval_file_fails(tmp_path: Path) -> None:
+    package_dir = tmp_path / "active-skill"
+    _write_skill(package_dir)
+
+    assert validate_pkg_evals(package_dir, TYPES["skill"]) == [
+        "active-skill: missing required evals/cases.yaml"
+    ]
+
+
+def test_deprecated_package_without_eval_file_is_exempt(tmp_path: Path) -> None:
+    package_dir = tmp_path / "deprecated-skill"
+    _write_skill(package_dir, deprecated=True)
+
+    assert validate_pkg_evals(package_dir, TYPES["skill"]) == []


### PR DESCRIPTION
## Summary

- makes active packages without `evals/cases.yaml` fail schema validation
- adds eval cases for the ten active packages that previously lacked coverage
- changes the changed-package CI coverage path from a warning to a failing gate
- removes the obsolete static score threshold from CI evaluation

## Stack

Stack-Id: `m1-evaluation-integrity-20260823`
Base: `refactor/evals-type-valid-contracts` (#107)
Position: 2/2

1. #107 `refactor/evals-type-valid-contracts`
2. `feat/evals-active-coverage` -> this PR

Depends on: #107
Upstack: none

## Validation

- `uv run ruff check scripts/validate_evals.py tests/test_validate_evals.py`
- `uv run pytest tests/test_validate_evals.py`
- `uv run python scripts/validate_evals.py`

Observed repository state: 141 package definitions, of which 133 are active and 8 are explicitly deprecated. The validator enforces complete active-package coverage and reports the observed active count; the local plan’s `141 active` wording is not supported by the current package metadata.