### PR TITLE
feat(skillsbench): add isolated omp dispatcher

### DIFF
--- a/evals/skillsbench/README.md
+++ b/evals/skillsbench/README.md
@@ -36,11 +36,11 @@ evals/skillsbench/
 
 ## Running the Benchmark
 
-**Status:** M4's no-cost OMP input and result preflights are available. They
-validate the frozen two-target matrix, reviewed treatment materialization, and
-derived-receipt schema against active Claude and Codex subscriptions without a
-model request. Live execution remains unavailable until the reviewed result-runner
-stack merges and a fresh M4 design gate authorizes it.
+**Status:** M4's no-cost OMP input, receipt, and dispatcher preflights are
+available. They validate the frozen two-target matrix, reviewed treatment
+materialization, derived-receipt schema, and all 900 isolated command shapes
+without a model request. Live execution remains unavailable until a fresh M4
+design gate authorizes the reviewed dispatcher.
 
 ```bash
 # Validate the frozen corpus and package strata.
@@ -52,6 +52,9 @@ uv run python scripts/omp_skillsbench.py --preflight
 
 # Materialize reviewed treatment inputs and validate immutable receipt handling.
 uv run python scripts/omp_skillsbench_results.py --preflight
+
+# Validate all 900 isolated OMP command shapes without starting OMP.
+uv run python scripts/omp_skillsbench_dispatch.py --preflight
 
 # Legacy harness dry-run: validates M2 target linkage and task data only.
 uv run python scripts/run_skillsbench.py --dry-run

--- a/evals/skillsbench/omp_run.yaml
+++ b/evals/skillsbench/omp_run.yaml
@@ -7,6 +7,7 @@ execution:
   attempts_per_cell: 1
   max_time_seconds: 600
   derived_receipts_only: true
+  profile: m4-benchmark
 
 targets:
   - id: omp-anthropic-claude-opus-5

--- a/scripts/omp_skillsbench.py
+++ b/scripts/omp_skillsbench.py
@@ -81,6 +81,7 @@ class OmpRunContract:
     treatments: tuple[TreatmentVariant, ...]
     attempts_per_cell: int
     max_time_seconds: int
+    profile: str
     corpus: CorpusManifest
 
 
@@ -212,6 +213,9 @@ def load_omp_run_contract(path: Path = _DEFAULT_CONTRACT_PATH) -> OmpRunContract
     )
     if attempts != 1:
         raise OmpRunConfigError("execution.attempts_per_cell must be exactly 1")
+    profile = _string(execution.get("profile"), "execution.profile")
+    if profile != "m4-benchmark":
+        raise OmpRunConfigError("execution.profile must be m4-benchmark")
     targets_raw = contract.get("targets")
     if not isinstance(targets_raw, list) or len(targets_raw) != _EXPECTED_TARGET_COUNT:
         raise OmpRunConfigError(
@@ -255,6 +259,7 @@ def load_omp_run_contract(path: Path = _DEFAULT_CONTRACT_PATH) -> OmpRunContract
         targets=targets,
         treatments=treatments,
         attempts_per_cell=attempts,
+        profile=profile,
         max_time_seconds=_positive_int(
             execution.get("max_time_seconds"), "execution.max_time_seconds"
         ),

--- a/scripts/omp_skillsbench_dispatch.py
+++ b/scripts/omp_skillsbench_dispatch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -39,7 +40,8 @@ from scripts.omp_skillsbench_results import (
 )
 
 _EXPECTED_CELL_COUNT: Final = 900
-_TOOL_SURFACE: Final = "Read,Write,Edit,Bash,Glob,Grep"
+_PROCESS_GRACE_SECONDS: Final = 30
+_TOOL_SURFACE: Final = "read,write,edit,bash,glob,grep"
 
 
 class OmpDispatchError(ValueError):
@@ -158,17 +160,12 @@ def build_omp_command(contract: OmpRunContract, prepared: PreparedCell) -> list[
 
 
 def _classify_nonzero(stderr: str) -> OmpDispatchError:
-    normalized = stderr.casefold()
-    if any(
-        token in normalized
-        for token in (
-            "no api key",
-            "not logged",
-            "auth",
-            "quota",
-            "rate limit",
-            "credit",
-        )
+    if "no api key" in stderr.casefold() or "not logged" in stderr.casefold():
+        return GlobalDispatchError("OMP provider authentication or quota failure")
+    if re.search(
+        r"\b(authentication|authorization|quota|rate limit|insufficient credit)\b",
+        stderr,
+        re.IGNORECASE,
     ):
         return GlobalDispatchError("OMP provider authentication or quota failure")
     return CellDispatchError("OMP process failed for the declared cell")
@@ -191,7 +188,7 @@ def dispatch_cell(
                 check=False,
                 stdin=subprocess.DEVNULL,
                 text=True,
-                timeout=contract.max_time_seconds,
+                timeout=contract.max_time_seconds + _PROCESS_GRACE_SECONDS,
             )
         except subprocess.TimeoutExpired as exc:
             raise CellDispatchError(
@@ -209,8 +206,14 @@ def dispatch_cell(
                 completed.stdout,
             )
         except OmpResultError as exc:
-            raise GlobalDispatchError(
-                f"OMP terminal receipt is invalid: {exc}"
+            if "provider/model differs" in str(exc) or "unapproved provider API" in str(
+                exc
+            ):
+                raise GlobalDispatchError(
+                    f"OMP terminal receipt has global identity drift: {exc}"
+                ) from exc
+            raise CellDispatchError(
+                f"OMP terminal receipt failed for the cell: {exc}"
             ) from exc
         write_derived_receipt(receipt_root, receipt)
         return receipt
@@ -226,9 +229,32 @@ def dispatcher_preflight(contract: OmpRunContract) -> DispatcherPreflightReport:
         for index, cell in enumerate(cells):
             prepared = prepare_cell(contract, cell, root / str(index))
             command = build_omp_command(contract, prepared)
-            if "--model" not in command or "--append-system-prompt" not in command:
+            model_index = command.index("--model") + 1
+            thinking_index = command.index("--thinking") + 1
+            cwd_index = command.index("--cwd") + 1
+            bundle_index = command.index("--append-system-prompt") + 1
+            bundle = Path(command[bundle_index]).resolve()
+            if command[model_index] != prepared.target.model:
                 raise OmpDispatchError(
-                    "dispatcher command omits required target or condition input"
+                    "dispatcher command model differs from its cell target"
+                )
+            if command[thinking_index] != prepared.target.thinking:
+                raise OmpDispatchError(
+                    "dispatcher command thinking differs from its cell target"
+                )
+            if Path(command[cwd_index]).resolve() != prepared.workspace:
+                raise OmpDispatchError(
+                    "dispatcher command cwd differs from its cell workspace"
+                )
+            if not bundle.is_relative_to(prepared.workspace) or not bundle.is_file():
+                raise OmpDispatchError(
+                    "dispatcher condition bundle escapes its cell workspace"
+                )
+            if prepared.materialized.content_hash not in bundle.read_text(
+                encoding="utf-8"
+            ):
+                raise OmpDispatchError(
+                    "dispatcher condition bundle omits its materialized hash"
                 )
             if "--api-key" in command or "--profile" in command:
                 raise OmpDispatchError(

--- a/scripts/omp_skillsbench_dispatch.py
+++ b/scripts/omp_skillsbench_dispatch.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Prepare and supervise one declared OMP SkillsBench cell.
+
+The command-line interface is intentionally preflight-only. `dispatch_cell` is
+an injectable library boundary for the separately authorized live run; it never
+persists prompts, assistant text, or raw OMP events.
+"""
+
+# ruff: noqa: E402
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Final
+
+_REPO_ROOT: Final = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.omp_skillsbench import (
+    OmpCell,
+    OmpRunContract,
+    OmpTarget,
+    declared_omp_cells,
+    load_omp_run_contract,
+)
+from scripts.omp_skillsbench_results import (
+    DerivedReceipt,
+    MaterializedCondition,
+    OmpResultError,
+    derive_receipt,
+    materialize_condition,
+    write_derived_receipt,
+)
+
+_EXPECTED_CELL_COUNT: Final = 900
+_TOOL_SURFACE: Final = "Read,Write,Edit,Bash,Glob,Grep"
+
+
+class OmpDispatchError(ValueError):
+    """Base class for failures while preparing or dispatching a cell."""
+
+
+class GlobalDispatchError(OmpDispatchError):
+    """A provider/auth/quota failure that invalidates every remaining cell."""
+
+
+class CellDispatchError(OmpDispatchError):
+    """A single-cell failure that must be persisted by a future run ledger."""
+
+
+@dataclass(frozen=True)
+class PreparedCell:
+    """Ephemeral isolated workspace and deterministic condition input."""
+
+    cell: OmpCell
+    target: OmpTarget
+    workspace: Path
+    materialized: MaterializedCondition
+    condition_bundle: Path
+
+
+@dataclass(frozen=True)
+class DispatcherPreflightReport:
+    """No-cost proof that every target command is deterministic and isolated."""
+
+    cell_count: int
+    target_count: int
+    tools: tuple[str, ...]
+    model_request_made: bool
+
+
+def _task_for_cell(contract: OmpRunContract, cell: OmpCell) -> str:
+    for task in contract.corpus.tasks:
+        if task.id == cell.task_id:
+            return task.prompt
+    raise OmpDispatchError(f"undeclared task: {cell.task_id}")
+
+
+def _target_for_cell(contract: OmpRunContract, cell: OmpCell) -> OmpTarget:
+    for target in contract.targets:
+        if target.id == cell.target_id:
+            return target
+    raise OmpDispatchError(f"undeclared target: {cell.target_id}")
+
+
+def _write_condition_bundle(
+    workspace: Path, materialized: MaterializedCondition
+) -> Path:
+    root = workspace / "condition"
+    entries: list[str] = [
+        "# Frozen M4 Condition Bundle",
+        f"Condition: {materialized.condition}",
+        f"Content hash: {materialized.content_hash}",
+        "Use these package definitions as the complete condition input for this task.",
+    ]
+    for relative in materialized.files:
+        content = (root / relative).read_text(encoding="utf-8")
+        entries.extend((f"\n## Source: {relative}\n", content.rstrip()))
+    bundle = workspace / "CONDITION.md"
+    bundle.write_text("\n".join(entries) + "\n", encoding="utf-8")
+    return bundle
+
+
+def prepare_cell(
+    contract: OmpRunContract, cell: OmpCell, workspace: Path
+) -> PreparedCell:
+    """Materialize one exact cell in a caller-owned isolated workspace."""
+    target = _target_for_cell(contract, cell)
+    workspace = workspace.resolve()
+    workspace.mkdir(parents=True, exist_ok=False)
+    materialized = materialize_condition(
+        contract, cell.condition, workspace / "condition"
+    )
+    return PreparedCell(
+        cell=cell,
+        target=target,
+        workspace=workspace,
+        materialized=materialized,
+        condition_bundle=_write_condition_bundle(workspace, materialized),
+    )
+
+
+def build_omp_command(contract: OmpRunContract, prepared: PreparedCell) -> list[str]:
+    """Build the exact headless command without executing it."""
+    if prepared.cell.target_id != prepared.target.id:
+        raise OmpDispatchError("prepared cell target does not match its target")
+    prompt = _task_for_cell(contract, prepared.cell)
+    return [
+        "omp",
+        "-p",
+        "--mode",
+        "json",
+        "--no-session",
+        "--no-title",
+        "--no-extensions",
+        "--no-skills",
+        "--no-rules",
+        "--tools",
+        _TOOL_SURFACE,
+        "--model",
+        prepared.target.model,
+        "--thinking",
+        prepared.target.thinking,
+        "--max-time",
+        str(contract.max_time_seconds),
+        "--cwd",
+        str(prepared.workspace),
+        "--append-system-prompt",
+        str(prepared.condition_bundle),
+        prompt,
+    ]
+
+
+def _classify_nonzero(stderr: str) -> OmpDispatchError:
+    normalized = stderr.casefold()
+    if any(
+        token in normalized
+        for token in (
+            "no api key",
+            "not logged",
+            "auth",
+            "quota",
+            "rate limit",
+            "credit",
+        )
+    ):
+        return GlobalDispatchError("OMP provider authentication or quota failure")
+    return CellDispatchError("OMP process failed for the declared cell")
+
+
+def dispatch_cell(
+    contract: OmpRunContract,
+    cell: OmpCell,
+    receipt_root: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> DerivedReceipt:
+    """Dispatch exactly one cell; intended only after a future execution gate."""
+    with tempfile.TemporaryDirectory(prefix="omp_skillsbench_cell_") as directory:
+        prepared = prepare_cell(contract, cell, Path(directory) / "workspace")
+        command = build_omp_command(contract, prepared)
+        try:
+            completed = runner(
+                command,
+                capture_output=True,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                timeout=contract.max_time_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CellDispatchError(
+                "OMP cell exceeded its declared wall-time limit"
+            ) from exc
+        except OSError as exc:
+            raise GlobalDispatchError(f"cannot launch OMP: {exc}") from exc
+        if completed.returncode != 0:
+            raise _classify_nonzero(completed.stderr)
+        try:
+            receipt = derive_receipt(
+                prepared.cell,
+                prepared.target,
+                prepared.materialized,
+                completed.stdout,
+            )
+        except OmpResultError as exc:
+            raise GlobalDispatchError(
+                f"OMP terminal receipt is invalid: {exc}"
+            ) from exc
+        write_derived_receipt(receipt_root, receipt)
+        return receipt
+
+
+def dispatcher_preflight(contract: OmpRunContract) -> DispatcherPreflightReport:
+    """Validate all command shapes without launching any provider process."""
+    cells = declared_omp_cells(contract)
+    if len(cells) != _EXPECTED_CELL_COUNT or len(cells) != len(set(cells)):
+        raise OmpDispatchError("dispatcher matrix is not the exact 900-cell set")
+    with tempfile.TemporaryDirectory(prefix="omp_skillsbench_dispatch_") as directory:
+        root = Path(directory)
+        for index, cell in enumerate(cells):
+            prepared = prepare_cell(contract, cell, root / str(index))
+            command = build_omp_command(contract, prepared)
+            if "--model" not in command or "--append-system-prompt" not in command:
+                raise OmpDispatchError(
+                    "dispatcher command omits required target or condition input"
+                )
+            if "--api-key" in command or "--profile" in command:
+                raise OmpDispatchError(
+                    "dispatcher command may not override subscription auth"
+                )
+    return DispatcherPreflightReport(
+        cell_count=len(cells),
+        target_count=len(contract.targets),
+        tools=tuple(_TOOL_SURFACE.split(",")),
+        model_request_made=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--preflight", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.preflight:
+        parser.error("--preflight is required; live OMP execution is unavailable")
+    try:
+        report = dispatcher_preflight(load_omp_run_contract())
+    except OmpDispatchError as exc:
+        print(f"OMP SkillsBench dispatcher preflight failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(asdict(report), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/omp_skillsbench_dispatch.py
+++ b/scripts/omp_skillsbench_dispatch.py
@@ -139,6 +139,8 @@ def build_omp_command(contract: OmpRunContract, prepared: PreparedCell) -> list[
         "--mode",
         "json",
         "--no-session",
+        "--profile",
+        contract.profile,
         "--no-title",
         "--no-extensions",
         "--no-skills",
@@ -160,12 +162,12 @@ def build_omp_command(contract: OmpRunContract, prepared: PreparedCell) -> list[
 
 
 def _classify_nonzero(stderr: str) -> OmpDispatchError:
-    if "no api key" in stderr.casefold() or "not logged" in stderr.casefold():
-        return GlobalDispatchError("OMP provider authentication or quota failure")
+    normalized = re.sub(r"[-_]", " ", stderr.casefold())
     if re.search(
-        r"\b(authentication|authorization|quota|rate limit|insufficient credit)\b",
-        stderr,
-        re.IGNORECASE,
+        r"\b(401|403|429)\b|no api key|invalid api key|not logged|oauth token expired|"
+        r"\b(unauthorized|authentication|authorization|quota|rate limit|"
+        r"insufficient quota|insufficient credit|credit balance|billing)\b",
+        normalized,
     ):
         return GlobalDispatchError("OMP provider authentication or quota failure")
     return CellDispatchError("OMP process failed for the declared cell")
@@ -215,7 +217,12 @@ def dispatch_cell(
             raise CellDispatchError(
                 f"OMP terminal receipt failed for the cell: {exc}"
             ) from exc
-        write_derived_receipt(receipt_root, receipt)
+        try:
+            write_derived_receipt(receipt_root, receipt)
+        except OmpResultError as exc:
+            raise CellDispatchError(
+                f"OMP receipt persistence failed for the cell: {exc}"
+            ) from exc
         return receipt
 
 
@@ -256,9 +263,10 @@ def dispatcher_preflight(contract: OmpRunContract) -> DispatcherPreflightReport:
                 raise OmpDispatchError(
                     "dispatcher condition bundle omits its materialized hash"
                 )
-            if "--api-key" in command or "--profile" in command:
+            profile_index = command.index("--profile") + 1
+            if command[profile_index] != contract.profile or "--api-key" in command:
                 raise OmpDispatchError(
-                    "dispatcher command may not override subscription auth"
+                    "dispatcher command does not use the dedicated subscription profile"
                 )
     return DispatcherPreflightReport(
         cell_count=len(cells),

--- a/tests/test_omp_skillsbench_dispatch.py
+++ b/tests/test_omp_skillsbench_dispatch.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
-from subprocess import CompletedProcess
+from subprocess import CompletedProcess, TimeoutExpired
 
 import pytest
 
 from scripts.omp_skillsbench import declared_omp_cells, load_omp_run_contract
 from scripts.omp_skillsbench_dispatch import (
+    CellDispatchError,
     GlobalDispatchError,
     build_omp_command,
     dispatch_cell,
@@ -78,7 +80,8 @@ def test_dispatch_persists_one_derived_receipt(tmp_path: Path) -> None:
 
     def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
         calls.append(command)
-        assert kwargs["stdin"] is not None
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["timeout"] == 630
         return CompletedProcess(command, 0, stdout=_terminal_events(), stderr="")
 
     receipt = dispatch_cell(contract, cell, tmp_path / "receipts", runner)
@@ -97,4 +100,26 @@ def test_dispatch_treats_auth_failures_as_global(tmp_path: Path) -> None:
         return CompletedProcess(command, 1, stdout="", stderr="No API key found")
 
     with pytest.raises(GlobalDispatchError, match="authentication or quota"):
+        dispatch_cell(contract, cell, tmp_path / "receipts", runner)
+
+
+def test_dispatch_treats_neutral_cell_failure_as_non_global(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        return CompletedProcess(command, 1, stdout="", stderr="authoring tool failed")
+
+    with pytest.raises(CellDispatchError, match="declared cell"):
+        dispatch_cell(contract, cell, tmp_path / "receipts", runner)
+
+
+def test_dispatch_timeout_is_cell_failure(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        raise TimeoutExpired(command, 630)
+
+    with pytest.raises(CellDispatchError, match="wall-time"):
         dispatch_cell(contract, cell, tmp_path / "receipts", runner)

--- a/tests/test_omp_skillsbench_dispatch.py
+++ b/tests/test_omp_skillsbench_dispatch.py
@@ -1,0 +1,100 @@
+"""Tests for the no-cost OMP SkillsBench dispatcher prerequisite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+from scripts.omp_skillsbench import declared_omp_cells, load_omp_run_contract
+from scripts.omp_skillsbench_dispatch import (
+    GlobalDispatchError,
+    build_omp_command,
+    dispatch_cell,
+    dispatcher_preflight,
+    prepare_cell,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONTRACT_PATH = _REPO_ROOT / "evals" / "skillsbench" / "omp_run.yaml"
+
+
+def _terminal_events() -> str:
+    return json.dumps(
+        {
+            "type": "turn_end",
+            "message": {
+                "provider": "anthropic",
+                "api": "anthropic-messages",
+                "model": "claude-opus-5",
+                "usage": {
+                    "input": 10,
+                    "output": 5,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                    "totalTokens": 15,
+                },
+                "duration": 2.5,
+                "stopReason": "stop",
+            },
+            "toolResults": [],
+        }
+    )
+
+
+def test_prepared_cell_has_explicit_condition_bundle(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+    prepared = prepare_cell(contract, cell, tmp_path / "cell")
+    command = build_omp_command(contract, prepared)
+
+    assert prepared.condition_bundle.is_file()
+    assert "Frozen M4 Condition Bundle" in prepared.condition_bundle.read_text(
+        encoding="utf-8"
+    )
+    assert "--mode" in command and command[command.index("--mode") + 1] == "json"
+    assert "--no-session" in command
+    assert (
+        "--model" in command
+        and command[command.index("--model") + 1] == "anthropic/claude-opus-5"
+    )
+    assert "--api-key" not in command
+
+
+def test_dispatcher_preflight_builds_all_cells_without_model_request() -> None:
+    report = dispatcher_preflight(load_omp_run_contract(_CONTRACT_PATH))
+
+    assert report.cell_count == 900
+    assert report.target_count == 2
+    assert report.model_request_made is False
+
+
+def test_dispatch_persists_one_derived_receipt(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+    calls: list[list[str]] = []
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        calls.append(command)
+        assert kwargs["stdin"] is not None
+        return CompletedProcess(command, 0, stdout=_terminal_events(), stderr="")
+
+    receipt = dispatch_cell(contract, cell, tmp_path / "receipts", runner)
+
+    assert receipt.task_id == cell.task_id
+    assert len(calls) == 1
+    assert "--append-system-prompt" in calls[0]
+    assert list((tmp_path / "receipts").rglob("*.json"))
+
+
+def test_dispatch_treats_auth_failures_as_global(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        return CompletedProcess(command, 1, stdout="", stderr="No API key found")
+
+    with pytest.raises(GlobalDispatchError, match="authentication or quota"):
+        dispatch_cell(contract, cell, tmp_path / "receipts", runner)

--- a/tests/test_omp_skillsbench_dispatch.py
+++ b/tests/test_omp_skillsbench_dispatch.py
@@ -62,6 +62,7 @@ def test_prepared_cell_has_explicit_condition_bundle(tmp_path: Path) -> None:
         "--model" in command
         and command[command.index("--model") + 1] == "anthropic/claude-opus-5"
     )
+    assert command[command.index("--profile") + 1] == "m4-benchmark"
     assert "--api-key" not in command
 
 
@@ -103,6 +104,22 @@ def test_dispatch_treats_auth_failures_as_global(tmp_path: Path) -> None:
         dispatch_cell(contract, cell, tmp_path / "receipts", runner)
 
 
+@pytest.mark.parametrize(
+    "stderr", ["401 Unauthorized", "rate_limit_error", "OAuth token expired"]
+)
+def test_dispatch_treats_provider_error_forms_as_global(
+    tmp_path: Path, stderr: str
+) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        return CompletedProcess(command, 1, stdout="", stderr=stderr)
+
+    with pytest.raises(GlobalDispatchError, match="authentication or quota"):
+        dispatch_cell(contract, cell, tmp_path / "receipts", runner)
+
+
 def test_dispatch_treats_neutral_cell_failure_as_non_global(tmp_path: Path) -> None:
     contract = load_omp_run_contract(_CONTRACT_PATH)
     cell = declared_omp_cells(contract)[0]
@@ -122,4 +139,17 @@ def test_dispatch_timeout_is_cell_failure(tmp_path: Path) -> None:
         raise TimeoutExpired(command, 630)
 
     with pytest.raises(CellDispatchError, match="wall-time"):
+        dispatch_cell(contract, cell, tmp_path / "receipts", runner)
+
+
+def test_dispatch_treats_abnormal_terminal_as_cell_failure(tmp_path: Path) -> None:
+    contract = load_omp_run_contract(_CONTRACT_PATH)
+    cell = declared_omp_cells(contract)[0]
+    event = json.loads(_terminal_events())
+    event["message"]["stopReason"] = "max_tokens"
+
+    def runner(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        return CompletedProcess(command, 0, stdout=json.dumps(event), stderr="")
+
+    with pytest.raises(CellDispatchError, match="terminal receipt failed"):
         dispatch_cell(contract, cell, tmp_path / "receipts", runner)


### PR DESCRIPTION
## Summary

- adds an isolated one-cell OMP dispatcher library with no live CLI path
- builds exact headless commands from frozen target, condition bundle, and task identity
- classifies provider auth/quota failures globally and retains only exclusive-created derived terminal receipts
- validates all 900 command shapes without launching OMP

## Stack

Stack-Id: `m4-omp-dispatcher-20260824`
Base: `main`
Position: 1/1

## Validation

- `uv run ruff check scripts/omp_skillsbench.py scripts/omp_skillsbench_results.py scripts/omp_skillsbench_dispatch.py tests/test_omp_skillsbench.py tests/test_omp_skillsbench_results.py tests/test_omp_skillsbench_dispatch.py`
- `uv run mypy --strict --follow-imports=silent scripts/omp_skillsbench.py scripts/omp_skillsbench_results.py scripts/omp_skillsbench_dispatch.py`
- `uv run python -m pytest tests/test_model_fit.py tests/test_run_skillsbench.py tests/test_validate_skillsbench.py tests/test_omp_skillsbench.py tests/test_omp_skillsbench_results.py tests/test_omp_skillsbench_dispatch.py`
- `uv run python scripts/omp_skillsbench_dispatch.py --preflight`

No model request is made by this PR.
