### PR TITLE
feat(skillsbench): register comparison matrix

### DIFF
--- a/evals/skillsbench/README.md
+++ b/evals/skillsbench/README.md
@@ -36,39 +36,44 @@ evals/skillsbench/
 
 ## Running the Benchmark
 
-**Status:** harness ready, seed task set partial. **Full execution is deferred
-to the operator** — a meaningful run requires hours of live `claude -p`
-execution and should be scheduled with budget awareness.
+**Status:** frozen corpus registered; live execution remains deferred to the
+operator. A meaningful run requires hours of live `claude -p` execution and
+requires M4's recorded approval, budget, privacy posture, and receipt policy.
 
 ```bash
-# Single task, dry-run (validates harness without live execution)
-uv run python scripts/run_skillsbench.py --task evals/skillsbench/tasks/task_001_*.yaml --dry-run
+# Validate the frozen task × condition × target × repetition declaration.
+uv run python scripts/run_skillsbench.py --validate-manifest
 
-# Full sweep, Config A only
-uv run python scripts/run_skillsbench.py --config A --all
+# Full declared corpus, dry-run (validates M2 target linkage and all task data
+# without a model request).
+uv run python scripts/run_skillsbench.py --dry-run
 
-# Full sweep, both configs, 3 runs each, median verdict
-uv run python scripts/run_skillsbench.py --all --runs 3
+# One registered task, dry-run.
+uv run python scripts/run_skillsbench.py --task task_001_code_review_simple --dry-run
 
-# Operator workflow for comparison
-uv run python scripts/run_skillsbench.py --all --config A --output results/run-A.json
-uv run python scripts/run_skillsbench.py --all --config B --output results/run-B.json
+# Full sweep, Config A only. Requires M4 approval before `--live`.
+uv run python scripts/run_skillsbench.py --all --config A --live
+
+# Operator workflow for comparison. Requires M4 approval before `--live`.
+uv run python scripts/run_skillsbench.py --all --config A --live --output results/run-A.json
+uv run python scripts/run_skillsbench.py --all --config B --live --output results/run-B.json
 uv run python scripts/run_skillsbench.py --compare results/run-A.json results/run-B.json
 ```
 
 ## Task Set Scope
 
-The current seed set is **5 synthetic integration tasks** chosen to exercise
-different armory capabilities without requiring external APIs or human
-judgment for scoring. Before running a verdict-bearing benchmark, expand to
-at least 50 tasks — the plan calls for GAIA-public samples plus additional
-synthetic tasks, but GAIA sampling is deferred until the harness has been
-validated on the seed set.
+`corpus.yaml` freezes **50 registered tasks** before any comparison result
+exists: the five retained seed tasks plus 45 inline tasks spanning development,
+review, operations, research, and content work. It resolves the M2 declared
+target (`claude-code-opus-xhigh`) and declares the `current`,
+`reduced-or-rewritten`, and `strengthened-contract` conditions, three
+repetitions, and explicit exclusions. The matrix therefore contains 450
+declared cells.
 
-Tasks in the seed set all use the `assertion` success criterion, which
-checks the model's final output against a list of regex/contains rules with
-weights. More complex tasks (multi-file edits, artifact checks) should add
-new criterion types rather than shoehorning into this schema.
+The legacy seed task files remain directly loadable for focused harness tests.
+Their assertion criteria remain useful for prose deliverables. Tasks whose
+intended deliverable is an artifact use artifact-aware validation rather than
+final-answer prose checks.
 
 ## What This Does Not Measure
 

--- a/evals/skillsbench/corpus.yaml
+++ b/evals/skillsbench/corpus.yaml
@@ -1,0 +1,389 @@
+schema_version: 1
+
+# M3 freezes this declaration before any comparison result exists. The target is
+# resolved through M2's no-cost model-fit contract; it does not authorize a live
+# model invocation.
+model_fit:
+  config: ../../model_fit.yaml
+  target: claude-code-opus-xhigh
+
+comparison:
+  baseline: current
+  treatments: [reduced-or-rewritten, strengthened-contract]
+  repetitions: 3
+  exclusions:
+    - id: unapproved-live-run
+      rationale: Live execution remains excluded until M4 records spend, privacy, and receipt-retention approval.
+    - id: external-state-dependency
+      rationale: Tasks requiring credentials, network mutation, or inaccessible private state cannot provide reproducible evidence.
+    - id: subjective-prose-only-artifact
+      rationale: Tasks whose intended deliverable is an artifact require artifact validation, not an assistant-prose assertion.
+
+# The five seed tasks remain file-backed. The remaining tasks are registered
+# inline so the matrix is frozen in one reviewable artifact.
+tasks:
+  - file: tasks/task_001_code_review_simple.yaml
+  - file: tasks/task_002_sql_injection_audit.yaml
+  - file: tasks/task_003_pytest_generation.yaml
+  - file: tasks/task_004_architecture_tradeoff.yaml
+  - file: tasks/task_005_migration_risk.yaml
+  - id: task_006_api_error_contract
+    description: Define a stable HTTP error contract for an invalid request.
+    category: development
+    difficulty: easy
+    prompt: Propose a JSON error response for an invalid request. Include a stable machine-readable code, a human-readable message, and the HTTP status. Do not expose internal implementation details.
+    success_criterion: {type: assertion, assertions: [{type: contains, target: code, weight: 0.34}, {type: contains, target: message, weight: 0.33}, {type: matches_regex, target: "4[0-9]{2}", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [api, error-handling]
+  - id: task_007_cache_invalidation
+    description: Identify a cache invalidation invariant for mutable user profiles.
+    category: development
+    difficulty: medium
+    prompt: A service caches user profiles by user ID. Describe the invariant that prevents stale reads after an update and provide concise pseudocode for the update path.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(invalidate|evict|delete).*(cache|cached)", weight: 0.5}, {type: matches_regex, target: "(?i)(after|upon).*(update|write)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [cache, consistency]
+  - id: task_008_schema_migration_lock
+    description: Review a schema migration for lock and rollback risks.
+    category: review
+    difficulty: medium
+    prompt: Review a migration that adds a non-null column with a default to a large table. State the lock risk and give a safer phased rollout with rollback handling.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(lock|rewrite|blocking)", weight: 0.34}, {type: matches_regex, target: "(?i)(backfill|batch)", weight: 0.33}, {type: matches_regex, target: "(?i)(rollback|revert)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [database, migration]
+  - id: task_009_token_redaction
+    description: Define log redaction rules for bearer credentials.
+    category: ops
+    difficulty: easy
+    prompt: Write a concise logging policy for HTTP Authorization headers. State what must be redacted and give one safe example log field.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(redact|mask|never log)", weight: 0.5}, {type: matches_regex, target: "(?i)authorization|bearer", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 3000, timeout_seconds: 120}
+    tags: [security, logging]
+  - id: task_010_retry_budget
+    description: Specify bounded retry behavior for an unavailable dependency.
+    category: development
+    difficulty: easy
+    prompt: Specify retry behavior for a transient upstream HTTP 503. Include a finite attempt budget, exponential backoff with jitter, and the condition that stops retries.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(max|finite).*(attempt|retry)", weight: 0.34}, {type: matches_regex, target: "(?i)(exponential|backoff)", weight: 0.33}, {type: matches_regex, target: "(?i)jitter", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [reliability, retry]
+  - id: task_011_path_traversal
+    description: Audit a file-serving endpoint for path traversal.
+    category: review
+    difficulty: medium
+    prompt: A download endpoint joins a user-provided filename to /srv/files. Explain the path traversal risk and provide a safe validation rule using resolved paths.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)path traversal", weight: 0.34}, {type: matches_regex, target: "(?i)resolve", weight: 0.33}, {type: matches_regex, target: "(?i)(relative_to|within|base)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, filesystem]
+  - id: task_012_sql_parameterization
+    description: Correct unsafe SQL string interpolation.
+    category: development
+    difficulty: easy
+    prompt: Replace SQL built with string interpolation from a user email with a parameterized query. Explain why the replacement prevents injection.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(parameter|placeholder|bind)", weight: 0.5}, {type: matches_regex, target: "(?i)injection", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, sql]
+  - id: task_013_idempotency_key
+    description: Define idempotency behavior for a create-payment request.
+    category: development
+    difficulty: medium
+    prompt: Define server behavior for a create-payment endpoint accepting an Idempotency-Key. Cover duplicate requests, payload conflicts, and response reuse.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)duplicate", weight: 0.34}, {type: matches_regex, target: "(?i)(same|reuse).*(response|result)", weight: 0.33}, {type: matches_regex, target: "(?i)(conflict|different payload)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [api, payments]
+  - id: task_014_rate_limit_policy
+    description: Propose an observable rate-limit response contract.
+    category: ops
+    difficulty: easy
+    prompt: Define a rate-limit response for an API. Include the status, a retry hint, and guidance that allows clients to distinguish a rate limit from authentication failure.
+    success_criterion: {type: assertion, assertions: [{type: contains, target: "429", weight: 0.34}, {type: matches_regex, target: "(?i)(retry-after|retry)", weight: 0.33}, {type: matches_regex, target: "(?i)(authentication|401)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [api, operations]
+  - id: task_015_feature_flag_cleanup
+    description: Plan safe removal of an expired feature flag.
+    category: ops
+    difficulty: easy
+    prompt: Give a safe checklist for removing an expired feature flag. Include usage discovery, rollout verification, and removal of stale configuration and tests.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(search|discover|usage)", weight: 0.34}, {type: matches_regex, target: "(?i)(verify|monitor)", weight: 0.33}, {type: matches_regex, target: "(?i)(test|config)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [operations, cleanup]
+  - id: task_016_incident_timeline
+    description: Structure an incident timeline from three events.
+    category: content
+    difficulty: easy
+    prompt: "Turn these events into a concise incident timeline: 10:00 alert fired, 10:07 rollback started, 10:18 error rate returned to normal. Include timestamps and state that customer impact ended at 10:18."
+    success_criterion: {type: assertion, assertions: [{type: contains, target: "10:00", weight: 0.25}, {type: contains, target: "10:07", weight: 0.25}, {type: contains, target: "10:18", weight: 0.25}, {type: matches_regex, target: "(?i)(impact ended|resolved)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 3, max_tokens: 3000, timeout_seconds: 120}
+    tags: [incident, communication]
+  - id: task_017_dependency_pin
+    description: Explain why a dependency pin needs a review trigger.
+    category: review
+    difficulty: easy
+    prompt: A project pins a dependency due to a regression. Specify the pin rationale, the evidence to retain, and the condition that triggers an unpin review.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)rationale|reason", weight: 0.34}, {type: matches_regex, target: "(?i)(evidence|issue|regression)", weight: 0.33}, {type: matches_regex, target: "(?i)(review|unpin)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [dependencies, maintenance]
+  - id: task_018_output_schema
+    description: Define strict JSON output for a classification response.
+    category: development
+    difficulty: easy
+    prompt: Specify a JSON response schema for classifying a support ticket. It must include category, confidence from 0 to 1, and a boolean needs_human_review.
+    success_criterion: {type: assertion, assertions: [{type: contains, target: "category", weight: 0.34}, {type: contains, target: "confidence", weight: 0.33}, {type: contains, target: "needs_human_review", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [api, schema]
+  - id: task_019_concurrency_limit
+    description: Select a bounded concurrency design for batch work.
+    category: development
+    difficulty: medium
+    prompt: A worker must process 10,000 jobs without opening unbounded concurrent connections. Describe a bounded concurrency design and how it reports failed jobs.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(semaphore|pool|bounded)", weight: 0.5}, {type: matches_regex, target: "(?i)(fail|error)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [concurrency, reliability]
+  - id: task_020_backup_restore_test
+    description: Define acceptance for a backup restore drill.
+    category: ops
+    difficulty: medium
+    prompt: Define a backup restore drill. Include an isolated restore target, integrity verification, recovery-time measurement, and a documented failure outcome.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(isolated|separate)", weight: 0.25}, {type: matches_regex, target: "(?i)(integrity|verify)", weight: 0.25}, {type: matches_regex, target: "(?i)(recovery time|RTO|duration)", weight: 0.25}, {type: matches_regex, target: "(?i)(failure|fail)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [backup, operations]
+  - id: task_021_authz_boundary
+    description: Identify authorization checks for a tenant resource.
+    category: review
+    difficulty: medium
+    prompt: Review a get-document endpoint that receives document_id and authenticated_user. State the authorization check required to prevent cross-tenant access and the response for a denied request.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(tenant|owner|membership)", weight: 0.5}, {type: matches_regex, target: "(?i)(403|forbidden)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, authorization]
+  - id: task_022_config_precedence
+    description: Specify deterministic configuration precedence.
+    category: development
+    difficulty: easy
+    prompt: State a deterministic precedence order for command-line flags, environment variables, config files, and built-in defaults. Include how conflicting values are surfaced.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(command.line|flag)", weight: 0.34}, {type: matches_regex, target: "(?i)environment", weight: 0.33}, {type: matches_regex, target: "(?i)(config file|default)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [configuration, cli]
+  - id: task_023_file_format_version
+    description: Plan a backward-compatible file-format change.
+    category: development
+    difficulty: medium
+    prompt: Add a required field to a persisted JSON document while preserving old readers and writers. Describe versioning, migration, and rejection of unsupported future versions.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)version", weight: 0.34}, {type: matches_regex, target: "(?i)(migrate|compatib)", weight: 0.33}, {type: matches_regex, target: "(?i)(unsupported|reject)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [data, compatibility]
+  - id: task_024_observability_slo
+    description: Define an SLO with an actionable error budget.
+    category: ops
+    difficulty: medium
+    prompt: Define an API availability SLO that includes a measurement window, target, error budget, and action when the budget is exhausted.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(window|30 day)", weight: 0.25}, {type: matches_regex, target: "(?i)(target|availability)", weight: 0.25}, {type: matches_regex, target: "(?i)error budget", weight: 0.25}, {type: matches_regex, target: "(?i)(action|freeze|stop)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [observability, slo]
+  - id: task_025_webhook_signature
+    description: Define verification for signed webhooks.
+    category: development
+    difficulty: medium
+    prompt: Specify verification for a signed webhook. Include raw-body preservation, constant-time signature comparison, replay protection, and failure behavior.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(raw body|raw payload)", weight: 0.25}, {type: matches_regex, target: "(?i)(constant.time|timing.safe)", weight: 0.25}, {type: matches_regex, target: "(?i)(replay|timestamp)", weight: 0.25}, {type: matches_regex, target: "(?i)(reject|fail)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [security, webhooks]
+  - id: task_026_cli_exit_codes
+    description: Define meaningful CLI exit-code behavior.
+    category: development
+    difficulty: easy
+    prompt: Define exit-code behavior for a CLI validation command. Distinguish success, invalid user input, and internal execution failure.
+    success_criterion: {type: assertion, assertions: [{type: contains, target: "0", weight: 0.34}, {type: matches_regex, target: "(?i)(invalid|usage)", weight: 0.33}, {type: matches_regex, target: "(?i)(internal|error)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [cli, error-handling]
+  - id: task_027_repository_handoff
+    description: Produce a concise implementation handoff structure.
+    category: content
+    difficulty: easy
+    prompt: Outline a repository handoff document containing current state, verification performed, unresolved risks, and exact resume steps.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)current state", weight: 0.25}, {type: matches_regex, target: "(?i)verification", weight: 0.25}, {type: matches_regex, target: "(?i)risk", weight: 0.25}, {type: matches_regex, target: "(?i)(resume|next step)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [documentation, handoff]
+  - id: task_028_test_boundary
+    description: Choose boundary tests for an input parser.
+    category: review
+    difficulty: easy
+    prompt: A parser accepts integers from 1 through 100. List boundary tests that detect off-by-one errors and invalid input handling.
+    success_criterion: {type: assertion, assertions: [{type: contains, target: "1", weight: 0.25}, {type: contains, target: "100", weight: 0.25}, {type: matches_regex, target: "(?i)(0|below)", weight: 0.25}, {type: matches_regex, target: "(?i)(101|above)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 3, max_tokens: 3000, timeout_seconds: 120}
+    tags: [testing, boundaries]
+  - id: task_029_release_rollback
+    description: Define a release rollback trigger.
+    category: ops
+    difficulty: medium
+    prompt: Define a deployment rollback trigger using an error-rate threshold and observation window. State how the rollback decision is recorded.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)error rate", weight: 0.34}, {type: matches_regex, target: "(?i)(window|minute)", weight: 0.33}, {type: matches_regex, target: "(?i)(record|document)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [release, rollback]
+  - id: task_030_prompt_injection_boundary
+    description: Distinguish untrusted retrieved text from instructions.
+    category: review
+    difficulty: medium
+    prompt: Explain how an assistant workflow should treat retrieved web text that says to reveal a secret. State the trust boundary and the safe handling rule.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(untrusted|data)", weight: 0.5}, {type: matches_regex, target: "(?i)(ignore|not follow|do not follow)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, agents]
+  - id: task_031_resource_cleanup
+    description: Identify cleanup requirements for a file handle.
+    category: development
+    difficulty: easy
+    prompt: Explain how to ensure a file handle is closed when processing raises an exception. Include the language construct that owns cleanup.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(with|context manager|finally)", weight: 0.5}, {type: matches_regex, target: "(?i)close", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 3000, timeout_seconds: 120}
+    tags: [resources, python]
+  - id: task_032_queue_poison_message
+    description: Define handling for repeatedly failing queue messages.
+    category: ops
+    difficulty: medium
+    prompt: Define handling for a queue message that fails processing repeatedly. Include bounded retries, a dead-letter destination, and an alert.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(bounded|max).*(retry|attempt)", weight: 0.34}, {type: matches_regex, target: "(?i)(dead.letter|DLQ)", weight: 0.33}, {type: matches_regex, target: "(?i)(alert|notify)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [queues, reliability]
+  - id: task_033_accessibility_form
+    description: Review a form error for accessible behavior.
+    category: review
+    difficulty: easy
+    prompt: Review a web form validation error. State how the error is associated with the input and announced to assistive technology.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(label|describedby|aria-describedby)", weight: 0.5}, {type: matches_regex, target: "(?i)(screen reader|announce|aria-live)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 3000, timeout_seconds: 120}
+    tags: [accessibility, frontend]
+  - id: task_034_timezone_schedule
+    description: Define a daylight-saving-safe schedule rule.
+    category: development
+    difficulty: medium
+    prompt: A job must run at 09:00 in a user's local timezone across daylight-saving changes. State how timezones are stored and how ambiguous local times are handled.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(IANA|timezone)", weight: 0.5}, {type: matches_regex, target: "(?i)(ambiguous|daylight|DST)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [time, scheduling]
+  - id: task_035_data_deletion
+    description: Define a verifiable personal-data deletion workflow.
+    category: ops
+    difficulty: medium
+    prompt: Define a personal-data deletion workflow. Include identity authorization, deletion across derived stores, an audit record without retaining the deleted content, and failure escalation.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(authorize|identity)", weight: 0.25}, {type: matches_regex, target: "(?i)(derived|backup|replica)", weight: 0.25}, {type: matches_regex, target: "(?i)(audit|record)", weight: 0.25}, {type: matches_regex, target: "(?i)(fail|escalat)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [privacy, data]
+  - id: task_036_contract_test
+    description: Define a consumer-driven contract test.
+    category: development
+    difficulty: medium
+    prompt: Define a consumer-driven contract test for an API response. Include the expected fields, versioning behavior, and how a breaking change fails CI.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(field|schema)", weight: 0.34}, {type: matches_regex, target: "(?i)version", weight: 0.33}, {type: matches_regex, target: "(?i)(CI|fail)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [testing, contracts]
+  - id: task_037_git_conflict_resolution
+    description: Describe safe resolution of a merge conflict.
+    category: development
+    difficulty: easy
+    prompt: Describe a safe workflow for resolving a merge conflict. Include inspecting both changes, testing the resolution, and avoiding force push without a lease.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(inspect|review)", weight: 0.34}, {type: matches_regex, target: "(?i)test", weight: 0.33}, {type: matches_regex, target: "(?i)force-with-lease", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [git, workflow]
+  - id: task_038_metric_cardinality
+    description: Identify a high-cardinality metrics risk.
+    category: review
+    difficulty: medium
+    prompt: A metrics label includes raw user IDs. Explain the cardinality risk and propose a safer aggregation or tracing alternative.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)cardinality", weight: 0.5}, {type: matches_regex, target: "(?i)(aggregate|trace|sample)", weight: 0.5}], pass_threshold: 0.7}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [observability, metrics]
+  - id: task_039_batch_partial_failure
+    description: Specify reporting for partial batch failure.
+    category: development
+    difficulty: medium
+    prompt: Define how a batch API reports partial failures. Include per-item outcomes, an aggregate summary, and retry eligibility without treating failures as success.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(per.item|each item)", weight: 0.34}, {type: matches_regex, target: "(?i)(summary|aggregate)", weight: 0.33}, {type: matches_regex, target: "(?i)(retry|failure)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [batch, error-handling]
+  - id: task_040_csrf_boundary
+    description: Define CSRF protection for a browser session.
+    category: review
+    difficulty: medium
+    prompt: Explain CSRF protection for a cookie-authenticated browser session. Include SameSite settings, an anti-CSRF token, and server-side validation.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)samesite", weight: 0.34}, {type: matches_regex, target: "(?i)(csrf token|anti-csrf)", weight: 0.33}, {type: matches_regex, target: "(?i)(validate|verify)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, web]
+  - id: task_041_api_deprecation
+    description: Plan a backward-compatible API deprecation.
+    category: development
+    difficulty: medium
+    prompt: Plan deprecation of an API field. Include published timeline, compatibility behavior, usage measurement, and removal criteria.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(timeline|date)", weight: 0.25}, {type: matches_regex, target: "(?i)(compatib|fallback)", weight: 0.25}, {type: matches_regex, target: "(?i)(measure|usage)", weight: 0.25}, {type: matches_regex, target: "(?i)(remove|criteria)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [api, deprecation]
+  - id: task_042_secret_rotation
+    description: Define an operational secret-rotation sequence.
+    category: ops
+    difficulty: medium
+    prompt: Define a secret rotation sequence that avoids downtime. Include creating the replacement, deploying consumers, verifying use, and revoking the old secret.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(create|generate).*(new|replacement)", weight: 0.25}, {type: matches_regex, target: "(?i)deploy", weight: 0.25}, {type: matches_regex, target: "(?i)(verify|monitor)", weight: 0.25}, {type: matches_regex, target: "(?i)(revoke|retire)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [security, secrets]
+  - id: task_043_benchmark_reproducibility
+    description: Define reproducibility metadata for a benchmark run.
+    category: research
+    difficulty: medium
+    prompt: List the metadata required to reproduce a benchmark run. Include corpus revision, task matrix, model and client configuration, randomization or repetition policy, and raw-result references.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(corpus|revision)", weight: 0.2}, {type: matches_regex, target: "(?i)(matrix|task)", weight: 0.2}, {type: matches_regex, target: "(?i)(model|client)", weight: 0.2}, {type: matches_regex, target: "(?i)(repeat|random)", weight: 0.2}, {type: matches_regex, target: "(?i)(raw|receipt|result)", weight: 0.2}], pass_threshold: 0.8}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [benchmark, reproducibility]
+  - id: task_044_incident_severity
+    description: Classify incident severity from stated impact.
+    category: ops
+    difficulty: easy
+    prompt: Define an incident severity decision for an outage affecting all paid users but no data loss. Include impact, urgency, and escalation expectation.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(high|sev|critical)", weight: 0.34}, {type: matches_regex, target: "(?i)(paid users|all users|impact)", weight: 0.33}, {type: matches_regex, target: "(?i)(escalat|urgent)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [incident, operations]
+  - id: task_045_pull_request_scope
+    description: Review a pull request for scope drift.
+    category: review
+    difficulty: easy
+    prompt: Give a review checklist that detects unrelated formatting churn, mixed concerns, missing tests for changed behavior, and undocumented compatibility impact.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(format|churn)", weight: 0.25}, {type: matches_regex, target: "(?i)(scope|concern)", weight: 0.25}, {type: matches_regex, target: "(?i)test", weight: 0.25}, {type: matches_regex, target: "(?i)(compatib|document)", weight: 0.25}], pass_threshold: 0.75}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [review, git]
+  - id: task_046_input_normalization
+    description: Define normalization boundaries for an email input.
+    category: development
+    difficulty: easy
+    prompt: Define how an API validates an email address. Distinguish presentation normalization from canonical storage and state how invalid input is returned.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(valid|validate)", weight: 0.34}, {type: matches_regex, target: "(?i)(normaliz|canonical)", weight: 0.33}, {type: matches_regex, target: "(?i)(invalid|error)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [input, validation]
+  - id: task_047_disaster_recovery
+    description: Define a disaster-recovery exercise acceptance gate.
+    category: ops
+    difficulty: hard
+    prompt: Define an acceptance gate for a disaster-recovery exercise. Include recovery point objective, recovery time objective, isolated validation, stakeholder communication, and a remediated failure log.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)(RPO|recovery point)", weight: 0.2}, {type: matches_regex, target: "(?i)(RTO|recovery time)", weight: 0.2}, {type: matches_regex, target: "(?i)isolated", weight: 0.2}, {type: matches_regex, target: "(?i)(stakeholder|communication)", weight: 0.2}, {type: matches_regex, target: "(?i)(failure|remediat)", weight: 0.2}], pass_threshold: 0.8}
+    limits: {max_turns: 5, max_tokens: 6000, timeout_seconds: 180}
+    tags: [disaster-recovery, operations]
+  - id: task_048_data_quality_gate
+    description: Define a data-quality gate before analytics publication.
+    category: research
+    difficulty: medium
+    prompt: Define a data-quality gate before publishing analytics. Include completeness, duplicate detection, schema validation, a threshold, and failure escalation.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)complet", weight: 0.2}, {type: matches_regex, target: "(?i)duplicate", weight: 0.2}, {type: matches_regex, target: "(?i)(schema|valid)", weight: 0.2}, {type: matches_regex, target: "(?i)(threshold|minimum)", weight: 0.2}, {type: matches_regex, target: "(?i)(escalat|fail)", weight: 0.2}], pass_threshold: 0.8}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [data, quality]
+  - id: task_049_permission_review
+    description: Review least-privilege requirements for a service account.
+    category: review
+    difficulty: medium
+    prompt: Review a service account requesting administrator access. Define the least-privilege review, evidence required, and a time-bound exception process.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)least privilege", weight: 0.34}, {type: matches_regex, target: "(?i)(evidence|justif)", weight: 0.33}, {type: matches_regex, target: "(?i)(time.bound|expire|review)", weight: 0.33}], pass_threshold: 0.67}
+    limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
+    tags: [security, authorization]
+  - id: task_050_change_approval
+    description: Define a high-risk change approval record.
+    category: ops
+    difficulty: medium
+    prompt: Define a record for approving a high-risk production change. Include scope, owner, verification plan, rollback plan, and decision timestamp.
+    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)scope", weight: 0.2}, {type: matches_regex, target: "(?i)owner", weight: 0.2}, {type: matches_regex, target: "(?i)verification", weight: 0.2}, {type: matches_regex, target: "(?i)rollback", weight: 0.2}, {type: matches_regex, target: "(?i)(timestamp|time)", weight: 0.2}], pass_threshold: 0.8}
+    limits: {max_turns: 4, max_tokens: 5000, timeout_seconds: 150}
+    tags: [change-management, operations]

--- a/evals/skillsbench/schema.yaml
+++ b/evals/skillsbench/schema.yaml
@@ -29,3 +29,22 @@ limits:
 
 # Tags for later analysis. Keep short and consistent.
 tags: [string]
+
+# M3 frozen corpus declaration. `corpus.yaml` references retained task files
+# or supplies equivalent inline task mappings and declares the complete matrix
+# before any result exists.
+schema_version: 1
+model_fit:
+  config: relative-path-to-model_fit.yaml
+  target: declared-model-fit-target-id
+comparison:
+  baseline: current
+  treatments: [reduced-or-rewritten, strengthened-contract]
+  repetitions: 3 # Minimum; all task × condition × target × repetition cells exist.
+  exclusions:
+    - id: stable-exclusion-id
+      rationale: Explicit reason the task class cannot enter this corpus.
+tasks:
+  - file: relative-path-to-retained-task.yaml
+  - id: task_006_example
+    # Inline task mapping with the task fields above.

--- a/scripts/run_skillsbench.py
+++ b/scripts/run_skillsbench.py
@@ -20,6 +20,8 @@ See ``evals/skillsbench/README.md`` for the experiment design. Full
 execution is deferred to the operator — a meaningful benchmark requires
 hours of live execution and should be scheduled deliberately.
 """
+
+# ruff: noqa: E402
 from __future__ import annotations
 
 import argparse
@@ -31,15 +33,23 @@ import tempfile
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import TypedDict
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-import yaml
+import yaml  # type: ignore[import-untyped]
+
+from scripts.model_fit import ModelFitConfigError, load_model_fit_config, select_target
 
 _SUPPORTED_CRITERION_TYPES = {"assertion"}
 _SUPPORTED_ASSERTION_TYPES = {"contains", "not_contains", "matches_regex"}
+_CORPUS_SCHEMA_VERSION = 1
+_REQUIRED_CONDITIONS = frozenset(
+    {"current", "reduced-or-rewritten", "strengthened-contract"}
+)
+_DEFAULT_CORPUS_PATH = _REPO_ROOT / "evals" / "skillsbench" / "corpus.yaml"
 
 # Tolerance for floating-point comparisons in compare_reports. Pass-rate
 # subtractions like 0.70 - 0.60 produce values slightly below 0.10 in
@@ -47,6 +57,14 @@ _SUPPORTED_ASSERTION_TYPES = {"contains", "not_contains", "matches_regex"}
 # One microunit (1e-6 percentage points) is small enough to be
 # semantically irrelevant and large enough to absorb FP error.
 _COMPARE_TOLERANCE_PP = 1e-6
+
+
+class Assertion(TypedDict):
+    """A validated final-answer assertion."""
+
+    type: str
+    target: str
+    weight: float
 
 
 @dataclass
@@ -58,13 +76,35 @@ class TaskDefinition:
     category: str
     difficulty: str
     prompt: str
-    assertions: list[dict]
+    assertions: list[Assertion]
     pass_threshold: float
     max_turns: int
     max_tokens: int
     timeout_seconds: int
     tags: list[str]
     source_path: str
+
+
+@dataclass(frozen=True)
+class ComparisonCell:
+    """One predeclared task × condition × target × repetition cell."""
+
+    task_id: str
+    condition: str
+    target_id: str
+    repetition: int
+
+
+@dataclass(frozen=True)
+class CorpusManifest:
+    """A validated, pre-result SkillsBench comparison declaration."""
+
+    target_id: str
+    baseline: str
+    treatments: tuple[str, ...]
+    repetitions: int
+    exclusions: tuple[tuple[str, str], ...]
+    tasks: tuple[TaskDefinition, ...]
 
 
 @dataclass
@@ -77,7 +117,7 @@ class TaskRunResult:
     verdict: str  # "pass" | "fail" | "error" | "skipped"
     weighted_score: float
     output_excerpt: str
-    assertion_results: list[dict]
+    assertion_results: list[dict[str, object]]
     execution_time_ms: int
     error: str | None = None
 
@@ -98,84 +138,311 @@ class BenchmarkReport:
     per_task: list[TaskRunResult] = field(default_factory=list)
 
 
-def load_task(path: Path) -> TaskDefinition:
-    """Load and validate a task YAML file.
+def _require_mapping(value: object, location: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{location}: expected a mapping")
+    return value
 
-    Args:
-        path: Path to a task YAML under evals/skillsbench/tasks/.
 
-    Returns:
-        Parsed TaskDefinition.
+def _require_string(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{location}: expected a non-empty string")
+    return value
 
-    Raises:
-        ValueError: If the file is missing required fields or uses an
-            unsupported criterion or assertion type.
-    """
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict):
-        raise ValueError(f"{path}: expected a mapping at the top level")
 
-    required = {"id", "description", "category", "prompt", "success_criterion", "limits"}
-    missing = required - raw.keys()
+def _require_string_list(value: object, location: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{location}: expected a list of strings")
+    values = tuple(
+        _require_string(item, f"{location}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(values) != len(set(values)):
+        raise ValueError(f"{location}: must not contain duplicates")
+    return values
+
+
+def _require_positive_int(value: object, location: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{location}: expected a positive integer")
+    return value
+
+
+def _require_probability(value: object, location: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{location}: expected a number from 0 to 1")
+    probability = float(value)
+    if not 0 < probability <= 1:
+        raise ValueError(f"{location}: expected a number from 0 to 1")
+    return probability
+
+
+def _load_task_raw(
+    raw: object,
+    source_path: str,
+    expected_id: str | None = None,
+) -> TaskDefinition:
+    """Validate one file-backed or inline task mapping."""
+    task = _require_mapping(raw, source_path)
+    required = {
+        "id",
+        "description",
+        "category",
+        "prompt",
+        "success_criterion",
+        "limits",
+    }
+    missing = required - task.keys()
     if missing:
-        raise ValueError(f"{path}: missing required fields: {sorted(missing)}")
+        raise ValueError(f"{source_path}: missing required fields: {sorted(missing)}")
 
-    if raw["id"] != path.stem:
+    task_id = _require_string(task["id"], f"{source_path}.id")
+    if expected_id is not None and task_id != expected_id:
         raise ValueError(
-            f"{path}: task id {raw['id']!r} must match filename stem {path.stem!r}"
+            f"{source_path}: task id {task_id!r} must match filename stem "
+            f"{expected_id!r}"
         )
 
-    criterion = raw["success_criterion"]
-    if criterion.get("type") not in _SUPPORTED_CRITERION_TYPES:
+    criterion = _require_mapping(
+        task["success_criterion"], f"{source_path}.success_criterion"
+    )
+    criterion_type = _require_string(
+        criterion.get("type"), f"{source_path}.success_criterion.type"
+    )
+    if criterion_type not in _SUPPORTED_CRITERION_TYPES:
         raise ValueError(
-            f"{path}: unsupported criterion type {criterion.get('type')!r} "
+            f"{source_path}: unsupported criterion type {criterion_type!r} "
             f"(supported: {sorted(_SUPPORTED_CRITERION_TYPES)})"
         )
 
-    assertions = criterion.get("assertions") or []
-    if not assertions:
-        raise ValueError(f"{path}: criterion has no assertions")
-    for idx, assertion in enumerate(assertions):
-        if assertion.get("type") not in _SUPPORTED_ASSERTION_TYPES:
+    assertions_raw = criterion.get("assertions")
+    if not isinstance(assertions_raw, list) or not assertions_raw:
+        raise ValueError(f"{source_path}: criterion has no assertions")
+    assertions: list[Assertion] = []
+    for index, assertion_raw in enumerate(assertions_raw):
+        assertion = _require_mapping(assertion_raw, f"{source_path}.assertion {index}")
+        assertion_type = _require_string(
+            assertion.get("type"), f"{source_path}.assertion {index}.type"
+        )
+        if assertion_type not in _SUPPORTED_ASSERTION_TYPES:
             raise ValueError(
-                f"{path}: assertion {idx} has unsupported type {assertion.get('type')!r}"
-            )
-        if "target" not in assertion or "weight" not in assertion:
-            raise ValueError(
-                f"{path}: assertion {idx} missing 'target' or 'weight'"
+                f"{source_path}: assertion {index} has unsupported type "
+                f"{assertion_type!r}"
             )
 
-    limits = raw["limits"]
+        assertions.append(
+            Assertion(
+                type=assertion_type,
+                target=_require_string(
+                    assertion.get("target"),
+                    f"{source_path}.assertion {index}.target",
+                ),
+                weight=_require_probability(
+                    assertion.get("weight"),
+                    f"{source_path}.assertion {index}.weight",
+                ),
+            )
+        )
+
+    limits = _require_mapping(task["limits"], f"{source_path}.limits")
     return TaskDefinition(
-        id=raw["id"],
-        description=raw["description"],
-        category=raw["category"],
-        difficulty=raw.get("difficulty", "medium"),
-        prompt=raw["prompt"],
+        id=task_id,
+        description=_require_string(task["description"], f"{source_path}.description"),
+        category=_require_string(task["category"], f"{source_path}.category"),
+        difficulty=_require_string(
+            task.get("difficulty", "medium"), f"{source_path}.difficulty"
+        ),
+        prompt=_require_string(task["prompt"], f"{source_path}.prompt"),
         assertions=assertions,
-        pass_threshold=float(criterion.get("pass_threshold", 0.7)),
-        max_turns=int(limits.get("max_turns", 5)),
-        max_tokens=int(limits.get("max_tokens", 10000)),
-        timeout_seconds=int(limits.get("timeout_seconds", 180)),
-        tags=list(raw.get("tags") or []),
-        source_path=str(path),
+        pass_threshold=_require_probability(
+            criterion.get("pass_threshold", 0.7),
+            f"{source_path}.success_criterion.pass_threshold",
+        ),
+        max_turns=_require_positive_int(
+            limits.get("max_turns", 5), f"{source_path}.limits.max_turns"
+        ),
+        max_tokens=_require_positive_int(
+            limits.get("max_tokens", 10000), f"{source_path}.limits.max_tokens"
+        ),
+        timeout_seconds=_require_positive_int(
+            limits.get("timeout_seconds", 180), f"{source_path}.limits.timeout_seconds"
+        ),
+        tags=list(_require_string_list(task.get("tags", []), f"{source_path}.tags")),
+        source_path=source_path,
     )
 
 
+def load_task(path: Path) -> TaskDefinition:
+    """Load and validate one legacy file-backed SkillsBench task."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read task: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: cannot parse task YAML: {exc}") from exc
+    return _load_task_raw(raw, str(path), expected_id=path.stem)
+
+
 def load_task_set(tasks_dir: Path) -> list[TaskDefinition]:
-    """Load every YAML task under a directory, sorted by id."""
+    """Load every legacy task YAML under a directory, sorted by id."""
     if not tasks_dir.is_dir():
         return []
+    return [load_task(path) for path in sorted(tasks_dir.glob("*.yaml"))]
+
+
+def _resolve_manifest_path(base: Path, value: object, location: str) -> Path:
+    relative_path = Path(_require_string(value, location))
+    if relative_path.is_absolute():
+        raise ValueError(f"{location}: absolute paths are not allowed")
+    resolved = (base / relative_path).resolve()
+    if not resolved.is_relative_to(_REPO_ROOT.resolve()):
+        raise ValueError(f"{location}: path must remain under the repository root")
+    return resolved
+
+
+def load_corpus_manifest(path: Path = _DEFAULT_CORPUS_PATH) -> CorpusManifest:
+    """Load a frozen M3 corpus and verify its M2 target and comparison matrix."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read corpus manifest: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: cannot parse corpus YAML: {exc}") from exc
+    manifest = _require_mapping(raw, str(path))
+
+    schema_version = manifest.get("schema_version")
+    if isinstance(schema_version, bool) or schema_version != _CORPUS_SCHEMA_VERSION:
+        raise ValueError(
+            f"{path}: schema_version must be {_CORPUS_SCHEMA_VERSION}, "
+            f"got {schema_version!r}"
+        )
+
+    model_fit = _require_mapping(manifest.get("model_fit"), f"{path}.model_fit")
+    config_path = _resolve_manifest_path(
+        path.parent, model_fit.get("config"), f"{path}.model_fit.config"
+    )
+    target_id = _require_string(model_fit.get("target"), f"{path}.model_fit.target")
+    try:
+        select_target(load_model_fit_config(config_path), target_id)
+    except ModelFitConfigError as exc:
+        raise ValueError(f"{path}.model_fit: {exc}") from exc
+
+    comparison = _require_mapping(manifest.get("comparison"), f"{path}.comparison")
+    baseline = _require_string(
+        comparison.get("baseline"), f"{path}.comparison.baseline"
+    )
+    treatments = _require_string_list(
+        comparison.get("treatments"), f"{path}.comparison.treatments"
+    )
+    conditions = {baseline, *treatments}
+    if baseline != "current" or conditions != _REQUIRED_CONDITIONS:
+        raise ValueError(
+            f"{path}.comparison: must declare current, reduced-or-rewritten, "
+            "and strengthened-contract conditions"
+        )
+    repetitions = _require_positive_int(
+        comparison.get("repetitions"), f"{path}.comparison.repetitions"
+    )
+    if repetitions < 3:
+        raise ValueError(f"{path}.comparison.repetitions: must be at least 3")
+
+    exclusions_raw = comparison.get("exclusions")
+    if not isinstance(exclusions_raw, list) or not exclusions_raw:
+        raise ValueError(f"{path}.comparison.exclusions: must be a non-empty list")
+    exclusions = tuple(
+        (
+            _require_string(
+                _require_mapping(
+                    exclusion_raw, f"{path}.comparison.exclusions[{index}]"
+                ).get("id"),
+                f"{path}.comparison.exclusions[{index}].id",
+            ),
+            _require_string(
+                _require_mapping(
+                    exclusion_raw, f"{path}.comparison.exclusions[{index}]"
+                ).get("rationale"),
+                f"{path}.comparison.exclusions[{index}].rationale",
+            ),
+        )
+        for index, exclusion_raw in enumerate(exclusions_raw)
+    )
+    if len({exclusion[0] for exclusion in exclusions}) != len(exclusions):
+        raise ValueError(f"{path}.comparison.exclusions: ids must be unique")
+
+    tasks_raw = manifest.get("tasks")
+    if not isinstance(tasks_raw, list):
+        raise ValueError(f"{path}.tasks: expected a list")
+    if len(tasks_raw) < 50:
+        raise ValueError(f"{path}.tasks: requires at least 50 registered tasks")
     tasks: list[TaskDefinition] = []
-    for path in sorted(tasks_dir.glob("*.yaml")):
-        tasks.append(load_task(path))
-    return tasks
+    for index, task_raw in enumerate(tasks_raw):
+        task_mapping = _require_mapping(task_raw, f"{path}.tasks[{index}]")
+        if "file" in task_mapping:
+            if len(task_mapping) != 1:
+                raise ValueError(
+                    f"{path}.tasks[{index}]: file references cannot add fields"
+                )
+            task_path = _resolve_manifest_path(
+                path.parent, task_mapping["file"], f"{path}.tasks[{index}].file"
+            )
+            tasks.append(load_task(task_path))
+        else:
+            tasks.append(_load_task_raw(task_mapping, f"{path}#tasks[{index}]"))
+    task_ids = tuple(task.id for task in tasks)
+    if len(task_ids) != len(set(task_ids)):
+        raise ValueError(f"{path}.tasks: task ids must be unique")
+
+    return CorpusManifest(
+        target_id=target_id,
+        baseline=baseline,
+        treatments=treatments,
+        repetitions=repetitions,
+        exclusions=exclusions,
+        tasks=tuple(tasks),
+    )
+
+
+def declared_cells(corpus: CorpusManifest) -> tuple[ComparisonCell, ...]:
+    """Expand a frozen manifest into its exact comparison cells."""
+    return tuple(
+        ComparisonCell(
+            task_id=task.id,
+            condition=condition,
+            target_id=corpus.target_id,
+            repetition=repetition,
+        )
+        for task in corpus.tasks
+        for condition in (corpus.baseline, *corpus.treatments)
+        for repetition in range(1, corpus.repetitions + 1)
+    )
+
+
+def validate_observed_cells(
+    corpus: CorpusManifest, observed_cells: tuple[ComparisonCell, ...]
+) -> None:
+    """Reject result-cell sets that differ from the frozen comparison matrix."""
+    expected = set(declared_cells(corpus))
+    observed = set(observed_cells)
+    if len(observed) != len(observed_cells):
+        raise ValueError("observed comparison cells contain duplicates")
+    undeclared = observed - expected
+    if undeclared:
+        raise ValueError(
+            "observed undeclared comparison cells: "
+            f"{sorted(undeclared, key=lambda cell: (cell.task_id, cell.condition, cell.target_id, cell.repetition))!r}"
+        )
+    missing = expected - observed
+    if missing:
+        raise ValueError(
+            "observed comparison cells are missing: "
+            f"{sorted(missing, key=lambda cell: (cell.task_id, cell.condition, cell.target_id, cell.repetition))!r}"
+        )
 
 
 def check_assertions(
     output: str,
-    assertions: list[dict],
-) -> tuple[float, list[dict]]:
+    assertions: list[Assertion],
+) -> tuple[float, list[dict[str, object]]]:
     """Score output against a task's assertions.
 
     Args:
@@ -193,7 +460,7 @@ def check_assertions(
         return 0.0, []
 
     passed_weight = 0.0
-    details: list[dict] = []
+    details: list[dict[str, object]] = []
     for assertion in assertions:
         a_type = assertion["type"]
         target = str(assertion["target"])
@@ -284,7 +551,7 @@ def compare_reports(
     report_a: BenchmarkReport,
     report_b: BenchmarkReport,
     min_delta_pp: float = 15.0,
-) -> dict:
+) -> dict[str, object]:
     """Compare two configuration reports against the S3 exit criterion.
 
     Args:
@@ -339,9 +606,12 @@ def run_task_live(
         result = subprocess.run(
             [
                 "claude",
-                "-p", task.prompt,
-                "--output-format", "text",
-                "--allowedTools", *tools,
+                "-p",
+                task.prompt,
+                "--output-format",
+                "text",
+                "--allowedTools",
+                *tools,
             ],
             capture_output=True,
             text=True,
@@ -392,18 +662,19 @@ def main() -> int:
         description="Run the SkillsBench bootstrap benchmark",
     )
     parser.add_argument(
-        "--tasks-dir",
-        default="evals/skillsbench/tasks",
-        help="Directory of task YAML files",
+        "--manifest",
+        type=Path,
+        default=_DEFAULT_CORPUS_PATH,
+        help="Frozen corpus manifest to validate and load",
     )
     parser.add_argument(
         "--task",
-        help="Run a single task by path (mutually exclusive with --all)",
+        help="Run one registered task by id (default: all registered tasks)",
     )
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Run every task under --tasks-dir",
+        help="Explicitly select every registered task",
     )
     parser.add_argument(
         "--config",
@@ -422,6 +693,11 @@ def main() -> int:
         help="Load tasks and validate schema without running claude",
     )
     parser.add_argument(
+        "--validate-manifest",
+        action="store_true",
+        help="Validate the frozen corpus and print its declared cell count",
+    )
+    parser.add_argument(
         "--live",
         action="store_true",
         help="Actually invoke claude -p (otherwise dry-run is implied)",
@@ -437,23 +713,39 @@ def main() -> int:
     if args.compare:
         return _compare_command(args.compare[0], args.compare[1])
 
-    if not args.task and not args.all:
-        parser.error("one of --task or --all is required")
+    corpus = load_corpus_manifest(args.manifest)
+    cells = declared_cells(corpus)
+    if len(cells) != len(set(cells)):
+        raise ValueError(f"{args.manifest}: generated duplicate comparison cells")
+    if args.validate_manifest:
+        print(
+            f"Validated {len(corpus.tasks)} task(s), {len(cells)} declared cell(s), "
+            f"and {len(corpus.exclusions)} exclusion rule(s)."
+        )
+        return 0
 
     if args.task:
-        tasks = [load_task(_REPO_ROOT / args.task)]
+        tasks = [task for task in corpus.tasks if task.id == args.task]
+        if not tasks:
+            parser.error(f"undeclared task: {args.task}")
     else:
-        tasks = load_task_set(_REPO_ROOT / args.tasks_dir)
-
-    if not tasks:
-        print(f"No tasks found in {args.tasks_dir}", file=sys.stderr)
-        return 1
+        tasks = list(corpus.tasks)
 
     if args.dry_run or not args.live:
-        print(f"Loaded {len(tasks)} task(s) for config {args.config}")
+        print(
+            f"Loaded {len(tasks)} registered task(s) for config {args.config} "
+            f"from {args.manifest}"
+        )
+        print(
+            f"Frozen comparison: target={corpus.target_id}, "
+            f"conditions={','.join((corpus.baseline, *corpus.treatments))}, "
+            f"repetitions={corpus.repetitions}, declared_cells={len(cells)}"
+        )
         print("Dry run — no tasks executed. Pass --live to actually run claude -p.")
-        for t in tasks:
-            print(f"  - {t.id} ({t.category}/{t.difficulty}): {t.description}")
+        for task in tasks:
+            print(
+                f"  - {task.id} ({task.category}/{task.difficulty}): {task.description}"
+            )
         return 0
 
     allowed_tools: list[str] | None
@@ -472,9 +764,7 @@ def main() -> int:
     report = aggregate_report(args.config, results)
     output_path = _REPO_ROOT / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        json.dumps(asdict(report), indent=2), encoding="utf-8"
-    )
+    output_path.write_text(json.dumps(asdict(report), indent=2), encoding="utf-8")
     print(
         f"Report written to {args.output} "
         f"(pass_rate={report.pass_rate:.2%}, mean_score={report.mean_score:.2f})"

--- a/tests/test_run_skillsbench.py
+++ b/tests/test_run_skillsbench.py
@@ -1,4 +1,5 @@
 """Tests for scripts.run_skillsbench pure logic (no live claude execution)."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -7,17 +8,22 @@ import pytest
 
 from scripts.run_skillsbench import (
     BenchmarkReport,
+    ComparisonCell,
     TaskRunResult,
     aggregate_report,
     check_assertions,
     compare_reports,
+    declared_cells,
+    load_corpus_manifest,
     load_task,
     load_task_set,
+    validate_observed_cells,
     verdict_from_score,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SEED_TASKS_DIR = _REPO_ROOT / "evals" / "skillsbench" / "tasks"
+_CORPUS_PATH = _REPO_ROOT / "evals" / "skillsbench" / "corpus.yaml"
 
 
 class TestLoadTask:
@@ -97,6 +103,45 @@ class TestLoadTaskSet:
         assert load_task_set(tmp_path / "nope") == []
 
 
+class TestCorpusManifest:
+    def test_loads_frozen_corpus_and_declared_cells(self) -> None:
+        corpus = load_corpus_manifest(_CORPUS_PATH)
+        cells = declared_cells(corpus)
+
+        assert corpus.target_id == "claude-code-opus-xhigh"
+        assert len(corpus.tasks) == 50
+        assert corpus.repetitions == 3
+        assert len(cells) == 450
+        validate_observed_cells(corpus, cells)
+
+    def test_rejects_undeclared_cell(self) -> None:
+        corpus = load_corpus_manifest(_CORPUS_PATH)
+        cells = declared_cells(corpus)
+        undeclared = ComparisonCell(
+            task_id="task_999_not_registered",
+            condition="current",
+            target_id=corpus.target_id,
+            repetition=1,
+        )
+
+        with pytest.raises(ValueError, match="undeclared comparison cells"):
+            validate_observed_cells(corpus, (*cells[1:], undeclared))
+
+    def test_rejects_duplicate_cells(self) -> None:
+        corpus = load_corpus_manifest(_CORPUS_PATH)
+        cells = declared_cells(corpus)
+
+        with pytest.raises(ValueError, match="contain duplicates"):
+            validate_observed_cells(corpus, (*cells[1:], cells[1], cells[1]))
+
+    def test_rejects_missing_cells(self) -> None:
+        corpus = load_corpus_manifest(_CORPUS_PATH)
+        cells = declared_cells(corpus)
+
+        with pytest.raises(ValueError, match="cells are missing"):
+            validate_observed_cells(corpus, cells[1:])
+
+
 class TestCheckAssertions:
     def test_all_pass(self) -> None:
         assertions = [
@@ -136,9 +181,7 @@ class TestCheckAssertions:
         assert score == 1.0
 
     def test_regex_case_insensitive(self) -> None:
-        assertions = [
-            {"type": "matches_regex", "target": "(?i)HELLO", "weight": 1.0}
-        ]
+        assertions = [{"type": "matches_regex", "target": "(?i)HELLO", "weight": 1.0}]
         score, _ = check_assertions("hello there", assertions)
         assert score == 1.0
 
@@ -210,7 +253,9 @@ class TestAggregateReport:
 
 
 class TestCompareReports:
-    def _report(self, config: str, pass_rate: float, total: int = 10) -> BenchmarkReport:
+    def _report(
+        self, config: str, pass_rate: float, total: int = 10
+    ) -> BenchmarkReport:
         return BenchmarkReport(
             config=config,
             timestamp="",


### PR DESCRIPTION
## Summary

- freezes a 50-task SkillsBench corpus against M2's declared target before any result exists
- declares current, reduced-or-rewritten, and strengthened-contract conditions with three repetitions and explicit exclusions
- validates all 450 comparison cells, including undeclared, duplicate, and missing-cell rejection

## Stack

Stack-Id: `skillsbench-m3-corpus-20260823`
Base: `main`
Position: 1/2

1. `feat/skillsbench-matrix` -> this PR
2. `feat/skillsbench-artifact-strata` -> pending child PR

Depends on: (none - root)
Upstack: pending

## Validation

- `uv run ruff check scripts/run_skillsbench.py tests/test_run_skillsbench.py`
- `uv run ruff format --check scripts/run_skillsbench.py tests/test_run_skillsbench.py`
- `uv run mypy --strict --follow-imports=silent scripts/run_skillsbench.py`
- `uv run python -m pytest tests/test_run_skillsbench.py tests/test_model_fit.py`
- `uv run python scripts/validate_evals.py`
- `uv run python scripts/run_skillsbench.py --validate-manifest`
- `uv run python scripts/run_skillsbench.py --dry-run`
