### PR TITLE
fix(skillsbench): select Codex subscription target

### DIFF
--- a/evals/skillsbench/omp_run.yaml
+++ b/evals/skillsbench/omp_run.yaml
@@ -13,8 +13,8 @@ targets:
     model: anthropic/claude-opus-5
     subscription_label: Anthropic
     thinking: xhigh
-  - id: omp-openai-gpt-5-codex
-    model: openai/gpt-5-codex
+  - id: omp-openai-codex-gpt-5-6-terra
+    model: openai-codex/gpt-5.6-terra
     subscription_label: Openai Codex
     thinking: xhigh
 

--- a/scripts/omp_skillsbench.py
+++ b/scripts/omp_skillsbench.py
@@ -222,7 +222,7 @@ def load_omp_run_contract(path: Path = _DEFAULT_CONTRACT_PATH) -> OmpRunContract
     if len(target_ids) != len(set(target_ids)):
         raise OmpRunConfigError("targets must not contain duplicate ids")
     target_models = {target.model for target in targets}
-    if target_models != {"anthropic/claude-opus-5", "openai/gpt-5-codex"}:
+    if target_models != {"anthropic/claude-opus-5", "openai-codex/gpt-5.6-terra"}:
         raise OmpRunConfigError(
             "targets must declare the approved Claude and Codex models"
         )

--- a/tests/test_omp_skillsbench.py
+++ b/tests/test_omp_skillsbench.py
@@ -28,7 +28,7 @@ def test_loads_fixed_two_target_contract() -> None:
 
     assert [target.model for target in contract.targets] == [
         "anthropic/claude-opus-5",
-        "openai/gpt-5-codex",
+        "openai-codex/gpt-5.6-terra",
     ]
     assert len(contract.treatments) == 7
     assert len(cells) == 900


### PR DESCRIPTION
## Summary

- replaces the API-key-only `openai/gpt-5-codex` selector with the user-approved Codex-subscription target `openai-codex/gpt-5.6-terra`
- pins preflight validation and tests to the provider identity that completed the OMP receipt-surface probe

## Validation

- `uv run ruff check scripts/omp_skillsbench.py tests/test_omp_skillsbench.py`
- `uv run ruff format --check scripts/omp_skillsbench.py tests/test_omp_skillsbench.py`
- `uv run mypy --strict --follow-imports=silent scripts/omp_skillsbench.py`
- `uv run python -m pytest tests/test_omp_skillsbench.py`
- `uv run python scripts/omp_skillsbench.py --preflight`

## Evidence

A headless OMP probe completed with `provider: openai-codex`, `api: openai-codex-responses`, and `model: gpt-5.6-terra`. No 900-cell run is included.
