### PR TITLE
feat(skillsbench): add artifact-aware criteria

### DIFF
--- a/evals/skillsbench/README.md
+++ b/evals/skillsbench/README.md
@@ -75,13 +75,17 @@ Their assertion criteria remain useful for prose deliverables. Tasks whose
 intended deliverable is an artifact use artifact-aware validation rather than
 final-answer prose checks.
 
+`package_strata.yaml` records one active, high-risk-relevant sample for each
+of the seven package types and an explicit rationale for every other package's
+exclusion. `uv run python scripts/validate_skillsbench.py` rejects duplicate,
+missing, undeclared, deprecated-included, and incomplete-type classifications.
+
 ## What This Does Not Measure
 
 - **Cost efficiency** — token and time totals are logged but are not part of
   the pass/fail criterion.
-- **Code quality of generated artifacts** — only the final assistant response
-  is scored against assertions. Tasks requiring artifact quality checks need
-  a richer success criterion type.
+- **Semantic artifact quality** — artifact criteria verify existence and
+  declared content checks, not correctness beyond those deterministic checks.
 - **Librarian drafting quality** — the librarian's drafted skills during
   Config B runs are captured but their correctness is not benchmarked here.
   That belongs to `package-evaluator`, not SkillsBench.

--- a/evals/skillsbench/corpus.yaml
+++ b/evals/skillsbench/corpus.yaml
@@ -127,8 +127,8 @@ tasks:
     description: Define strict JSON output for a classification response.
     category: development
     difficulty: easy
-    prompt: Specify a JSON response schema for classifying a support ticket. It must include category, confidence from 0 to 1, and a boolean needs_human_review.
-    success_criterion: {type: assertion, assertions: [{type: contains, target: "category", weight: 0.34}, {type: contains, target: "confidence", weight: 0.33}, {type: contains, target: "needs_human_review", weight: 0.33}], pass_threshold: 0.67}
+    prompt: In the working directory, create ticket_schema.json containing a JSON response schema for classifying a support ticket. It must include category, confidence from 0 to 1, and boolean needs_human_review.
+    success_criterion: {type: artifact, artifact: {path: ticket_schema.json, assertions: [{type: contains, target: "category", weight: 0.34}, {type: contains, target: "confidence", weight: 0.33}, {type: contains, target: "needs_human_review", weight: 0.33}]}, pass_threshold: 0.67}
     limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
     tags: [api, schema]
   - id: task_019_concurrency_limit
@@ -191,16 +191,16 @@ tasks:
     description: Define meaningful CLI exit-code behavior.
     category: development
     difficulty: easy
-    prompt: Define exit-code behavior for a CLI validation command. Distinguish success, invalid user input, and internal execution failure.
-    success_criterion: {type: assertion, assertions: [{type: contains, target: "0", weight: 0.34}, {type: matches_regex, target: "(?i)(invalid|usage)", weight: 0.33}, {type: matches_regex, target: "(?i)(internal|error)", weight: 0.33}], pass_threshold: 0.67}
+    prompt: In the working directory, create exit_codes.md defining exit-code behavior for a CLI validation command. Distinguish success, invalid user input, and internal execution failure.
+    success_criterion: {type: artifact, artifact: {path: exit_codes.md, assertions: [{type: contains, target: "0", weight: 0.34}, {type: matches_regex, target: "(?i)(invalid|usage)", weight: 0.33}, {type: matches_regex, target: "(?i)(internal|error)", weight: 0.33}]}, pass_threshold: 0.67}
     limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
     tags: [cli, error-handling]
   - id: task_027_repository_handoff
     description: Produce a concise implementation handoff structure.
     category: content
     difficulty: easy
-    prompt: Outline a repository handoff document containing current state, verification performed, unresolved risks, and exact resume steps.
-    success_criterion: {type: assertion, assertions: [{type: matches_regex, target: "(?i)current state", weight: 0.25}, {type: matches_regex, target: "(?i)verification", weight: 0.25}, {type: matches_regex, target: "(?i)risk", weight: 0.25}, {type: matches_regex, target: "(?i)(resume|next step)", weight: 0.25}], pass_threshold: 0.75}
+    prompt: In the working directory, create handoff.md containing current state, verification performed, unresolved risks, and exact resume steps.
+    success_criterion: {type: artifact, artifact: {path: handoff.md, assertions: [{type: matches_regex, target: "(?i)current state", weight: 0.25}, {type: matches_regex, target: "(?i)verification", weight: 0.25}, {type: matches_regex, target: "(?i)risk", weight: 0.25}, {type: matches_regex, target: "(?i)(resume|next step)", weight: 0.25}]}, pass_threshold: 0.75}
     limits: {max_turns: 3, max_tokens: 4000, timeout_seconds: 120}
     tags: [documentation, handoff]
   - id: task_028_test_boundary

--- a/evals/skillsbench/package_strata.yaml
+++ b/evals/skillsbench/package_strata.yaml
@@ -1,0 +1,429 @@
+schema_version: 1
+
+# M3 sample registration. Every discovered package is classified exactly once.
+included:
+  - package_type: agent
+    name: security-reviewer
+    rationale: Reviews security-sensitive code and findings; samples the safety-critical agent surface.
+  - package_type: command
+    name: stack-pr
+    rationale: Exercises a command that mutates dependent Git and pull-request topology.
+  - package_type: hook
+    name: git-protection
+    rationale: Exercises a preventive hook guarding destructive Git operations.
+  - package_type: preset
+    name: sec-strict
+    rationale: Exercises a composed security preset with cross-package instruction interactions.
+  - package_type: rule
+    name: security-standards
+    rationale: Exercises a high-risk rule governing credentials, paths, and external input.
+  - package_type: skill
+    name: pr-review
+    rationale: Exercises a review skill whose findings can gate code changes.
+  - package_type: utility
+    name: dependency-tree
+    rationale: Exercises a utility package with a constrained command-facing surface.
+
+excluded:
+  - package_type: agent
+    name: code-reviewer
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: codebase-auditor
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: content-strategist
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: full-stack-builder
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: idea-scout
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: media-producer
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: project-architect
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: project-planner
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: proposal-writer
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: release-captain
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: research-analyst
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: secret-scanner
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: skill-librarian
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: skill-router
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: team-lead
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: agent
+    name: test-engineer
+    rationale: Excluded from the fixed one-package agent stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: decision-map
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: evolve
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: handoff
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: pr-swarm
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: refactor
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: route
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: security-scan
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: command
+    name: tdd
+    rationale: Excluded from the fixed one-package command stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: anatomy-index
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: cost-tracker
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: handoff-on-stop
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: pre-edit-backup
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: prompt-context
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: read-dedup
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: simplify-ignore
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: hook
+    name: stack-guard
+    rationale: Excluded from the fixed one-package hook stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: ai-builder
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: biz-validation
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: preset
+    name: content-ops
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: preset
+    name: core
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: eng-ops
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: preset
+    name: media-craft
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: preset
+    name: python-strict
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: research
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: preset
+    name: session-continuity
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: skill-evolution
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: stack-workflow
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: preset
+    name: terse-mode
+    rationale: Excluded from the fixed one-package preset stratum; its type is represented by the registered sample.
+  - package_type: rule
+    name: adaptive-thinking-control
+    rationale: Excluded from the fixed one-package rule stratum; its type is represented by the registered sample.
+  - package_type: rule
+    name: commit-standards
+    rationale: Excluded from the fixed one-package rule stratum; its type is represented by the registered sample.
+  - package_type: rule
+    name: intent-discipline
+    rationale: Excluded from the fixed one-package rule stratum; its type is represented by the registered sample.
+  - package_type: rule
+    name: test-standards
+    rationale: Excluded from the fixed one-package rule stratum; its type is represented by the registered sample.
+  - package_type: rule
+    name: token-efficiency
+    rationale: Excluded from the fixed one-package rule stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: adr-writer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: agent-builder
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: api-docs-generator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: architecture-diagram
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: architecture-reviewer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: arxiv-figures
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: arxiv-package
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: arxiv-preflight
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: benchmark-runner
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: changelog-composer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: chart-clarity
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: citation-audit
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: code-refiner
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: codebase-advisor
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: competitive-analyzer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: concept-to-image
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: concept-to-video
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: debug-investigator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: decision-map
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: dependency-audit
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: devils-advocate
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: doc-condenser
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: skill
+    name: engineering-retro
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: env-validator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: estimate-calibrator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: feasibility-assessor
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: figure-rhetoric
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: figure-table-quality
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: filesystem
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: github
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: gpu-optimizer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: handoff
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: html-presentation
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: humanize
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: idea-validator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: immune
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: kg-builder
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: lightpanda-browser
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: linkedin-post-style
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: literature-review
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: manuscript-provenance
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: manuscript-review
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: manuscript-typography
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: market-analyzer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: marp-slides
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: mcp-to-skill
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: md-to-pdf
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: migration-risk-analyzer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: milestone-runner
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: notebooklm
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: opus-4-7-migration
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: package-evaluator
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: paper-to-skill
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: plan-prompts
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: plan-review
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: pr-swarm
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: pre-landing-review
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: project-context-setup
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: prompt-lab
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: qa-systematic
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: rag-auditor
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: regex-builder
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: skill
+    name: remotion-video
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: repo-sentinel
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: research-critique
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: sequential-thinking
+    rationale: Deprecated packages are excluded from effectiveness sampling.
+  - package_type: skill
+    name: ship-workflow
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: skill-distiller
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: skill-library
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: sql-optimizer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: stacked-prs
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: static-web-artifacts-builder
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: surrogate-verifier
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: task-decomposer
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: tavily
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: test-harness
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: tldraw
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: to-markdown
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: usage-audit
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: ux-expert
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: web-fetch
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: youtube-analysis
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: skill
+    name: youtube-search
+    rationale: Excluded from the fixed one-package skill stratum; its type is represented by the registered sample.
+  - package_type: utility
+    name: arxiv-search
+    rationale: Excluded from the fixed one-package utility stratum; its type is represented by the registered sample.
+  - package_type: utility
+    name: test-coverage-report
+    rationale: Excluded from the fixed one-package utility stratum; its type is represented by the registered sample.

--- a/evals/skillsbench/schema.yaml
+++ b/evals/skillsbench/schema.yaml
@@ -10,16 +10,22 @@ category: string             # development | research | review | content | ops
 difficulty: string           # easy | medium | hard
 prompt: string               # The task prompt delivered to the assistant (block).
 
-# Success criterion. Only `assertion` is supported in the seed harness.
-# Additional types (artifact_check, llm_judge) may be added later.
+# Success criterion. `assertion` checks final assistant output. `artifact`
+# checks a safe relative file path in the task workspace and never accepts
+# final-answer prose as a substitute.
 success_criterion:
-  type: assertion
-  assertions:
-    # Each assertion mirrors the schema from scripts/eval_assertions.py:
-    - type: contains | not_contains | matches_regex | json_path
-      target: string         # Literal, regex, or JSONPath expression
-      weight: 0.0-1.0        # Contribution to the task's weighted score
-  pass_threshold: 0.0-1.0    # Weighted score required to mark the task "pass"
+  type: assertion | artifact
+  assertions: # Required only for `assertion`.
+    - type: contains | not_contains | matches_regex
+      target: string
+      weight: 0.0-1.0
+  artifact: # Required only for `artifact`.
+    path: safe-relative-path
+    assertions:
+      - type: contains | not_contains | matches_regex
+        target: string
+        weight: 0.0-1.0
+  pass_threshold: 0.0-1.0
 
 # Execution bounds. The runner enforces these caps per attempt.
 limits:

--- a/scripts/run_skillsbench.py
+++ b/scripts/run_skillsbench.py
@@ -43,7 +43,7 @@ import yaml  # type: ignore[import-untyped]
 
 from scripts.model_fit import ModelFitConfigError, load_model_fit_config, select_target
 
-_SUPPORTED_CRITERION_TYPES = {"assertion"}
+_SUPPORTED_CRITERION_TYPES = {"assertion", "artifact"}
 _SUPPORTED_ASSERTION_TYPES = {"contains", "not_contains", "matches_regex"}
 _CORPUS_SCHEMA_VERSION = 1
 _REQUIRED_CONDITIONS = frozenset(
@@ -77,6 +77,8 @@ class TaskDefinition:
     difficulty: str
     prompt: str
     assertions: list[Assertion]
+    criterion_type: str
+    artifact_path: str | None
     pass_threshold: float
     max_turns: int
     max_tokens: int
@@ -215,7 +217,30 @@ def _load_task_raw(
             f"(supported: {sorted(_SUPPORTED_CRITERION_TYPES)})"
         )
 
-    assertions_raw = criterion.get("assertions")
+    assertion_source = criterion
+    artifact_path: str | None = None
+    if criterion_type == "artifact":
+        if "assertions" in criterion:
+            raise ValueError(
+                f"{source_path}: artifact criterion must not use prose assertions"
+            )
+        artifact = _require_mapping(
+            criterion.get("artifact"), f"{source_path}.success_criterion.artifact"
+        )
+        artifact_relative = Path(
+            _require_string(
+                artifact.get("path"),
+                f"{source_path}.success_criterion.artifact.path",
+            )
+        )
+        if artifact_relative.is_absolute() or ".." in artifact_relative.parts:
+            raise ValueError(
+                f"{source_path}: artifact path must be a safe relative path"
+            )
+        artifact_path = str(artifact_relative)
+        assertion_source = artifact
+
+    assertions_raw = assertion_source.get("assertions")
     if not isinstance(assertions_raw, list) or not assertions_raw:
         raise ValueError(f"{source_path}: criterion has no assertions")
     assertions: list[Assertion] = []
@@ -243,7 +268,6 @@ def _load_task_raw(
                 ),
             )
         )
-
     limits = _require_mapping(task["limits"], f"{source_path}.limits")
     return TaskDefinition(
         id=task_id,
@@ -254,6 +278,8 @@ def _load_task_raw(
         ),
         prompt=_require_string(task["prompt"], f"{source_path}.prompt"),
         assertions=assertions,
+        criterion_type=criterion_type,
+        artifact_path=artifact_path,
         pass_threshold=_require_probability(
             criterion.get("pass_threshold", 0.7),
             f"{source_path}.success_criterion.pass_threshold",
@@ -644,7 +670,27 @@ def run_task_live(
             error=error,
         )
 
-    score, details = check_assertions(output, task.assertions)
+    if task.artifact_path is None:
+        score, details = check_assertions(output, task.assertions)
+    else:
+        artifact = (Path(tmpdir) / task.artifact_path).resolve()
+        if (
+            not artifact.is_relative_to(Path(tmpdir).resolve())
+            or not artifact.is_file()
+        ):
+            score = 0.0
+            details = [
+                {
+                    "type": "artifact_exists",
+                    "target": task.artifact_path,
+                    "weight": 1.0,
+                    "passed": False,
+                }
+            ]
+        else:
+            score, details = check_assertions(
+                artifact.read_text(encoding="utf-8"), task.assertions
+            )
     return TaskRunResult(
         task_id=task.id,
         config=config,

--- a/scripts/validate_skillsbench.py
+++ b/scripts/validate_skillsbench.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Validate the frozen SkillsBench package strata declaration."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import cast
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml  # type: ignore[import-untyped]  # noqa: E402
+
+from scripts.install import discover_packages  # noqa: E402
+from scripts.package_types import TYPES  # noqa: E402
+from scripts.validate_evals import is_deprecated  # noqa: E402
+
+_DEFAULT_STRATA_PATH = _REPO_ROOT / "evals" / "skillsbench" / "package_strata.yaml"
+
+
+def _mapping(value: object, location: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{location}: expected a mapping")
+    return cast(dict[str, object], value)
+
+
+def _string(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{location}: expected a non-empty string")
+    return value
+
+
+def _entries(value: object, location: str) -> set[tuple[str, str]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{location}: expected a list")
+    entries: set[tuple[str, str]] = set()
+    for index, raw in enumerate(value):
+        entry = _mapping(raw, f"{location}[{index}]")
+        package_type = _string(
+            entry.get("package_type"), f"{location}[{index}].package_type"
+        )
+        name = _string(entry.get("name"), f"{location}[{index}].name")
+        _string(entry.get("rationale"), f"{location}[{index}].rationale")
+        key = (package_type, name)
+        if key in entries:
+            raise ValueError(f"{location}: duplicate package classification {key}")
+        entries.add(key)
+    return entries
+
+
+def validate_strata(path: Path = _DEFAULT_STRATA_PATH) -> tuple[int, int]:
+    """Require every discovered package to have one explicit classification."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read package strata: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: cannot parse package strata YAML: {exc}") from exc
+    document = _mapping(raw, str(path))
+    if document.get("schema_version") != 1:
+        raise ValueError(f"{path}: schema_version must be 1")
+
+    included = _entries(document.get("included"), f"{path}.included")
+    excluded = _entries(document.get("excluded"), f"{path}.excluded")
+    if included & excluded:
+        raise ValueError(f"{path}: a package cannot be both included and excluded")
+
+    packages = discover_packages()
+    expected = {(package.pkg_type.key, package.name) for package in packages}
+    observed = included | excluded
+    if observed != expected:
+        missing = sorted(expected - observed)
+        undeclared = sorted(observed - expected)
+        raise ValueError(
+            f"{path}: classifications differ from inventory; missing={missing}, undeclared={undeclared}"
+        )
+    if {package_type for package_type, _ in included} != set(TYPES):
+        raise ValueError(f"{path}: included sample must cover every package type")
+    if len(included) != len(TYPES):
+        raise ValueError(
+            f"{path}: included sample must contain exactly one package per type"
+        )
+
+    by_key = {(package.pkg_type.key, package.name): package for package in packages}
+    for key in included:
+        package = by_key[key]
+        if is_deprecated(package.source_path, package.pkg_type):
+            raise ValueError(f"{path}: included package {key} is deprecated")
+    return len(included), len(excluded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--strata", type=Path, default=_DEFAULT_STRATA_PATH)
+    args = parser.parse_args()
+    try:
+        included, excluded = validate_strata(args.strata)
+    except ValueError as exc:
+        print(f"SkillsBench strata validation failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        f"Validated {included} included and {excluded} excluded package classifications"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_skillsbench.py
+++ b/tests/test_run_skillsbench.py
@@ -112,6 +112,7 @@ class TestCorpusManifest:
         assert len(corpus.tasks) == 50
         assert corpus.repetitions == 3
         assert len(cells) == 450
+        assert sum(task.criterion_type == "artifact" for task in corpus.tasks) == 3
         validate_observed_cells(corpus, cells)
 
     def test_rejects_undeclared_cell(self) -> None:
@@ -140,6 +141,25 @@ class TestCorpusManifest:
 
         with pytest.raises(ValueError, match="cells are missing"):
             validate_observed_cells(corpus, cells[1:])
+
+    def test_rejects_prose_only_artifact_claim(self, tmp_path: Path) -> None:
+        path = tmp_path / "artifact_claim.yaml"
+        path.write_text(
+            "id: artifact_claim\n"
+            "description: x\n"
+            "category: development\n"
+            "prompt: create a file\n"
+            "success_criterion:\n"
+            "  type: artifact\n"
+            "  assertions:\n"
+            "    - {type: contains, target: x, weight: 1.0}\n"
+            "  artifact: {path: result.txt}\n"
+            "limits: {max_turns: 1, max_tokens: 100, timeout_seconds: 10}\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="must not use prose assertions"):
+            load_task(path)
 
 
 class TestCheckAssertions:

--- a/tests/test_validate_skillsbench.py
+++ b/tests/test_validate_skillsbench.py
@@ -1,0 +1,28 @@
+"""Tests for frozen SkillsBench package-strata validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_skillsbench import validate_strata
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_STRATA_PATH = _REPO_ROOT / "evals" / "skillsbench" / "package_strata.yaml"
+
+
+def test_validates_every_package_classification() -> None:
+    assert validate_strata(_STRATA_PATH) == (7, 134)
+
+
+def test_rejects_conflicting_package_classification(tmp_path: Path) -> None:
+    path = tmp_path / "strata.yaml"
+    path.write_text(
+        _STRATA_PATH.read_text(encoding="utf-8")
+        + "\n  - package_type: agent\n    name: security-reviewer\n    rationale: duplicate\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cannot be both included and excluded"):
+        validate_strata(path)


### PR DESCRIPTION
## Summary

- adds deterministic artifact criteria that reject final-answer prose as a substitute for workspace output
- registers one active package per type and explicit rationales for all 141 included or excluded packages
- validates artifact claims and package strata without running a model

## Stack

Stack-Id: `skillsbench-m3-corpus-20260823`
Base: `feat/skillsbench-matrix`
Position: 2/2

1. #111
2. `feat/skillsbench-artifact-strata` -> this PR

Depends on: #111
Upstack: (none - leaf)

## Validation

- `uv run ruff check scripts/run_skillsbench.py scripts/validate_skillsbench.py tests/test_run_skillsbench.py tests/test_validate_skillsbench.py`
- `uv run mypy --strict --follow-imports=silent scripts/run_skillsbench.py scripts/validate_skillsbench.py`
- `uv run python -m pytest tests/test_run_skillsbench.py tests/test_validate_skillsbench.py`
- `uv run python scripts/validate_skillsbench.py`
- `uv run python scripts/run_skillsbench.py --validate-manifest`
- `uv run python scripts/run_skillsbench.py --dry-run`
