### PR TITLE
feat(skillsbench): add omp run preflight

### DIFF
--- a/evals/skillsbench/README.md
+++ b/evals/skillsbench/README.md
@@ -36,28 +36,21 @@ evals/skillsbench/
 
 ## Running the Benchmark
 
-**Status:** frozen corpus registered; live execution remains deferred to the
-operator. A meaningful run requires hours of live `claude -p` execution and
-requires M4's recorded approval, budget, privacy posture, and receipt policy.
+**Status:** M4's no-cost OMP preflight is available. It validates the frozen
+two-target matrix against active Claude and Codex subscriptions without sending a
+model request. Live execution remains unavailable until the reviewed preflight
+stack merges and a fresh M4 design gate authorizes the resulting runtime.
 
 ```bash
-# Validate the frozen task × condition × target × repetition declaration.
+# Validate the frozen corpus and package strata.
 uv run python scripts/run_skillsbench.py --validate-manifest
+uv run python scripts/validate_skillsbench.py
 
-# Full declared corpus, dry-run (validates M2 target linkage and all task data
-# without a model request).
+# Validate the 900-cell OMP subscription contract without a model request.
+uv run python scripts/omp_skillsbench.py --preflight
+
+# Legacy harness dry-run: validates M2 target linkage and task data only.
 uv run python scripts/run_skillsbench.py --dry-run
-
-# One registered task, dry-run.
-uv run python scripts/run_skillsbench.py --task task_001_code_review_simple --dry-run
-
-# Full sweep, Config A only. Requires M4 approval before `--live`.
-uv run python scripts/run_skillsbench.py --all --config A --live
-
-# Operator workflow for comparison. Requires M4 approval before `--live`.
-uv run python scripts/run_skillsbench.py --all --config A --live --output results/run-A.json
-uv run python scripts/run_skillsbench.py --all --config B --live --output results/run-B.json
-uv run python scripts/run_skillsbench.py --compare results/run-A.json results/run-B.json
 ```
 
 ## Task Set Scope
@@ -67,8 +60,9 @@ exists: the five retained seed tasks plus 45 inline tasks spanning development,
 review, operations, research, and content work. It resolves the M2 declared
 target (`claude-code-opus-xhigh`) and declares the `current`,
 `reduced-or-rewritten`, and `strengthened-contract` conditions, three
-repetitions, and explicit exclusions. The matrix therefore contains 450
-declared cells.
+repetitions, and explicit exclusions. The M3 declaration contains 450 cells.
+`omp_run.yaml` expands those conditions over pinned Claude and Codex OMP targets
+into the M4 900-cell subscription matrix without running a model.
 
 The legacy seed task files remain directly loadable for focused harness tests.
 Their assertion criteria remain useful for prose deliverables. Tasks whose

--- a/evals/skillsbench/omp_run.yaml
+++ b/evals/skillsbench/omp_run.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+execution:
+  runner: omp
+  mode: json
+  subscription_only: true
+  session_persistence: false
+  attempts_per_cell: 1
+  max_time_seconds: 600
+  derived_receipts_only: true
+
+targets:
+  - id: omp-anthropic-claude-opus-5
+    model: anthropic/claude-opus-5
+    subscription_label: Anthropic
+    thinking: xhigh
+  - id: omp-openai-gpt-5-codex
+    model: openai/gpt-5-codex
+    subscription_label: Openai Codex
+    thinking: xhigh
+
+# Each source revision is pinned. The reduced condition keeps only the reviewed
+# load-bearing sections; strengthened-contract appends the stated invariant to
+# the complete pinned source. PR-2 materializes these specifications in isolated
+# worktrees and records the resulting content hashes per cell.
+treatments:
+  - package: agent/security-reviewer
+    source: agents/security-reviewer/AGENT.md
+    source_sha256: e27c6b70f4fb08456e4098f4a06007e598323e71c36c34fd0badbbe9826f3e71
+    reduced_sections: ["Scope and Trigger Conditions", "Severity Classification", "Output Format", "Rules", "Verification"]
+    strengthened_append: "Every reported finding MUST distinguish verified source-to-sink evidence from a hypothesis and MUST state the evidence gap when verification is unavailable."
+  - package: command/stack-pr
+    source: commands/stack-pr/COMMAND.md
+    source_sha256: 5c86024f50fd7d1d68e52d01360b61408d2fbe3b4869d62dbfbd6053874bbcb9
+    reduced_sections: ["Workflow", "Operations", "Argument Rules", "Error Handling", "Output"]
+    strengthened_append: "Before any stack mutation, require an explicit branch order or provider-base evidence; refuse inferred topology when the two disagree."
+  - package: hook/git-protection
+    source: hooks/git-protection/HOOK.md
+    source_sha256: bb392e70d026df14088895c64d7e8775699b97d0234c37feca615b29891da2ce
+    reduced_sections: ["Blocked Operations", "Behavior", "Bypassing"]
+    strengthened_append: "Malformed tool input is a blocked operation: emit an explicit denial and never treat an unreadable command as safe."
+  - package: preset/sec-strict
+    source: presets/sec-strict/PRESET.md
+    source_sha256: 874b4ea9af2fb6bf7778d3be0df45525e97bb731efc9b644565600e67f199e41
+    reduced_sections: ["Included Packages", "Defense Layers", "When to Use", "Relationship to Core"]
+    strengthened_append: "For every exception to this preset, record the omitted package, security rationale, approver, and expiry before execution."
+  - package: rule/security-standards
+    source: rules/security-standards/RULE.md
+    source_sha256: 3657c435d3ed86a0db1eb026e65162c721e9aa89402919542e965b808516764a
+    reduced_sections: ["Secret Management", "Input Validation", "Authentication and Session Handling", "HTTP Security Headers", "File Upload Security"]
+    strengthened_append: "Security exceptions require an explicit owner, compensating control, expiry, and verification command; undocumented exceptions are rejected."
+  - package: skill/pr-review
+    source: skills/pr-review/SKILL.md
+    source_sha256: 776a618c37d1b9c0ae5466f5af06f506056d69b574c3dd93557217b5bef96c54
+    reduced_sections: ["Workflow", "Output Format", "Error Handling", "Calibration Rules", "Verification"]
+    strengthened_append: "Every approval must identify the tested behavioral contract and name unresolved risks; a green test suite alone is not an approval rationale."
+  - package: utility/dependency-tree
+    source: utilities/dependency-tree/UTILITY.md
+    source_sha256: be88aad965885eb00d525a1a8cfd01557cbb0050d7113e6fe48f4497898619af
+    reduced_sections: ["Usage", "Output Format", "Supported Formats", "Limitations"]
+    strengthened_append: "Output MUST state the parsed manifest path and explicitly label unresolved transitive dependencies as unavailable rather than absent."

--- a/scripts/omp_skillsbench.py
+++ b/scripts/omp_skillsbench.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Validate the no-cost OMP contract for the frozen SkillsBench run."""
+
+# ruff: noqa: E402
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final, cast
+
+_REPO_ROOT: Final = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+import re
+
+import yaml  # type: ignore[import-untyped]
+
+from scripts.run_skillsbench import CorpusManifest, load_corpus_manifest
+from scripts.validate_skillsbench import validate_strata
+
+_DEFAULT_CONTRACT_PATH: Final = _REPO_ROOT / "evals" / "skillsbench" / "omp_run.yaml"
+_REQUIRED_CONDITIONS: Final = (
+    "current",
+    "reduced-or-rewritten",
+    "strengthened-contract",
+)
+
+_EXPECTED_TASK_COUNT: Final = 50
+_EXPECTED_TARGET_COUNT: Final = 2
+_EXPECTED_REPETITIONS: Final = 3
+_EXPECTED_CELL_COUNT: Final = 900
+_USAGE_TIMEOUT_SECONDS: Final = 30
+
+
+class OmpRunConfigError(ValueError):
+    """Raised when an OMP benchmark contract is not reproducible."""
+
+
+@dataclass(frozen=True)
+class OmpTarget:
+    """A subscription-authenticated model target."""
+
+    id: str
+    model: str
+    subscription_label: str
+    thinking: str
+
+
+@dataclass(frozen=True)
+class TreatmentVariant:
+    """One reviewed source and its declared treatment transformations."""
+
+    package: str
+    source: Path
+    source_sha256: str
+    reduced_sections: tuple[str, ...]
+    strengthened_append: str
+
+
+@dataclass(frozen=True)
+class OmpCell:
+    """One immutable task × condition × target × repetition unit."""
+
+    task_id: str
+    condition: str
+    target_id: str
+    repetition: int
+    condition_hash: str
+
+
+@dataclass(frozen=True)
+class OmpRunContract:
+    """Validated no-cost specification for the OMP comparative pilot."""
+
+    targets: tuple[OmpTarget, ...]
+    treatments: tuple[TreatmentVariant, ...]
+    attempts_per_cell: int
+    max_time_seconds: int
+    corpus: CorpusManifest
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Machine-readable no-cost verification output."""
+
+    targets: tuple[str, ...]
+    task_count: int
+    cell_count: int
+    attempts_per_cell: int
+    max_time_seconds: int
+    condition_hashes: dict[str, str]
+    subscription_labels: tuple[str, ...]
+    model_request_made: bool
+
+
+def _mapping(value: object, location: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise OmpRunConfigError(f"{location}: expected a mapping")
+    return cast(dict[str, object], value)
+
+
+def _string(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise OmpRunConfigError(f"{location}: expected a non-empty string")
+    return value
+
+
+def _positive_int(value: object, location: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise OmpRunConfigError(f"{location}: expected a positive integer")
+    return value
+
+
+def _strings(value: object, location: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise OmpRunConfigError(f"{location}: expected a non-empty list of strings")
+    values = tuple(
+        _string(item, f"{location}[{index}]") for index, item in enumerate(value)
+    )
+    if len(values) != len(set(values)):
+        raise OmpRunConfigError(f"{location}: must not contain duplicates")
+    return values
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise OmpRunConfigError(f"cannot read contract {path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise OmpRunConfigError(f"cannot parse contract {path}: {exc}") from exc
+    return _mapping(raw, str(path))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_target(raw: object, index: int) -> OmpTarget:
+    location = f"targets[{index}]"
+    target = _mapping(raw, location)
+    model = _string(target.get("model"), f"{location}.model")
+    if "/" not in model:
+        raise OmpRunConfigError(
+            f"{location}.model: use an explicit provider/model selector"
+        )
+    return OmpTarget(
+        id=_string(target.get("id"), f"{location}.id"),
+        model=model,
+        subscription_label=_string(
+            target.get("subscription_label"), f"{location}.subscription_label"
+        ),
+        thinking=_string(target.get("thinking"), f"{location}.thinking"),
+    )
+
+
+def _load_treatment(raw: object, index: int) -> TreatmentVariant:
+    location = f"treatments[{index}]"
+    treatment = _mapping(raw, location)
+    source_value = Path(_string(treatment.get("source"), f"{location}.source"))
+    if source_value.is_absolute() or ".." in source_value.parts:
+        raise OmpRunConfigError(
+            f"{location}.source: expected a safe repository-relative path"
+        )
+    source = (_REPO_ROOT / source_value).resolve()
+    if not source.is_relative_to(_REPO_ROOT) or not source.is_file():
+        raise OmpRunConfigError(f"{location}.source: source file is unavailable")
+    source_sha256 = _string(treatment.get("source_sha256"), f"{location}.source_sha256")
+    if _sha256(source) != source_sha256:
+        raise OmpRunConfigError(f"{location}.source_sha256: source revision changed")
+    sections = _strings(
+        treatment.get("reduced_sections"), f"{location}.reduced_sections"
+    )
+    source_text = source.read_text(encoding="utf-8")
+    for section in sections:
+        if re.search(rf"^## {re.escape(section)}$", source_text, re.MULTILINE) is None:
+            raise OmpRunConfigError(
+                f"{location}.reduced_sections: missing level-two heading {section!r}"
+            )
+    return TreatmentVariant(
+        package=_string(treatment.get("package"), f"{location}.package"),
+        source=source,
+        source_sha256=source_sha256,
+        reduced_sections=sections,
+        strengthened_append=_string(
+            treatment.get("strengthened_append"), f"{location}.strengthened_append"
+        ),
+    )
+
+
+def load_omp_run_contract(path: Path = _DEFAULT_CONTRACT_PATH) -> OmpRunContract:
+    """Load and validate the fixed OMP target and treatment declaration."""
+    contract = _load_yaml(path)
+    if contract.get("schema_version") != 1:
+        raise OmpRunConfigError("schema_version must be 1")
+    execution = _mapping(contract.get("execution"), "execution")
+    if execution.get("runner") != "omp" or execution.get("mode") != "json":
+        raise OmpRunConfigError("execution must use omp JSON mode")
+    if execution.get("subscription_only") is not True:
+        raise OmpRunConfigError("execution.subscription_only must be true")
+    if execution.get("session_persistence") is not False:
+        raise OmpRunConfigError("execution.session_persistence must be false")
+    if execution.get("derived_receipts_only") is not True:
+        raise OmpRunConfigError("execution.derived_receipts_only must be true")
+    attempts = _positive_int(
+        execution.get("attempts_per_cell"), "execution.attempts_per_cell"
+    )
+    if attempts != 1:
+        raise OmpRunConfigError("execution.attempts_per_cell must be exactly 1")
+    targets_raw = contract.get("targets")
+    if not isinstance(targets_raw, list) or len(targets_raw) != _EXPECTED_TARGET_COUNT:
+        raise OmpRunConfigError(
+            f"targets must declare exactly {_EXPECTED_TARGET_COUNT} OMP targets"
+        )
+    targets = tuple(_load_target(raw, index) for index, raw in enumerate(targets_raw))
+    target_ids = tuple(target.id for target in targets)
+    if len(target_ids) != len(set(target_ids)):
+        raise OmpRunConfigError("targets must not contain duplicate ids")
+    target_models = {target.model for target in targets}
+    if target_models != {"anthropic/claude-opus-5", "openai/gpt-5-codex"}:
+        raise OmpRunConfigError(
+            "targets must declare the approved Claude and Codex models"
+        )
+
+    treatments_raw = contract.get("treatments")
+    if not isinstance(treatments_raw, list) or len(treatments_raw) != 7:
+        raise OmpRunConfigError("treatments must declare all seven package samples")
+    treatments = tuple(
+        _load_treatment(raw, index) for index, raw in enumerate(treatments_raw)
+    )
+    packages = tuple(treatment.package for treatment in treatments)
+    if len(packages) != len(set(packages)):
+        raise OmpRunConfigError("treatments must not contain duplicate packages")
+    try:
+        validate_strata()
+        corpus = load_corpus_manifest()
+    except ValueError as exc:
+        raise OmpRunConfigError(f"frozen input validation failed: {exc}") from exc
+    if len(corpus.tasks) != _EXPECTED_TASK_COUNT:
+        raise OmpRunConfigError(
+            f"corpus must contain exactly {_EXPECTED_TASK_COUNT} tasks"
+        )
+    if corpus.repetitions != _EXPECTED_REPETITIONS:
+        raise OmpRunConfigError(
+            f"corpus must declare exactly {_EXPECTED_REPETITIONS} repetitions"
+        )
+    if (corpus.baseline, *corpus.treatments) != _REQUIRED_CONDITIONS:
+        raise OmpRunConfigError("corpus conditions do not match the approved matrix")
+    return OmpRunContract(
+        targets=targets,
+        treatments=treatments,
+        attempts_per_cell=attempts,
+        max_time_seconds=_positive_int(
+            execution.get("max_time_seconds"), "execution.max_time_seconds"
+        ),
+        corpus=corpus,
+    )
+
+
+def condition_hashes(contract: OmpRunContract) -> dict[str, str]:
+    """Produce stable hashes for the three concrete treatment specifications."""
+    payloads = {
+        "current": [
+            {"package": treatment.package, "source": treatment.source_sha256}
+            for treatment in contract.treatments
+        ],
+        "reduced-or-rewritten": [
+            {
+                "package": treatment.package,
+                "source": treatment.source_sha256,
+                "sections": treatment.reduced_sections,
+            }
+            for treatment in contract.treatments
+        ],
+        "strengthened-contract": [
+            {
+                "package": treatment.package,
+                "source": treatment.source_sha256,
+                "append": treatment.strengthened_append,
+            }
+            for treatment in contract.treatments
+        ],
+    }
+    return {
+        condition: hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        for condition, payload in payloads.items()
+    }
+
+
+def declared_omp_cells(contract: OmpRunContract) -> tuple[OmpCell, ...]:
+    """Expand the immutable M3 corpus into its two-target OMP matrix."""
+    hashes = condition_hashes(contract)
+    return tuple(
+        OmpCell(
+            task_id=task.id,
+            condition=condition,
+            target_id=target.id,
+            repetition=repetition,
+            condition_hash=hashes[condition],
+        )
+        for task in contract.corpus.tasks
+        for condition in (contract.corpus.baseline, *contract.corpus.treatments)
+        for target in contract.targets
+        for repetition in range(1, contract.corpus.repetitions + 1)
+    )
+
+
+def validate_subscription_usage(contract: OmpRunContract, usage_output: str) -> None:
+    """Require OMP's no-cost usage report to show every approved subscription."""
+    missing = [
+        target.subscription_label
+        for target in contract.targets
+        if re.search(
+            rf"^{re.escape(target.subscription_label)}\s*[—:-].*\b\d+\s+accounts?\b",
+            usage_output,
+            re.IGNORECASE | re.MULTILINE,
+        )
+        is None
+    ]
+    if missing:
+        raise OmpRunConfigError(
+            f"OMP subscription usage is missing approved target(s): {', '.join(missing)}"
+        )
+
+
+def preflight(contract: OmpRunContract, usage_output: str) -> PreflightReport:
+    """Validate matrix, source revisions, and subscriptions without a model call."""
+    validate_subscription_usage(contract, usage_output)
+    cells = declared_omp_cells(contract)
+    if len(cells) != len(set(cells)):
+        raise OmpRunConfigError("OMP matrix contains duplicate cells")
+    if len(cells) != _EXPECTED_CELL_COUNT:
+        raise OmpRunConfigError(
+            f"OMP matrix must contain exactly {_EXPECTED_CELL_COUNT} cells"
+        )
+    return PreflightReport(
+        targets=tuple(target.model for target in contract.targets),
+        task_count=len(contract.corpus.tasks),
+        cell_count=len(cells),
+        attempts_per_cell=contract.attempts_per_cell,
+        max_time_seconds=contract.max_time_seconds,
+        condition_hashes=condition_hashes(contract),
+        subscription_labels=tuple(
+            target.subscription_label for target in contract.targets
+        ),
+        model_request_made=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, default=_DEFAULT_CONTRACT_PATH)
+    parser.add_argument(
+        "--preflight", action="store_true", help="Run no-cost contract validation"
+    )
+    args = parser.parse_args(argv)
+    if not args.preflight:
+        parser.error(
+            "--preflight is required; live OMP execution is not available in this command"
+        )
+    try:
+        contract = load_omp_run_contract(args.contract)
+        try:
+            usage = subprocess.run(
+                ["omp", "usage"],
+                capture_output=True,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                timeout=_USAGE_TIMEOUT_SECONDS,
+            )
+        except FileNotFoundError as exc:
+            raise OmpRunConfigError("'omp' CLI not found in PATH") from exc
+        except OSError as exc:
+            raise OmpRunConfigError(f"cannot execute omp usage: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise OmpRunConfigError(
+                f"omp usage timed out after {_USAGE_TIMEOUT_SECONDS}s"
+            ) from exc
+        if usage.returncode != 0:
+            detail = usage.stderr.strip() or f"exit status {usage.returncode}"
+            raise OmpRunConfigError(f"omp usage failed: {detail}")
+        report = preflight(contract, usage.stdout)
+    except ValueError as exc:
+        print(f"OMP SkillsBench preflight failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(asdict(report), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_omp_skillsbench.py
+++ b/tests/test_omp_skillsbench.py
@@ -1,0 +1,160 @@
+"""Tests for the no-cost OMP SkillsBench preflight contract."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from subprocess import CompletedProcess, TimeoutExpired
+
+import pytest
+
+import scripts.omp_skillsbench as omp_skillsbench
+from scripts.omp_skillsbench import (
+    OmpRunConfigError,
+    declared_omp_cells,
+    load_omp_run_contract,
+    preflight,
+    validate_subscription_usage,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONTRACT_PATH = _REPO_ROOT / "evals" / "skillsbench" / "omp_run.yaml"
+_USAGE = "Anthropic — 1 account\nOpenai Codex — 1 account\n"
+
+
+def test_loads_fixed_two_target_contract() -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cells = declared_omp_cells(contract)
+
+    assert [target.model for target in contract.targets] == [
+        "anthropic/claude-opus-5",
+        "openai/gpt-5-codex",
+    ]
+    assert len(contract.treatments) == 7
+    assert len(cells) == 900
+    assert len(cells) == len(set(cells))
+
+
+def test_preflight_is_explicitly_no_cost() -> None:
+    report = preflight(load_omp_run_contract(_CONTRACT_PATH), _USAGE)
+
+    assert report.cell_count == 900
+    assert report.attempts_per_cell == 1
+    assert report.model_request_made is False
+    assert set(report.condition_hashes) == {
+        "current",
+        "reduced-or-rewritten",
+        "strengthened-contract",
+    }
+
+
+def test_rejects_missing_subscription() -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+
+    with pytest.raises(OmpRunConfigError, match="Openai Codex"):
+        validate_subscription_usage(contract, "Anthropic — 1 account\n")
+
+
+def test_rejects_provider_mentions_without_subscription_account() -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+
+    with pytest.raises(OmpRunConfigError, match="Anthropic"):
+        validate_subscription_usage(
+            contract,
+            "Anthropic: not configured\nOpenai Codex: unavailable\n",
+        )
+
+
+def test_rejects_source_revision_drift(tmp_path: Path) -> None:
+    contract = _CONTRACT_PATH.read_text(encoding="utf-8")
+    path = tmp_path / "omp_run.yaml"
+    path.write_text(
+        contract.replace(
+            "e27c6b70f4fb08456e4098f4a06007e598323e71c36c34fd0badbbe9826f3e71", "a" * 64
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OmpRunConfigError, match="source revision changed"):
+        load_omp_run_contract(path)
+
+
+def test_rejects_unpinned_corpus_cardinality(monkeypatch: pytest.MonkeyPatch) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    monkeypatch.setattr(
+        omp_skillsbench,
+        "load_corpus_manifest",
+        lambda: replace(contract.corpus, repetitions=4),
+    )
+
+    with pytest.raises(OmpRunConfigError, match="exactly 3 repetitions"):
+        load_omp_run_contract(_CONTRACT_PATH)
+
+
+def test_main_prints_no_cost_receipt(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    call_kwargs: dict[str, object] = {}
+
+    def usage_succeeds(*args: object, **kwargs: object) -> CompletedProcess[str]:
+        call_kwargs.update(kwargs)
+        return CompletedProcess(args=args[0], returncode=0, stdout=_USAGE, stderr="")
+
+    monkeypatch.setattr(omp_skillsbench.subprocess, "run", usage_succeeds)
+
+    assert omp_skillsbench.main(["--preflight"]) == 0
+    assert '"model_request_made": false' in capsys.readouterr().out
+    assert call_kwargs["timeout"] == 30
+    assert call_kwargs["stdin"] is omp_skillsbench.subprocess.DEVNULL
+    assert call_kwargs["capture_output"] is True
+
+
+def test_main_fails_loudly_when_omp_usage_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        omp_skillsbench.subprocess,
+        "run",
+        lambda *args, **kwargs: CompletedProcess(
+            args=args[0], returncode=1, stdout="", stderr="denied"
+        ),
+    )
+
+    assert omp_skillsbench.main(["--preflight"]) == 2
+    assert "omp usage failed: denied" in capsys.readouterr().err
+
+
+def test_main_fails_loudly_when_omp_is_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def missing_omp(*args: object, **kwargs: object) -> CompletedProcess[str]:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(omp_skillsbench.subprocess, "run", missing_omp)
+
+    assert omp_skillsbench.main(["--preflight"]) == 2
+    assert "'omp' CLI not found in PATH" in capsys.readouterr().err
+
+
+def test_main_fails_loudly_when_usage_times_out(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def timeout_omp(*args: object, **kwargs: object) -> CompletedProcess[str]:
+        raise TimeoutExpired(cmd=["omp", "usage"], timeout=30)
+
+    monkeypatch.setattr(omp_skillsbench.subprocess, "run", timeout_omp)
+
+    assert omp_skillsbench.main(["--preflight"]) == 2
+    assert "omp usage timed out after 30s" in capsys.readouterr().err
+
+
+def test_main_normalizes_frozen_input_validation_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def invalid_strata() -> tuple[int, int]:
+        raise ValueError("inventory drift")
+
+    monkeypatch.setattr(omp_skillsbench, "validate_strata", invalid_strata)
+
+    assert omp_skillsbench.main(["--preflight"]) == 2
+    assert "frozen input validation failed: inventory drift" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- adds a no-cost OMP preflight for the fixed Claude/Codex subscription experiment
- freezes seven reviewed manual treatment specifications and source revisions
- validates 900 unique cells, target selectors, subscription availability, derived-only receipts, and one-attempt/per-cell time limits without a model request

## Stack

Stack-Id: `m4-omp-preflight-20260824`
Base: `main`
Position: 1/2

1. `feat/skillsbench-omp-preflight` -> this PR
2. M4 immutable result bundle -> planned child PR

Depends on: (none - root)
Upstack: pending

## Validation

- `uv run ruff check scripts/omp_skillsbench.py tests/test_omp_skillsbench.py`
- `uv run ruff format --check scripts/omp_skillsbench.py tests/test_omp_skillsbench.py`
- `uv run mypy --strict --follow-imports=silent scripts/omp_skillsbench.py`
- `uv run python -m pytest tests/test_model_fit.py tests/test_run_skillsbench.py tests/test_validate_skillsbench.py tests/test_omp_skillsbench.py`
- `uv run python scripts/omp_skillsbench.py --preflight`

No model request is made by this PR.
