### PR TITLE
feat(stacked-prs): add GitHub native stack mode

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1227,18 +1227,19 @@ packages:
     difficulty: intermediate
     phase: build
   - name: stacked-prs
-    version: 0.1.0
+    version: 0.2.0
     description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create
       stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs",
-      "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches". Use when local branches or
-      one source branch need to become a dependency-ordered PR stack with correct parent bases, validation, synchronization,
-      merge order, and cleanup.'
+      "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches", or "GitHub native stack". Use
+      when local branches or one source branch need a dependency-ordered PR stack with correct parent bases, validation, synchronization,
+      merge order, cleanup, and optional GitHub-native stack support.'
     path: skills/stacked-prs
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/stacked-prs/SKILL.md
     tags:
     - git
     - pull-requests
     - stacked-prs
+    - github-native
     - workflow
     category: development
     difficulty: advanced

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: stacked-prs
-description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs", "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches". Use when local branches or one source branch need to become a dependency-ordered PR stack with correct parent bases, validation, synchronization, merge order, and cleanup.'
+description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs", "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches", or "GitHub native stack". Use when local branches or one source branch need a dependency-ordered PR stack with correct parent bases, validation, synchronization, merge order, cleanup, and optional GitHub-native stack support.'
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   category: development
-  tags: [git, pull-requests, stacked-prs, workflow]
+  tags: [git, pull-requests, stacked-prs, github-native, workflow]
   difficulty: advanced
   phase: ship
 ---
@@ -25,6 +25,7 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 | `references/merge-discipline.md` | Bottom-up merge and branch cleanup rules | Merging or closing out a stack |
 | `references/metadata-format.md` | Optional metadata schema and validation rules | `.stack-prs.yaml` exists or inference is ambiguous |
 | `references/provenance.md` | Commit-trailer stack identity, stamping, verification, merge-mode coupling | Creating, splitting, syncing, or merging any stack |
+| `references/github-native.md` | Eligibility, `gh stack` operations, preview limits, and manual fallback | A GitHub-native stack is requested or detected |
 
 ## When To Use
 
@@ -48,6 +49,46 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 - Stamp `Stack-Id` and `Stack-Position` trailers on every commit the skill creates or splits; copy the ID from `.stack-prs.yaml` or mint it once when absent.
 - Verify trailers are present and consistent before merge.
 - Detect the provider merge mode before merging. Under squash-only repos, fold trailers into the squash body or stack identity is lost.
+
+## GitHub-native stack mode
+
+GitHub-native stacks are public preview, same-repository-only, and optional.
+They enhance manual Armory stacks; they do not replace provenance trailers,
+`.stack-prs.yaml`, or the provider-neutral workflow.
+
+Use `github-native` mode only after this eligibility probe passes:
+
+1. GitHub CLI plus `gh stack --help` succeeds; install `github/gh-stack` when absent.
+2. Native stack support is enabled for the repository; native exit code 9 falls
+   back to manual mode.
+3. Every proposed head/base branch and pull request belongs to the same GitHub
+   repository; reject forks and cross-repository stacks.
+4. Existing PR bases, local branch order, and `Stack-Id`/`Stack-Position`
+   provenance agree. Stop on disagreement.
+5. Native merge is eligible only when trailers survive: use merge/rebase mode;
+   use manual Armory mode for squash-only repositories.
+6. The user explicitly requests native mode or accepts its public-preview risk.
+
+When eligible:
+
+- Link existing branches or PRs bottom-to-top with
+  `gh stack link --base <base> <branch-or-pr>...`.
+- Inspect both Armory provenance and the GitHub-native stack position.
+- Sync with `gh stack sync`; re-read `gh stack view` after every non-interactive
+  sync and use `gh stack rebase` plus `gh stack push` for non-linear history.
+- Merge the entire stack only on an explicit user request; invoke
+  `gh stack merge --yes --merge-method <merge|rebase>` with no positional
+  argument. For a partial prefix, require the exact highest PR number and run
+  `gh stack merge <pr-number> --yes --merge-method <merge|rebase>`.
+  Outside a merge queue, GitHub merges every lower layer atomically.
+- For a merge queue, method flags are ignored and stack members may land in
+  separate queue groups; require explicit queue acceptance and verify each group.
+- Re-fetch and verify the remaining stack topology, CI, and provenance after
+  GitHub's cascading rebase/retarget.
+
+Fall back to the manual workflow when the probe fails, the stack spans a fork,
+the GitHub preview surface is unavailable, or provider/trailer topology differs.
+Never silently switch modes mid-stack.
 
 ## Workflow
 

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -204,6 +204,101 @@ cases:
         target: "(stop|stops|do not|must not)[\\s\\S]*(mismatch|differs|different)"
         weight: 1.0
 
+  - id: github_native_same_repo_stack
+    prompt: >
+      Link same-repository branches feat/core, feat/api, and feat/ui into a
+      GitHub-native stack on main. Preserve the existing Stack-Id trailers and
+      stop if native topology disagrees with the Armory stack metadata.
+    fixtures: []
+    rubric:
+      - "probes gh stack support and same-repository eligibility"
+      - "links the stack bottom-to-top with gh stack link"
+      - "preserves Armory provenance and fails on topology disagreement"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh stack --help"
+        weight: 0.8
+      - type: matches_regex
+        target: "gh stack link[\\s\\S]*--base[\\s\\S]*main"
+        weight: 1.0
+      - type: matches_regex
+        target: "(Stack-Id|Stack-Position|\\.stack-prs\\.yaml)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(same.repository|fork|topology|disagree|mismatch)"
+        weight: 0.9
+
+  - id: github_native_prefix_merge
+    prompt: >
+      In a GitHub-native stack, merge only the prefix through PR #42 with a merge
+      commit after every displayed layer is green. Do not infer the merge boundary.
+    fixtures: []
+    rubric:
+      - "requires the explicit highest PR number for a partial merge"
+      - "uses GitHub atomic stack merge with a trailer-preserving explicit method"
+      - "re-fetches and verifies remaining topology after the cascading rebase"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh stack merge[\\s\\S]*42[\\s\\S]*--yes[\\s\\S]*--merge-method\\s+merge\\b"
+        weight: 1.0
+      - type: matches_regex
+        target: "(atomic|every lower|prefix|partial)"
+        weight: 0.8
+      - type: matches_regex
+        target: "(fetch|re-fetch|topology|cascading)"
+        weight: 0.8
+
+  - id: github_native_fork_fallback
+    prompt: >
+      Use GitHub-native stack mode for a stack whose child branch belongs to a
+      fork. Keep the stack safe.
+    fixtures: []
+    rubric:
+      - "rejects GitHub-native mode for cross-fork stacks"
+      - "falls back to the manual Armory workflow without losing provenance"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(fork|cross.repository|same.repository)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(manual|fallback|root.to.leaf)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(Stack-Id|Stack-Position|provenance)"
+        weight: 0.8
+      - type: not_contains
+        target: "gh stack link"
+        weight: 1.0
+      - type: not_contains
+        target: "gh stack merge"
+        weight: 1.0
+      - type: matches_regex
+        target: "gh pr merge|gh pr edit[\\s\\S]*--base"
+        weight: 0.9
+
+  - id: github_native_unavailable_fallback
+    prompt: >
+      GitHub native stacked pull requests are disabled for this repository.
+      Keep a same-repository stack safe and continue without native mode.
+    fixtures: []
+    rubric:
+      - "detects native mode unavailability and selects manual Armory mode"
+      - "does not run native link or merge operations"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(exit code 9|not enabled|native.*unavailable|manual.*fallback)"
+        weight: 1.0
+      - type: not_contains
+        target: "gh stack link"
+        weight: 1.0
+      - type: not_contains
+        target: "gh stack merge"
+        weight: 1.0
+
   - id: negative_single_pr
     prompt: "Open a normal PR for my current branch against main."
     fixtures: []

--- a/skills/stacked-prs/references/github-native.md
+++ b/skills/stacked-prs/references/github-native.md
@@ -1,0 +1,94 @@
+# GitHub-native stacked pull requests
+
+GitHub-native stacked pull requests are public preview. Use them only as an
+optional GitHub adapter over Armory's existing provenance and manual workflow.
+
+## Eligibility
+
+Require all of the following before linking or merging natively:
+
+1. GitHub CLI is version 2.0 or later and `gh stack --help` succeeds. Install
+   the extension when absent: `gh extension install github/gh-stack`.
+2. Every branch and pull request is in the same GitHub repository. Reject forks
+   and cross-repository stacks.
+3. Repository native-stack support is enabled. Treat native command exit code 9
+   as unavailable and fall back to manual mode.
+4. Armory branch order, PR base order, and `Stack-Id`/`Stack-Position` trailers
+   agree with the proposed native order.
+5. The repository permits merge commits or rebase merges. A squash-only
+   repository may link natively but must use Armory's manual squash-body merge
+   path so trailers survive.
+6. The user explicitly selects `github-native` mode or accepts the preview risk.
+
+Do not use native mode for cross-fork stacks, unavailable preview tooling,
+disabled repository support, squash-only merge, or topology mismatch. Report the
+reason and use manual Armory mode instead.
+
+## Link and inspect
+
+Arguments are bottom-to-top:
+
+```bash
+gh stack link --base main feat/core feat/api feat/ui
+gh stack view
+```
+
+`gh stack link` can push named branches, create missing pull requests, and
+correct existing PR bases to the expected chain. Run dirty-worktree,
+provenance, and topology checks before it mutates anything.
+
+Link updates are additive only: it never removes an existing member. `--base`
+is ignored when appending to an existing stack. A wrong native order requires
+`gh stack unstack` followed by a verified relink; do not use link as a repair.
+
+Record both GitHub stack position and Armory provenance in the stack report. A
+native stack object never replaces `.stack-prs.yaml` or commit trailers.
+
+## Sync and rebase
+
+```bash
+gh stack sync
+gh stack sync --prune
+```
+
+`sync` fetches, cascade-rebases, force-with-lease pushes, and links open PRs.
+Use `--prune` only after confirming the pruned branches' pull requests merged.
+
+Do not trust a successful non-interactive exit alone: stack divergence can abort
+without a failing exit status. Re-run `gh stack view` and compare composition
+against Armory branch/PR/trailer metadata before continuing. For wrong native
+order, unstack and relink. For a non-linear history or a lower-branch amend,
+run `gh stack rebase`, resolve conflicts interactively, then `gh stack push`.
+
+## Merge
+
+Outside a merge queue, a native stack merge is atomic: a selected pull request
+merges with every lower layer, or none merge. Require a fully linear history
+between stack branches before merging.
+
+```bash
+# Entire current stack, only after explicit user request; no positional argument
+gh stack merge --yes --merge-method merge
+
+# Explicit prefix through PR #42
+gh stack merge 42 --yes --merge-method merge
+```
+
+Never infer a prefix. Require the exact highest pull request number. GitHub
+applies branch protection at merge time. After completion, re-fetch, verify
+stack topology/CI/provenance, and clean only confirmed merged branches.
+
+### Merge queues
+
+When the base uses a merge queue, stack members enter the queue together but can
+land in separate merge groups. Merge-method flags are ignored, auto-merge is
+unsupported, and atomicity does not hold across queue groups. Require explicit
+queue acceptance, then verify topology, CI, and provenance after every group.
+
+## CI and fallback
+
+GitHub applies the bottom pull request's base-branch requirements across a
+native stack. Still inspect every displayed stack layer as green before a merge.
+
+Manual Armory mode remains mandatory for every ineligible stack and retains its
+root-to-leaf merge, explicit rebase/retarget, and trailer-preservation rules.


### PR DESCRIPTION
## Summary

- adds optional GitHub-native stacked PR mode backed by `gh stack`
- preserves Armory trailers and manual stack mode as the portable baseline
- requires same-repository eligibility, explicit preview acceptance, and topology/provenance agreement
- documents atomic prefix merge, sync, CI, and fork fallback behavior

## Validation

- `gh stack --help`
- `gh stack link --help`
- `gh stack merge --help`
- `gh stack sync --help`
- `uv run python scripts/validate_evals.py`
- `uv run python scripts/evaluate_package.py --path skills/stacked-prs --json`
- `uv run python scripts/run_evals.py --package skills/stacked-prs --dry-run --no-history`
