### PR TITLE
feat(model-fit): capture disclosure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ uv run python scripts/model_fit.py --target claude-code-opus-xhigh --profile ful
 
 Dry runs read `claude --version` and resolve repository package definitions only. They report discovery metadata and explicitly state that package content was not loaded. They do not install a profile or make a paid call.
 
+Use `--live --output /path/to/receipt.json` only when a model request is authorized. The probe disables built-in tools, suppresses ambient MCP configuration, and does not persist sessions. Its receipt stores derived fields only: declared target/profile/tool surface, client version, an observed model that must match the target's declared prefix, required token fields, wall time, and terminal metadata. Raw prompts, assistant text, and stream events are never retained. A missing or changed required field exits non-zero; the probe never estimates a token value.
+
 ### Skills — Development & Tooling
 
 | Skill                                            | Description                                                                                                                                                 |

--- a/scripts/model_fit.py
+++ b/scripts/model_fit.py
@@ -10,9 +10,12 @@ package was injected into a turn.
 from __future__ import annotations
 
 import argparse
+import os
 import json
 import subprocess
+import signal
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Literal, TypeAlias, cast
@@ -327,6 +330,195 @@ def dry_run(target: ModelFitTarget, profiles: tuple[str, ...]) -> dict[str, Json
     }
 
 
+class ModelFitCaptureError(RuntimeError):
+    """Raised when a live client response cannot supply declared evidence."""
+
+
+def _probe_command(target: ModelFitTarget) -> list[str]:
+    return [
+        "claude",
+        "-p",
+        "Reply with exactly READY.",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        target.model,
+        "--effort",
+        target.effort,
+        "--strict-mcp-config",
+        "--no-session-persistence",
+        "--tools",
+        ",".join(target.tool_surface),
+    ]
+
+
+def _require_event_mapping(value: JsonValue, location: str) -> RawMapping:
+    if not isinstance(value, dict):
+        raise ModelFitCaptureError(
+            f"malformed client disclosure: {location} must be a mapping",
+        )
+    return value
+
+
+def _parse_stream_events(stdout: str) -> tuple[RawMapping, ...]:
+    events: list[RawMapping] = []
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = cast(JsonValue, json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ModelFitCaptureError(
+                f"malformed stream-json at line {line_number}: {exc.msg}",
+            ) from exc
+        events.append(
+            _require_event_mapping(value, f"stream event at line {line_number}")
+        )
+    if not events:
+        raise ModelFitCaptureError("client emitted no stream-json events")
+    return tuple(events)
+
+
+def _required_int(value: JsonValue, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ModelFitCaptureError(f"required telemetry missing: {field}")
+    return value
+
+
+def _capture_from_events(
+    events: tuple[RawMapping, ...],
+    target: ModelFitTarget,
+) -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+    models: set[str] = set()
+    terminal_events: list[RawMapping] = []
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "assistant":
+            message = _require_event_mapping(event.get("message"), "assistant.message")
+            model = message.get("model")
+            if isinstance(model, str) and model:
+                models.add(model)
+        elif event_type == "result":
+            terminal_events.append(event)
+
+    if not models:
+        raise ModelFitCaptureError(
+            "required telemetry missing: model (assistant.message.model)",
+        )
+    if len(models) != 1:
+        raise ModelFitCaptureError(
+            "model disclosure changed: assistant messages reported multiple model values",
+        )
+    observed_model = next(iter(models))
+    if not observed_model.startswith(target.expected_model_prefix):
+        raise ModelFitCaptureError(
+            f"observed model {observed_model!r} does not match expected prefix "
+            f"{target.expected_model_prefix!r}",
+        )
+    if len(terminal_events) != 1:
+        raise ModelFitCaptureError(
+            f"expected exactly one terminal result event, found {len(terminal_events)}",
+        )
+
+    terminal = terminal_events[0]
+    if terminal.get("is_error") is not False:
+        raise ModelFitCaptureError("terminal result does not declare is_error: false")
+    usage = _require_event_mapping(terminal.get("usage"), "result.usage")
+    observed_usage: dict[str, JsonValue] = {}
+    for field in target.required_telemetry:
+        if field == "usage.input_tokens":
+            observed_usage["input_tokens"] = _required_int(
+                usage.get("input_tokens"),
+                "usage.input_tokens (result.usage.input_tokens)",
+            )
+        elif field == "usage.output_tokens":
+            observed_usage["output_tokens"] = _required_int(
+                usage.get("output_tokens"),
+                "usage.output_tokens (result.usage.output_tokens)",
+            )
+
+    terminal_metadata: dict[str, JsonValue] = {}
+    for field in ("subtype", "stop_reason"):
+        value = terminal.get(field)
+        if isinstance(value, str) and value:
+            terminal_metadata[field] = value
+    return (
+        {
+            "model": observed_model,
+            "usage": observed_usage,
+        },
+        terminal_metadata,
+    )
+
+
+def live_probe(
+    target: ModelFitTarget,
+    profiles: tuple[str, ...],
+    timeout_seconds: int,
+) -> dict[str, JsonValue]:
+    """Invoke an explicitly requested live probe and retain derived fields only."""
+    if timeout_seconds <= 0:
+        raise ModelFitConfigError("timeout_seconds must be greater than zero")
+    declaration = dry_run(target, profiles)
+    started = time.monotonic_ns()
+    try:
+        process = subprocess.Popen(
+            _probe_command(target),
+            cwd=_REPO_ROOT,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            start_new_session=True,
+            text=True,
+        )
+        stdout, _stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.communicate()
+        raise ModelFitCaptureError(
+            f"live probe timed out after {timeout_seconds} seconds",
+        ) from exc
+    except OSError as exc:
+        raise ModelFitCaptureError(f"cannot execute Claude Code probe: {exc}") from exc
+    wall_time_ms = (time.monotonic_ns() - started) // 1_000_000
+    if process.returncode != 0:
+        raise ModelFitCaptureError(
+            f"Claude Code probe exited with status {process.returncode}; no receipt was written",
+        )
+    events = _parse_stream_events(stdout)
+    observed, terminal_metadata = _capture_from_events(events, target)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": "live",
+        "model_request_made": True,
+        "raw_receipt_retention": "derived-only",
+        "target": declaration["target"],
+        "client_version": declaration["client_version"],
+        "profile_manifests": declaration["profile_manifests"],
+        "package_content_observation": "not-observed",
+        "tool_surface": {
+            "declared": list(target.tool_surface),
+            "observed": "not-disclosed",
+        },
+        "observed": observed,
+        "terminal_metadata": terminal_metadata,
+        "wall_time_ms": wall_time_ms,
+        "stream_event_count": len(events),
+    }
+
+
+def write_receipt(path: Path, receipt: dict[str, JsonValue]) -> None:
+    """Persist a derived receipt; raw prompts, text, and stream events are excluded."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
@@ -336,29 +528,48 @@ def _parser() -> argparse.ArgumentParser:
         action="append",
         help="Declared target profile to validate; repeat to select multiple",
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
         "--dry-run",
         action="store_true",
         help="Validate declarations without invoking a model",
+    )
+    mode.add_argument(
+        "--live",
+        action="store_true",
+        help="Invoke the declared model and write a derived receipt",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Required receipt path for --live; raw events are never written",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=120,
+        help="External wall-clock deadline for --live (default: 120)",
     )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run dry-run validation for one declared target."""
-    args = _parser().parse_args(argv)
-    if not args.dry_run:
-        print(
-            "live probe execution is not available in this command version",
-            file=sys.stderr,
-        )
-        return 2
+    parser = _parser()
+    args = parser.parse_args(argv)
     try:
         config = load_model_fit_config(args.config)
         target = select_target(config, args.target)
-        profiles = tuple(args.profile) if args.profile else target.profiles
-        result = dry_run(target, profiles)
-    except ModelFitConfigError as exc:
+        profiles = (
+            tuple(dict.fromkeys(args.profile)) if args.profile else target.profiles
+        )
+        if args.dry_run:
+            result = dry_run(target, profiles)
+        else:
+            if args.output is None:
+                parser.error("--output is required with --live")
+            result = live_probe(target, profiles, args.timeout_seconds)
+            write_receipt(args.output, result)
+    except (ModelFitCaptureError, ModelFitConfigError) as exc:
         print(f"model-fit validation failed: {exc}", file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/tests/test_model_fit.py
+++ b/tests/test_model_fit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -140,3 +142,322 @@ def test_dry_run_rejects_profile_outside_target(tmp_path: Path) -> None:
 
     with pytest.raises(model_fit.ModelFitConfigError, match="does not declare profile"):
         model_fit.dry_run(config.targets[0], ("developer",))
+
+
+def _stream_output(
+    *,
+    model: str = "claude-opus-4-7-20250219",
+    output_tokens: int | None = 4,
+) -> str:
+    usage: dict[str, int] = {"input_tokens": 11}
+    if output_tokens is not None:
+        usage["output_tokens"] = output_tokens
+    return "\n".join(
+        (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "model": model,
+                        "content": "sensitive assistant text",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "stop_reason": "end_turn",
+                    "usage": usage,
+                }
+            ),
+        )
+    )
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        stdout: str,
+        returncode: int = 0,
+        timeout_once: bool = False,
+    ) -> None:
+        self.pid = 123
+        self.returncode = returncode
+        self._stdout = stdout
+        self._timeout_once = timeout_once
+
+    def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+        if timeout is not None and self._timeout_once:
+            self._timeout_once = False
+            raise subprocess.TimeoutExpired(["claude"], timeout)
+        return self._stdout, ""
+
+
+def test_probe_command_isolated_and_toolless(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    command = model_fit._probe_command(target)
+
+    assert command == [
+        "claude",
+        "-p",
+        "Reply with exactly READY.",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        "opus",
+        "--effort",
+        "xhigh",
+        "--strict-mcp-config",
+        "--no-session-persistence",
+        "--tools",
+        "",
+    ]
+
+
+def test_capture_maps_client_fields_without_retaining_raw_text(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+    observed, terminal_metadata = model_fit._capture_from_events(
+        model_fit._parse_stream_events(_stream_output()),
+        target,
+    )
+
+    assert observed == {
+        "model": "claude-opus-4-7-20250219",
+        "usage": {"input_tokens": 11, "output_tokens": 4},
+    }
+    assert terminal_metadata == {"subtype": "success", "stop_reason": "end_turn"}
+    assert "sensitive assistant text" not in json.dumps(observed | terminal_metadata)
+
+
+def test_capture_rejects_missing_required_telemetry(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    with pytest.raises(
+        model_fit.ModelFitCaptureError,
+        match=r"usage\.output_tokens",
+    ):
+        model_fit._capture_from_events(
+            model_fit._parse_stream_events(_stream_output(output_tokens=None)),
+            target,
+        )
+
+
+def test_live_probe_writes_derived_receipt_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+    monkeypatch.setattr(
+        model_fit,
+        "resolve_profile_manifest",
+        lambda profile: model_fit.ProfileManifest(profile=profile, packages=()),
+    )
+    monkeypatch.setattr(
+        model_fit, "probe_client_version", lambda: "2.1.241 (Claude Code)"
+    )
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    process = _FakeProcess(stdout=_stream_output())
+
+    def fake_popen(*args: object, **kwargs: object) -> _FakeProcess:
+        calls.append((args, kwargs))
+        return process
+
+    monkeypatch.setattr(model_fit.subprocess, "Popen", fake_popen)
+
+    receipt = model_fit.live_probe(target, ("core",), timeout_seconds=10)
+    output_path = tmp_path / "receipt.json"
+    model_fit.write_receipt(output_path, receipt)
+
+    persisted = output_path.read_text(encoding="utf-8")
+    assert receipt["schema_version"] == model_fit.SCHEMA_VERSION
+    assert receipt["mode"] == "live"
+    assert receipt["model_request_made"] is True
+    assert receipt["raw_receipt_retention"] == "derived-only"
+    assert receipt["package_content_observation"] == "not-observed"
+    assert receipt["tool_surface"] == {"declared": [], "observed": "not-disclosed"}
+    assert calls[0][1]["start_new_session"] is True
+    assert "sensitive assistant text" not in persisted
+
+
+def test_live_mode_requires_output_path(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        model_fit.main(
+            [
+                "--config",
+                str(_write_config(tmp_path)),
+                "--target",
+                "claude-code-opus-xhigh",
+                "--live",
+            ]
+        )
+
+
+def test_capture_rejects_model_outside_declared_prefix(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    with pytest.raises(
+        model_fit.ModelFitCaptureError, match="does not match expected prefix"
+    ):
+        model_fit._capture_from_events(
+            model_fit._parse_stream_events(
+                _stream_output(model="claude-sonnet-4-7-20250219"),
+            ),
+            target,
+        )
+
+
+def test_stream_parser_skips_blank_lines(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    events = model_fit._parse_stream_events(f"\n{_stream_output()}\n\n")
+    observed, _metadata = model_fit._capture_from_events(events, target)
+
+    assert observed["model"] == "claude-opus-4-7-20250219"
+
+
+@pytest.mark.parametrize(
+    ("stream", "message"),
+    [
+        ("", "client emitted no stream-json events"),
+        ("not json", "malformed stream-json"),
+        ('{"type":"assistant","message":[]}', "malformed client disclosure"),
+        (
+            chr(10).join(
+                (
+                    '{"type":"assistant","message":{"model":"claude-opus-4-7-20250219"}}',
+                    '{"type":"result","is_error":false,"usage":{}}',
+                    '{"type":"result","is_error":false,"usage":{}}',
+                )
+            ),
+            "expected exactly one terminal result event",
+        ),
+    ],
+)
+def test_capture_rejects_malformed_client_disclosures(
+    tmp_path: Path,
+    stream: str,
+    message: str,
+) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    with pytest.raises(model_fit.ModelFitCaptureError, match=message):
+        events = model_fit._parse_stream_events(stream)
+        model_fit._capture_from_events(events, target)
+
+
+def test_capture_rejects_error_terminal(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+    stream = chr(10).join(
+        (
+            '{"type":"assistant","message":{"model":"claude-opus-4-7-20250219"}}',
+            '{"type":"result","is_error":true,"usage":{"input_tokens":1,"output_tokens":1}}',
+        )
+    )
+
+    with pytest.raises(model_fit.ModelFitCaptureError, match="is_error: false"):
+        model_fit._capture_from_events(model_fit._parse_stream_events(stream), target)
+
+
+def test_live_probe_rejects_nonzero_client_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+    monkeypatch.setattr(
+        model_fit,
+        "resolve_profile_manifest",
+        lambda profile: model_fit.ProfileManifest(profile=profile, packages=()),
+    )
+    monkeypatch.setattr(
+        model_fit, "probe_client_version", lambda: "2.1.241 (Claude Code)"
+    )
+    monkeypatch.setattr(
+        model_fit.subprocess,
+        "Popen",
+        lambda *args, **kwargs: _FakeProcess(stdout="", returncode=1),
+    )
+
+    with pytest.raises(model_fit.ModelFitCaptureError, match="status 1"):
+        model_fit.live_probe(target, ("core",), timeout_seconds=10)
+
+
+def test_live_probe_kills_process_group_on_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+    monkeypatch.setattr(
+        model_fit,
+        "resolve_profile_manifest",
+        lambda profile: model_fit.ProfileManifest(profile=profile, packages=()),
+    )
+    monkeypatch.setattr(
+        model_fit, "probe_client_version", lambda: "2.1.241 (Claude Code)"
+    )
+    monkeypatch.setattr(
+        model_fit.subprocess,
+        "Popen",
+        lambda *args, **kwargs: _FakeProcess(stdout="", timeout_once=True),
+    )
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        model_fit.os,
+        "killpg",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    with pytest.raises(model_fit.ModelFitCaptureError, match="timed out after 10"):
+        model_fit.live_probe(target, ("core",), timeout_seconds=10)
+
+    assert killed == [(123, model_fit.signal.SIGKILL)]
+
+
+def test_live_probe_rejects_nonpositive_timeout(tmp_path: Path) -> None:
+    target = model_fit.load_model_fit_config(_write_config(tmp_path)).targets[0]
+
+    with pytest.raises(model_fit.ModelFitConfigError, match="greater than zero"):
+        model_fit.live_probe(target, ("core",), timeout_seconds=0)
+
+
+def test_main_deduplicates_selected_profiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setattr(
+        model_fit,
+        "resolve_profile_manifest",
+        lambda profile: model_fit.ProfileManifest(profile=profile, packages=()),
+    )
+    monkeypatch.setattr(
+        model_fit, "probe_client_version", lambda: "2.1.241 (Claude Code)"
+    )
+
+    result = model_fit.main(
+        [
+            "--config",
+            str(config_path),
+            "--target",
+            "claude-code-opus-xhigh",
+            "--profile",
+            "full",
+            "--profile",
+            "core",
+            "--profile",
+            "full",
+            "--dry-run",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert result == 0
+    assert [manifest["profile"] for manifest in payload["profile_manifests"]] == [
+        "full",
+        "core",
+    ]


### PR DESCRIPTION
## Summary

- adds an explicit `--live` probe path over Claude Code `stream-json` output; `--dry-run` remains no-cost
- maps the dated model only from `assistant.message.model`, requires it to match the declared prefix, and maps required usage fields only from terminal `result.usage`
- fails on malformed stream records, absent/ambiguous/mismatched model disclosure, absent token disclosure, error terminals, nonzero client exits, and timeouts
- starts the client in its own process group and kills that group on timeout
- persists derived receipts only; raw prompts, assistant content, terminal text, and stream events are never retained

## Stack

Stack-Id: `m2-model-fit-runtime-disclosure-20260823`
Base: `feat/model-fit-target-matrix` (#109)
Position: 2/2

1. #109 `feat/model-fit-target-matrix`
2. this PR: `feat/model-fit-probe-evidence`

Depends on: #109
Upstack: none

## Validation

- `uv run ruff check scripts/model_fit.py tests/test_model_fit.py`
- `uv run ruff format --check scripts/model_fit.py tests/test_model_fit.py`
- `uv run mypy --strict --follow-imports=silent scripts/model_fit.py`
- `uv run python -m pytest tests/test_model_fit.py` — 24 passed
- `uv run python scripts/validate_evals.py`
- documented dry runs for `core` and `full` complete with `model_request_made: false`
- incomplete target fixture exits 2 and names `targets[0].model`

## Retention boundary

`raw_receipt_retention: derived-only` is enforced by configuration. The probe has no raw-capture option. Derived output is operator-directed with `--output`; no default receipt path is created or ignored.

## Known repository baseline

The focused M2 lint/format/type checks pass. Repository-wide `ruff check` and `ruff format --check .` currently fail on unrelated pre-existing files; this PR does not widen those failures.
