### PR TITLE
fix(stacked-prs): fix native-stack merge path and five related defects

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1227,7 +1227,7 @@ packages:
     difficulty: intermediate
     phase: build
   - name: stacked-prs
-    version: 0.2.0
+    version: 0.3.0
     description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create
       stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs",
       "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches", or "GitHub native stack". Use

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -2,7 +2,7 @@
 name: stacked-prs
 description: 'Manages dependent branch stacks and stacked pull requests using safe Git topology rules. Triggers on: "create stacked PRs", "publish this stack", "sync my PR stack", "rebase this stack", "merge the stack", "retarget child PRs", "split this branch into stacked PRs", "validate this stack", "cleanup stacked branches", or "GitHub native stack". Use when local branches or one source branch need a dependency-ordered PR stack with correct parent bases, validation, synchronization, merge order, cleanup, and optional GitHub-native stack support.'
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   category: development
   tags: [git, pull-requests, stacked-prs, github-native, workflow]
   difficulty: advanced

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -107,6 +107,14 @@ When eligible or already native:
   `gh stack merge` has no `--subject`/`--body` override to fold them back in —
   change the repository's policy first or merge with `--merge-method
   merge`/`rebase` instead.
+- `gh stack merge` exposes no `--subject`/`--body`. With
+  `squash_merge_commit_title: COMMIT_OR_PR_TITLE` (GitHub's default), a PR
+  squashing a single commit takes that commit's headline as the base-branch
+  subject, not the PR title, and this cannot be corrected after merge without
+  rewriting pushed history. When the visible subject matters for a
+  single-commit PR under `--merge-method squash`, align the commit headline
+  with the PR title first (`git commit --amend -m "<pr-title>"`, then
+  force-with-lease push) before running `gh stack merge`.
 - For a merge queue, method flags are ignored and stack members may land in
   separate queue groups; require explicit queue acceptance and verify each group.
 - Re-fetch and verify the remaining stack topology, CI, and provenance after

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -262,11 +262,30 @@ After the stack lands:
 git switch <base>
 git pull --ff-only origin <base>
 git fetch --prune origin
+```
+
+Delete local branches with merge-mode-appropriate proof. For a `--merge`
+(merge-commit) landing, ancestry survives:
+
+```bash
 git branch --merged <base>
 git branch -d <merged-stack-branch>
 ```
 
-Delete only branches confirmed merged into the current base.
+For a `--squash` or `--rebase` landing, the landed commit has no ancestry link
+to the local branch: `git branch --merged <base>` never lists it and `git
+branch -d` always refuses. Prove content equivalence instead:
+
+```bash
+git diff --quiet origin/<base> <merged-stack-branch>
+git branch -D <merged-stack-branch>
+```
+
+A stale local branch predating a remote rebase can show diffs in files it
+never touched; read `git diff --stat` for additions unique to the branch, not
+merely for nonzero output, before trusting the comparison. When in doubt, use
+`git cherry <base> <merged-stack-branch>` instead: no `+`-prefixed lines means
+every commit already landed, and `-D` is safe.
 
 Delete remote stack branches only after every stack PR has landed or been retargeted away from the branch:
 
@@ -330,6 +349,7 @@ Do not publish if the leaf differs from the source branch.
 | Trailer `Stack-Id` differs from `.stack-prs.yaml` | Stop; resolve canonical ID before mutation |
 | PR is a detected native-stack member | Stop the manual merge path; use GitHub-native stack mode merge instead |
 | Squash repo with `PR_BODY`/`BLANK` message policy and trailers not present | Stop; use the squash-body merge path |
+| Local branch fails its merge-mode-appropriate proof (unmerged per `git branch --merged <base>` under a merge-commit landing, or shows `+` commits under `git cherry <base> <branch>` for a squash/rebase landing) | Stop; do not force-delete without explicit user instruction |
 
 ## Recovery: Deleted Parent Branch Closed A Child PR
 

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -49,6 +49,7 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 - Stamp `Stack-Id` and `Stack-Position` trailers on every commit the skill creates or splits; copy the ID from `.stack-prs.yaml` or mint it once when absent.
 - Verify trailers are present and consistent before merge.
 - Probe every open stack PR for native-stack membership during Inspect (`references/stack-model.md` § Native Stack Detection) before merge planning; a detected native stack makes the manual merge path in §5 unavailable, not merely discouraged.
+- Detect the provider's squash message policy (`squash_merge_commit_message`) before merging with `--squash`. Fold trailers into the squash body only when the policy is `PR_BODY` or `BLANK`; under `COMMIT_MESSAGES` (GitHub's default) trailers already survive automatically.
 
 ## GitHub-native stack mode
 
@@ -94,10 +95,18 @@ When eligible or already native:
 - Sync with `gh stack sync`; re-read `gh stack view` after every non-interactive
   sync and use `gh stack rebase` plus `gh stack push` for non-linear history.
 - Merge the entire stack only on an explicit user request; invoke
-  `gh stack merge --yes --merge-method <merge|rebase>` with no positional
-  argument. For a partial prefix, require the exact highest PR number and run
-  `gh stack merge <pr-number> --yes --merge-method <merge|rebase>`.
-  Outside a merge queue, GitHub merges every lower layer atomically.
+  `gh stack merge --yes --merge-method <merge|squash|rebase>` with no
+  positional argument. For a partial prefix, require the exact highest PR
+  number and run `gh stack merge <pr-number> --yes --merge-method
+  <merge|squash|rebase>`. Outside a merge queue, GitHub merges every lower
+  layer atomically.
+- Before choosing `--squash`, check `gh api repos/{owner}/{repo} --jq
+  '.squash_merge_commit_message'`. Trailers survive automatically under
+  `COMMIT_MESSAGES` (GitHub's default). Under `PR_BODY` they survive only if
+  every PR body already carries them. Under `BLANK` they are always lost and
+  `gh stack merge` has no `--subject`/`--body` override to fold them back in —
+  change the repository's policy first or merge with `--merge-method
+  merge`/`rebase` instead.
 - For a merge queue, method flags are ignored and stack members may land in
   separate queue groups; require explicit queue acceptance and verify each group.
 - Re-fetch and verify the remaining stack topology, CI, and provenance after
@@ -226,7 +235,13 @@ git push --force-with-lease origin <child-branch>
 gh pr edit <child-pr> --base main
 ```
 
-If merge commits are allowed, use `gh pr merge <pr> --merge`. If the repository is squash-only, use the squash-body path from `references/provenance.md` so the `Stack-Id` and `Stack-Position` trailers land in the squash commit body.
+If merge commits are allowed, use `gh pr merge <pr> --merge`. If the
+repository squashes and `squash_merge_commit_message` is `PR_BODY` or `BLANK`
+(`gh api repos/{owner}/{repo} --jq '.squash_merge_commit_message'`), use the
+squash-body path from `references/provenance.md` so the `Stack-Id` and
+`Stack-Position` trailers land in the squash commit body. Under
+`COMMIT_MESSAGES` (GitHub's default), squash already preserves trailers
+automatically.
 
 On GitHub, do not pass `--delete-branch` while any open PR still has the branch being merged as its `baseRefName`. Deleting a parent branch that is still a child PR base can close the child PR unmerged. Repeat for each child. Require trailer verification, parent checks, and provider merge confirmation before moving to the next branch.
 
@@ -305,7 +320,7 @@ Do not publish if the leaf differs from the source branch.
 | Commit in stack range missing `Stack-Id` trailer | Stop; stamp via provenance backfill before merge |
 | Trailer `Stack-Id` differs from `.stack-prs.yaml` | Stop; resolve canonical ID before mutation |
 | PR is a detected native-stack member | Stop the manual merge path; use GitHub-native stack mode merge instead |
-| Squash-only repo without trailers folded into squash body | Stop; use the squash-body merge path |
+| Squash repo with `PR_BODY`/`BLANK` message policy and trailers not present | Stop; use the squash-body merge path |
 
 ## Recovery: Deleted Parent Branch Closed A Child PR
 

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -48,13 +48,17 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 - Do not delete unmerged stack branches without explicit user instruction.
 - Stamp `Stack-Id` and `Stack-Position` trailers on every commit the skill creates or splits; copy the ID from `.stack-prs.yaml` or mint it once when absent.
 - Verify trailers are present and consistent before merge.
-- Detect the provider merge mode before merging. Under squash-only repos, fold trailers into the squash body or stack identity is lost.
+- Probe every open stack PR for native-stack membership during Inspect (`references/stack-model.md` § Native Stack Detection) before merge planning; a detected native stack makes the manual merge path in §5 unavailable, not merely discouraged.
 
 ## GitHub-native stack mode
 
 GitHub-native stacks are public preview, same-repository-only, and optional.
 They enhance manual Armory stacks; they do not replace provenance trailers,
 `.stack-prs.yaml`, or the provider-neutral workflow.
+
+Native-stack membership is a provider-side property of a pull request, not a
+mode this skill chooses. Detect it for every stack PR during Inspect, before
+any merge planning, whether or not `github-native` mode was requested.
 
 Use `github-native` mode only after this eligibility probe passes:
 
@@ -105,12 +109,14 @@ git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
 gh pr list --state open --json number,title,headRefName,baseRefName,state,url
 ```
 
-Produce a table with one row per stack branch:
+Produce a table with one row per stack branch. Run the native-stack probe
+(`references/stack-model.md` § Native Stack Detection) for every PR before
+recording this table:
 
-| Order | Branch | Parent | PR | State | Checks |
-| ---: | --- | --- | --- | --- | --- |
-| 1 | `feat/parser-core` | `main` | `#101` | open | pending |
-| 2 | `feat/parser-cache` | `feat/parser-core` | `#102` | open | pending |
+| Order | Branch | Parent | PR | State | Checks | Native |
+| ---: | --- | --- | --- | --- | --- | --- |
+| 1 | `feat/parser-core` | `main` | `#101` | open | pending | no |
+| 2 | `feat/parser-cache` | `feat/parser-core` | `#102` | open | pending | no |
 
 Stop when no provider adapter is available, no local branches match the requested stack, or parent order cannot be inferred from PR bases, explicit order, or metadata.
 

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -42,6 +42,7 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 - Run `git status --porcelain` before rebases, pushes, PR creation, PR retargeting, merge, or cleanup.
 - Stop on a dirty worktree unless the user explicitly scopes the operation to inspection only.
 - Prefer existing PR `baseRefName` values over inferred ancestry.
+- Resolve `<base>` from the root PR's `baseRefName` (`gh pr view <root-pr> --json baseRefName --jq .baseRefName`), not from `origin/HEAD`; a stack's trunk need not be the repository's default branch.
 - Use explicit branch order or `.stack-prs.yaml` when parent inference is ambiguous.
 - Never use plain `git push --force`; use `git push --force-with-lease origin <branch>`.
 - Merge from root to leaf. Never merge a child before its parent.
@@ -194,7 +195,7 @@ Stop when a branch has no commits beyond its parent, an existing PR is closed an
 
 ### 3. Sync
 
-Rebase each stack branch onto its parent after `main` or any parent branch moves:
+Rebase each stack branch onto its parent after `<base>` or any parent branch moves:
 
 ```bash
 git status --porcelain
@@ -238,9 +239,9 @@ gh pr list --state open --json number,baseRefName,headRefName \
 gh pr merge <root-pr> --merge
 git fetch origin --prune
 git switch <child-branch>
-git rebase origin/main
+git rebase origin/<base>
 git push --force-with-lease origin <child-branch>
-gh pr edit <child-pr> --base main
+gh pr edit <child-pr> --base <base>
 ```
 
 If merge commits are allowed, use `gh pr merge <pr> --merge`. If the
@@ -258,10 +259,10 @@ On GitHub, do not pass `--delete-branch` while any open PR still has the branch 
 After the stack lands:
 
 ```bash
-git switch main
-git pull --ff-only origin main
+git switch <base>
+git pull --ff-only origin <base>
 git fetch --prune origin
-git branch --merged main
+git branch --merged <base>
 git branch -d <merged-stack-branch>
 ```
 
@@ -320,7 +321,7 @@ Do not publish if the leaf differs from the source branch.
 | Dirty worktree before mutation | Stop and report changed paths |
 | Ambiguous parent order | Request explicit branch order or `.stack-prs.yaml` |
 | Existing closed unmerged PR | Stop before creating replacements |
-| Closed unmerged child after parent branch deletion | Confirm the head branch and intended commit still exist, recreate the PR against `main` or the current merged parent, wait for checks, then continue |
+| Closed unmerged child after parent branch deletion | Confirm the head branch and intended commit still exist, recreate the PR against `<base>` or the current merged parent, wait for checks, then continue |
 | Rebase or cherry-pick conflict | Stop, report branch and conflicted files, do not continue children |
 | Remote branch changed since fetch | Stop; do not retry without a fresh inspect |
 | Failed validation | Record the failed command and stop merge or publish |
@@ -338,7 +339,7 @@ Use this only when a provider closed a child PR because its base branch was dele
 2. Confirm the closed PR's base branch was deleted by the parent merge or cleanup command.
 3. Confirm the child head branch still exists on `origin`.
 4. Confirm the child head commit is the intended stack slice.
-5. Recreate the PR against `main` or the current merged parent.
+5. Recreate the PR against `<base>` or the current merged parent.
 6. Wait for required checks on the recreated PR.
 7. Continue the root-to-leaf merge sequence.
 

--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -52,15 +52,18 @@ The package identity is provider-neutral. Git is the source of truth for branch 
 
 ## GitHub-native stack mode
 
-GitHub-native stacks are public preview, same-repository-only, and optional.
-They enhance manual Armory stacks; they do not replace provenance trailers,
+GitHub-native stacks are public preview and same-repository-only. They
+enhance manual Armory stacks; they do not replace provenance trailers,
 `.stack-prs.yaml`, or the provider-neutral workflow.
 
 Native-stack membership is a provider-side property of a pull request, not a
 mode this skill chooses. Detect it for every stack PR during Inspect, before
 any merge planning, whether or not `github-native` mode was requested.
 
-Use `github-native` mode only after this eligibility probe passes:
+### Creating native state (opt-in)
+
+Converting a manual stack to native with `gh stack link` is a mutation with
+public-preview risk. Use it only after this eligibility probe passes:
 
 1. GitHub CLI plus `gh stack --help` succeeds; install `github/gh-stack` when absent.
 2. Native stack support is enabled for the repository; native exit code 9 falls
@@ -69,11 +72,21 @@ Use `github-native` mode only after this eligibility probe passes:
    repository; reject forks and cross-repository stacks.
 4. Existing PR bases, local branch order, and `Stack-Id`/`Stack-Position`
    provenance agree. Stop on disagreement.
-5. Native merge is eligible only when trailers survive: use merge/rebase mode;
-   use manual Armory mode for squash-only repositories.
-6. The user explicitly requests native mode or accepts its public-preview risk.
+5. The user explicitly requests native mode or accepts its public-preview risk.
 
-When eligible:
+### Operating on an already-native stack (mandatory)
+
+Once Inspect finds a PR already native, native mode is not a choice for any
+operation that mutates that PR: the provider refuses a plain synchronous merge
+mutation (`gh pr merge`, and the underlying `mergePullRequest`/`PUT
+.../pulls/{n}/merge`) for a stack member with "must be merged using the
+asynchronous merge REST API." There is no manual Armory merge path for an
+already-native stack; do not present one as an alternative. Conditions 1-4
+above still apply as safety checks; condition 5's user consent does not — a
+stack the provider already registered as native carries no additional
+preview risk beyond what already exists.
+
+When eligible or already native:
 
 - Link existing branches or PRs bottom-to-top with
   `gh stack link --base <base> <branch-or-pr>...`.
@@ -90,9 +103,11 @@ When eligible:
 - Re-fetch and verify the remaining stack topology, CI, and provenance after
   GitHub's cascading rebase/retarget.
 
-Fall back to the manual workflow when the probe fails, the stack spans a fork,
-the GitHub preview surface is unavailable, or provider/trailer topology differs.
-Never silently switch modes mid-stack.
+Fall back to the manual workflow only when the stack is not yet native: the
+creation probe fails, the stack spans a fork, the preview surface is
+unavailable, or provider/trailer topology differs. Never silently switch
+modes mid-stack, and never attempt the manual merge path once Inspect has
+found the stack is already native.
 
 ## Workflow
 
@@ -190,6 +205,11 @@ uv run python scripts/evaluate_package.py --path skills/stacked-prs
 
 ### 5. Merge
 
+Before merging, confirm the Inspect native-stack probe reported `null` for
+this PR. A non-null result means the provider already treats this stack as
+native; `gh pr merge` will be rejected outright — switch to the GitHub-native
+stack mode merge path above instead of continuing here.
+
 Merge root to leaf:
 
 ```bash
@@ -284,6 +304,7 @@ Do not publish if the leaf differs from the source branch.
 | Top split branch differs from source | Stop before PR creation and report remaining diff |
 | Commit in stack range missing `Stack-Id` trailer | Stop; stamp via provenance backfill before merge |
 | Trailer `Stack-Id` differs from `.stack-prs.yaml` | Stop; resolve canonical ID before mutation |
+| PR is a detected native-stack member | Stop the manual merge path; use GitHub-native stack mode merge instead |
 | Squash-only repo without trailers folded into squash body | Stop; use the squash-body merge path |
 
 ## Recovery: Deleted Parent Branch Closed A Child PR

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -151,19 +151,22 @@ cases:
     fixtures: []
     rubric:
       - "activates stacked-prs"
-      - "detects provider merge policy before merge"
-      - "folds stack trailers into the squash commit body"
+      - "detects the repo's squash_merge_commit_message policy before merge, not just whether squash is allowed"
+      - "folds stack trailers into the squash commit body only when the policy is PR_BODY or BLANK"
     trigger_expected: true
     assertions:
       - type: matches_regex
         target: "gh api repos/\\{owner\\}/\\{repo\\}"
         weight: 0.8
       - type: matches_regex
-        target: "allow_squash_merge"
-        weight: 0.8
-      - type: matches_regex
-        target: "gh pr merge[\\s\\S]*--squash[\\s\\S]*--body[\\s\\S]*Stack-Id"
+        target: "squash_merge_commit_message"
         weight: 1.0
+      - type: matches_regex
+        target: "(COMMIT_MESSAGES|PR_BODY|BLANK)"
+        weight: 0.9
+      - type: matches_regex
+        target: "(PR_BODY|BLANK)[\\s\\S]*(--body|fold)"
+        weight: 0.9
 
   - id: backfill_existing_stack_trailers
     prompt: "Backfill Stack-Id trailers onto this existing unmerged stack and prove the leaf tree still matches the original source branch."
@@ -249,6 +252,31 @@ cases:
       - type: matches_regex
         target: "(fetch|re-fetch|topology|cascading)"
         weight: 0.8
+
+  - id: github_native_prefix_merge_squash
+    prompt: >
+      In a GitHub-native stack whose repo defaults squash_merge_commit_message
+      to COMMIT_MESSAGES, merge only the prefix through PR #42 with a squash
+      after every displayed layer is green.
+    fixtures: []
+    rubric:
+      - "checks squash_merge_commit_message before choosing squash as the merge method"
+      - "expects trailers to survive automatically under COMMIT_MESSAGES with no squash-body workaround"
+      - "does not attempt a --body override on gh stack merge"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh stack merge[\\s\\S]*42[\\s\\S]*--yes[\\s\\S]*--merge-method\\s+squash\\b"
+        weight: 1.0
+      - type: matches_regex
+        target: "squash_merge_commit_message"
+        weight: 0.9
+      - type: matches_regex
+        target: "(COMMIT_MESSAGES)[\\s\\S]*(automatic|survive)"
+        weight: 0.8
+      - type: not_contains
+        target: "gh stack merge[\\s\\S]*--body"
+        weight: 0.9
 
   - id: github_native_fork_fallback
     prompt: >

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -299,6 +299,27 @@ cases:
         target: "gh stack merge"
         weight: 1.0
 
+  - id: github_native_detection_forces_native_merge
+    prompt: >
+      Merge this stack. The Inspect probe already found that PR #193 reports a
+      non-null native stack.
+    fixtures: []
+    rubric:
+      - "treats a detected native stack as mandatory, not opt-in"
+      - "uses gh stack merge instead of gh pr merge for the detected stack"
+      - "does not offer the manual gh pr merge path as an alternative"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh stack merge"
+        weight: 1.0
+      - type: not_contains
+        target: "gh pr merge 193"
+        weight: 0.9
+      - type: matches_regex
+        target: "(mandatory|must|no opt-in|not a choice)"
+        weight: 0.8
+
   - id: native_stack_detected_during_inspect
     prompt: >
       Inspect this two-PR stack before planning anything else.

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -299,6 +299,26 @@ cases:
         target: "gh stack merge"
         weight: 1.0
 
+  - id: native_stack_detected_during_inspect
+    prompt: >
+      Inspect this two-PR stack before planning anything else.
+    fixtures: []
+    rubric:
+      - "probes native stack membership for every open stack PR during Inspect"
+      - "uses a non-mutating provider check rather than gh stack view"
+      - "records native status in the stack model output"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "gh api repos/\\{owner\\}/\\{repo\\}/pulls/"
+        weight: 1.0
+      - type: matches_regex
+        target: "\\.stack"
+        weight: 0.8
+      - type: not_contains
+        target: "gh stack view <"
+        weight: 0.8
+
   - id: negative_single_pr
     prompt: "Open a normal PR for my current branch against main."
     fixtures: []

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -368,6 +368,27 @@ cases:
         target: "gh stack view <"
         weight: 0.8
 
+  - id: squash_merged_local_branch_cleanup
+    prompt: >
+      The stack merged with --squash and git branch --merged origin/staging
+      lists nothing for the stack branches. Clean up the local branches.
+    fixtures: []
+    rubric:
+      - "recognizes git branch --merged is unreachable proof after a squash or rebase merge"
+      - "proves content equivalence instead before deleting"
+      - "deletes only after the equivalence proof passes"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "(git diff --quiet|git cherry)"
+        weight: 1.0
+      - type: matches_regex
+        target: "git branch -D"
+        weight: 0.8
+      - type: matches_regex
+        target: "(squash|rebase)[\\s\\S]*(ancestry|no ancestry|not list)"
+        weight: 0.8
+
   - id: stack_base_is_not_main
     prompt: >
       Merge this stack. Both PRs target staging, not main.

--- a/skills/stacked-prs/evals/cases.yaml
+++ b/skills/stacked-prs/evals/cases.yaml
@@ -368,6 +368,29 @@ cases:
         target: "gh stack view <"
         weight: 0.8
 
+  - id: stack_base_is_not_main
+    prompt: >
+      Merge this stack. Both PRs target staging, not main.
+    fixtures: []
+    rubric:
+      - "resolves the base branch from the root PR's baseRefName instead of assuming main"
+      - "uses the resolved base in every rebase, retarget, and cleanup command"
+      - "never hardcodes main when the stack's actual base is staging"
+    trigger_expected: true
+    assertions:
+      - type: matches_regex
+        target: "baseRefName"
+        weight: 0.9
+      - type: matches_regex
+        target: "staging"
+        weight: 0.9
+      - type: not_contains
+        target: "--base main"
+        weight: 1.0
+      - type: not_contains
+        target: "origin/main"
+        weight: 1.0
+
   - id: negative_single_pr
     prompt: "Open a normal PR for my current branch against main."
     fixtures: []

--- a/skills/stacked-prs/references/github-native.md
+++ b/skills/stacked-prs/references/github-native.md
@@ -135,6 +135,22 @@ Under `BLANK`, either change the repository's message policy before merging or
 use `--merge-method merge`/`rebase` for this merge; `--merge-method squash`
 gives up provenance with no recovery path.
 
+### Commit-title control under squash
+
+`gh stack merge` exposes only `--merge`, `--merge-method`, `--rebase`,
+`--squash`, `--yes` — no `--subject` or `--body`. With
+`squash_merge_commit_title: COMMIT_OR_PR_TITLE` (GitHub's default), a pull
+request that squashes a single commit takes that commit's headline as the
+base-branch commit subject, not the PR title. This cannot be corrected after
+merge without rewriting pushed base-branch history. Before merging, when the
+visible base-branch subject matters for a single-commit PR under
+`--merge-method squash`, align the commit headline with the PR title first:
+
+```bash
+git commit --amend -m "<pr-title>"
+git push --force-with-lease origin <branch>
+```
+
 ### Merge queues
 
 When the base uses a merge queue, stack members enter the queue together but can

--- a/skills/stacked-prs/references/github-native.md
+++ b/skills/stacked-prs/references/github-native.md
@@ -1,11 +1,28 @@
 # GitHub-native stacked pull requests
 
-GitHub-native stacked pull requests are public preview. Use them only as an
-optional GitHub adapter over Armory's existing provenance and manual workflow.
+GitHub-native stacked pull requests are public preview. Native-stack
+membership is a provider-side property of a pull request; detect it for every
+open stack PR during Inspect (`references/stack-model.md` § Native Stack
+Detection) before any merge planning.
 
-## Eligibility
+## Two distinct operations, two different opt-in rules
 
-Require all of the following before linking or merging natively:
+- **Creating native state** — `gh stack link` converts a manual stack (or
+  links loose PRs) into a native stack on GitHub. This is a mutation with
+  public-preview risk; it requires the eligibility probe below plus explicit
+  user consent.
+- **Operating on a stack Inspect already found to be native** — merging,
+  syncing, or otherwise mutating a PR the provider already registers as a
+  stack member. This is not a choice: the provider's synchronous merge
+  mutation (`gh pr merge`, the legacy `PUT .../pulls/{n}/merge`, and the
+  `mergePullRequest` GraphQL mutation) refuses any pull request that is part
+  of a stack with an explicit "must be merged using the asynchronous merge
+  REST API" error. There is no manual Armory merge path for an already-native
+  stack; do not present one as an alternative.
+
+## Eligibility (creating native state)
+
+Require all of the following before running `gh stack link`:
 
 1. GitHub CLI is version 2.0 or later and `gh stack --help` succeeds. Install
    the extension when absent: `gh extension install github/gh-stack`.
@@ -15,14 +32,34 @@ Require all of the following before linking or merging natively:
    as unavailable and fall back to manual mode.
 4. Armory branch order, PR base order, and `Stack-Id`/`Stack-Position` trailers
    agree with the proposed native order.
-5. The repository permits merge commits or rebase merges. A squash-only
-   repository may link natively but must use Armory's manual squash-body merge
-   path so trailers survive.
-6. The user explicitly selects `github-native` mode or accepts the preview risk.
+5. The user explicitly selects `github-native` mode or accepts the preview risk.
 
-Do not use native mode for cross-fork stacks, unavailable preview tooling,
-disabled repository support, squash-only merge, or topology mismatch. Report the
-reason and use manual Armory mode instead.
+Do not use native linking for cross-fork stacks, unavailable preview tooling,
+disabled repository support, or topology mismatch. Report the reason and use
+manual Armory mode instead.
+
+Condition 5 gates linking only. Once Inspect finds a PR already native (see
+below), skip condition 5 and proceed with native merge; conditions 1-4 remain
+in force as safety checks.
+
+## Detecting an already-native stack
+
+`gh stack view` is current-branch-only and takes no PR argument; it fails with
+`current branch "<branch>" is not part of a stack` from any other branch,
+including the stack's own base branch. Probe per PR instead, non-mutating:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number> --jq '.stack'
+```
+
+Returns `null` when the PR is not part of a native stack, or an object with
+`number`, `size`, `position`, and `base.ref` when it is. Run this for every
+open stack PR during Inspect, before merge planning.
+
+If the probe is unavailable for any reason, treat the merge-time
+`mergePullRequest`/`merge-async` "part of a stack" rejection as authoritative
+detection and switch to the native merge path below rather than reporting
+failure.
 
 ## Link and inspect
 
@@ -90,5 +127,9 @@ queue acceptance, then verify topology, CI, and provenance after every group.
 GitHub applies the bottom pull request's base-branch requirements across a
 native stack. Still inspect every displayed stack layer as green before a merge.
 
-Manual Armory mode remains mandatory for every ineligible stack and retains its
-root-to-leaf merge, explicit rebase/retarget, and trailer-preservation rules.
+Manual Armory mode remains mandatory for a stack Inspect has NOT already found
+native: an ineligible creation probe, a cross-fork stack, unavailable preview
+tooling, or topology mismatch. It retains its root-to-leaf merge, explicit
+rebase/retarget, and trailer-preservation rules. Manual mode is not available
+once Inspect finds a stack already native — see "Two distinct operations"
+above.

--- a/skills/stacked-prs/references/github-native.md
+++ b/skills/stacked-prs/references/github-native.md
@@ -115,6 +115,26 @@ Never infer a prefix. Require the exact highest pull request number. GitHub
 applies branch protection at merge time. After completion, re-fetch, verify
 stack topology/CI/provenance, and clean only confirmed merged branches.
 
+### Choosing a merge method for trailer survival
+
+Key the method choice on the repository's squash message policy, not on
+whether squash is merely one of the allowed methods:
+
+```bash
+gh api repos/{owner}/{repo} \
+  --jq '{title: .squash_merge_commit_title, message: .squash_merge_commit_message}'
+```
+
+| `squash_merge_commit_message` | Trailers under `--merge-method squash` |
+| --- | --- |
+| `COMMIT_MESSAGES` (GitHub default) | Survive automatically, once per squashed commit |
+| `PR_BODY` | Survive only if every PR body already carries them |
+| `BLANK` | Always lost; `gh stack merge` has no `--subject`/`--body` override |
+
+Under `BLANK`, either change the repository's message policy before merging or
+use `--merge-method merge`/`rebase` for this merge; `--merge-method squash`
+gives up provenance with no recovery path.
+
 ### Merge queues
 
 When the base uses a merge queue, stack members enter the queue together but can

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -9,7 +9,7 @@ Stacked PRs land bottom-up from the base perspective: merge the root PR first, t
 - After each merge, fetch, rebase the next child onto the updated base, push with lease, and retarget the child PR.
 - Do not delete a branch while any open PR still has that branch as its base.
 - Delete remote stack branches only during final cleanup after descendants are merged or retargeted.
-- Delete local branches only when `git branch --merged <base>` proves they are merged.
+- Delete local branches only after merge-mode-appropriate proof: `git branch --merged <base>` for a merge-commit landing, or content equivalence (`git diff --quiet origin/<base> <branch>` or `git cherry <base> <branch>` with no `+` lines) for a squash or rebase landing.
 
 ## Root Merge
 
@@ -44,9 +44,30 @@ Then validate and merge that child.
 git switch <base>
 git pull --ff-only origin <base>
 git fetch --prune origin
+```
+
+Delete local branches with merge-mode-appropriate proof. For a `--merge`
+(merge-commit) landing, ancestry survives:
+
+```bash
 git branch --merged <base>
 git branch -d <merged-stack-branch>
 ```
+
+For a `--squash` or `--rebase` landing, the landed commit has no ancestry link
+to the local branch: `git branch --merged <base>` never lists it and `git
+branch -d` always refuses. Prove content equivalence instead:
+
+```bash
+git diff --quiet origin/<base> <merged-stack-branch>
+git branch -D <merged-stack-branch>
+```
+
+A stale local branch predating a remote rebase can show diffs in files it
+never touched; read `git diff --stat` for additions unique to the branch, not
+merely for nonzero output, before trusting the comparison. When in doubt, use
+`git cherry <base> <merged-stack-branch>` instead: no `+`-prefixed lines means
+every commit already landed, and `-D` is safe.
 
 Before deleting any remote stack branch, verify no open PR still targets it:
 
@@ -56,7 +77,7 @@ gh pr list --state open --json number,baseRefName,headRefName \
 git push origin --delete <merged-stack-branch>
 ```
 
-Never use `git branch -D` for stack cleanup unless the user explicitly asks to delete an unmerged branch after reviewing the risk.
+`git branch -D` for stack cleanup requires either a passed merge-mode-appropriate equivalence proof (Cleanup, above) or the user explicitly asking to delete an unmerged branch after reviewing the risk. Never use it on unproven say-so.
 
 ## Recovery: Deleted Parent Branch Closed A Child PR
 
@@ -78,7 +99,7 @@ Use this path only for the specific provider failure where a child PR was closed
 - Squash message policy is `PR_BODY` or `BLANK` and stack trailers are not present in the squash body or PR body.
 - Provider reports branch protection failure.
 - Rebase conflict occurs after parent merge.
-- Local branch is not listed by `git branch --merged <base>`.
+- Local branch fails its merge-mode-appropriate proof: not listed by `git branch --merged <base>` under a merge-commit landing, or shows unmerged (`+`) commits under `git cherry <base> <branch>` (or a nonzero `git diff` against `<base>`) under a squash or rebase landing.
 - A closed unmerged child PR cannot be traced to deleted-base recovery.
 
 Report the stopped branch and next safe command.

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -31,9 +31,9 @@ If the child-base guard returns any PRs, keep the parent branch. On GitHub, dele
 
 ```bash
 git switch <child-branch>
-git rebase origin/main
+git rebase origin/<base>
 git push --force-with-lease origin <child-branch>
-gh pr edit <child-pr> --base main
+gh pr edit <child-pr> --base <base>
 ```
 
 Then validate and merge that child.
@@ -41,10 +41,10 @@ Then validate and merge that child.
 ## Cleanup
 
 ```bash
-git switch main
-git pull --ff-only origin main
+git switch <base>
+git pull --ff-only origin <base>
 git fetch --prune origin
-git branch --merged main
+git branch --merged <base>
 git branch -d <merged-stack-branch>
 ```
 
@@ -66,7 +66,7 @@ Use this path only for the specific provider failure where a child PR was closed
 2. Confirm the deleted branch was the closed PR's `baseRefName`.
 3. Confirm the child `headRefName` still exists on `origin`.
 4. Confirm the child head commit is still the intended stack slice.
-5. Recreate the PR against `main` or the current merged parent.
+5. Recreate the PR against `<base>` or the current merged parent.
 6. Wait for required provider checks on the recreated PR.
 7. Continue root-to-leaf merging.
 

--- a/skills/stacked-prs/references/merge-discipline.md
+++ b/skills/stacked-prs/references/merge-discipline.md
@@ -23,7 +23,7 @@ gh pr merge <root-pr> --merge
 git fetch origin --prune
 ```
 
-Verify `Stack-Id` and `Stack-Position` trailers before each merge. Prefer `gh pr merge <pr> --merge` when merge commits are allowed. If the repository is squash-only, use the squash-body path from `references/provenance.md`; do not merge until the trailers are folded into the squash commit body.
+Verify `Stack-Id` and `Stack-Position` trailers before each merge. Prefer `gh pr merge <pr> --merge` when merge commits are allowed. If the repository squashes and `squash_merge_commit_message` is `PR_BODY` or `BLANK`, use the squash-body path from `references/provenance.md`; do not merge until the trailers are present. Under `COMMIT_MESSAGES` (GitHub's default), squash already preserves trailers automatically.
 
 If the child-base guard returns any PRs, keep the parent branch. On GitHub, deleting a branch that is still a child PR base can close the child PR unmerged.
 
@@ -75,7 +75,7 @@ Use this path only for the specific provider failure where a child PR was closed
 - Parent PR is not merged.
 - Required checks are failing or pending.
 - A stack commit is missing `Stack-Id` or has a `Stack-Id` that differs from `.stack-prs.yaml`.
-- The repository is squash-only and the squash body does not include stack trailers.
+- Squash message policy is `PR_BODY` or `BLANK` and stack trailers are not present in the squash body or PR body.
 - Provider reports branch protection failure.
 - Rebase conflict occurs after parent merge.
 - Local branch is not listed by `git branch --merged <base>`.

--- a/skills/stacked-prs/references/provenance.md
+++ b/skills/stacked-prs/references/provenance.md
@@ -80,17 +80,36 @@ git log --grep 'Stack-Id: <stack-id>' \
 
 ## Merge Mode Coupling
 
-Trailer survival depends on merge mode:
+Trailer survival depends on merge mode and, for squash, on the repository's
+squash message policy — not on a blanket "squash discards messages"
+assumption.
 
 | Merge mode | Commit messages | Trailers survive |
 | --- | --- | --- |
 | `gh pr merge --merge` | Original commits preserved | Yes, automatically |
 | `gh pr merge --rebase` | Original commits replayed | Yes, automatically |
-| `gh pr merge --squash` | Messages collapsed and rewritten | No, unless folded into squash body |
+| `gh pr merge --squash`, policy `COMMIT_MESSAGES` (GitHub default) | Every squashed commit's full message concatenated | Yes, automatically, once per squashed commit |
+| `gh pr merge --squash`, policy `PR_BODY` | PR body only | Only if the PR body carries the trailers |
+| `gh pr merge --squash`, policy `BLANK` | Discarded | No; fold trailers in with `--body` |
 
-The documented merge path uses `--merge`, so trailers survive as-is. If a
-target repo enforces squash merges, inject the trailers into the squash commit
-body because GitHub's squash default discards per-commit messages:
+Detect the repo's squash message policy before merging, not merely whether
+squash is allowed:
+
+```bash
+gh api repos/{owner}/{repo} \
+  --jq '{title: .squash_merge_commit_title, message: .squash_merge_commit_message}'
+```
+
+- `COMMIT_MESSAGES` (GitHub's default): trailers survive automatically. No
+  `--body` override needed.
+- `PR_BODY`: trailers survive only if the PR body includes them; use the
+  squash-body path below.
+- `BLANK`: trailers are always discarded; use the squash-body path below or
+  switch to `--merge`/`--rebase`.
+
+The documented merge path uses `--merge`, so trailers survive as-is by
+default. When the target repository squashes and `squash_merge_commit_message`
+is `PR_BODY` or `BLANK`, inject the trailers into the squash commit body:
 
 ```bash
 gh pr merge <pr> --squash \
@@ -101,11 +120,19 @@ gh pr merge <pr> --squash \
     'Stack-Position: <n>/<total>')"
 ```
 
-Detect the repo's merge policy before merging:
+For a GitHub-native stack merged with `gh stack merge`, no `--subject`/`--body`
+override exists (`references/github-native.md` § Merge). Under
+`COMMIT_MESSAGES` this is safe by default; under `PR_BODY` or `BLANK`, fold
+the trailers into each PR body before merging so the squash captures them, or
+use `--merge-method merge`/`rebase` instead of squash.
+
+Detect the repo's overall merge policy (which methods are allowed) separately,
+to choose a method at all:
 
 ```bash
 gh api repos/{owner}/{repo} \
   --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
 ```
 
-If only squash is allowed, take the squash-body path. Otherwise prefer `--merge`.
+If only squash is allowed, take the squash-body path (or confirm
+`COMMIT_MESSAGES`). Otherwise prefer `--merge`.

--- a/skills/stacked-prs/references/provider-adapters.md
+++ b/skills/stacked-prs/references/provider-adapters.md
@@ -68,7 +68,7 @@ gh api repos/{owner}/{repo} \
 gh pr merge <number> --merge
 ```
 
-Prefer `--merge` when merge commits are allowed. If the repository is squash-only, use the squash-body merge path in `references/provenance.md` so `Stack-Id` and `Stack-Position` survive in history.
+Prefer `--merge` when merge commits are allowed. If the repository squashes and `squash_merge_commit_message` is `PR_BODY` or `BLANK` (`gh api repos/{owner}/{repo} --jq '.squash_merge_commit_message'`), use the squash-body merge path in `references/provenance.md` so `Stack-Id` and `Stack-Position` survive in history. Under `COMMIT_MESSAGES` (GitHub's default), squash already preserves trailers automatically.
 
 Do not use `--delete-branch` while any open PR still has the branch being merged as `baseRefName`. For GitHub stacks, branch deletion can close descendant PRs unmerged when their base branch disappears.
 

--- a/skills/stacked-prs/references/stack-model.md
+++ b/skills/stacked-prs/references/stack-model.md
@@ -38,6 +38,32 @@ git merge-base <branch> <candidate-parent>
 git log --oneline <candidate-parent>..<branch>
 ```
 
+## Native Stack Detection
+
+Run for every open stack PR during Inspect, before any merge planning,
+whether or not `github-native` mode was requested. A pull request the
+provider already registers as a GitHub-native stack member rejects a plain
+synchronous merge mutation outright; detection must happen here, not as a
+merge-time failure.
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number> --jq '.stack'
+```
+
+A plain `GET`; it mutates nothing and is safe to run for every open PR.
+Returns `null` when the PR is not part of a native stack, or an object with
+`number` (stack number), `size`, `position`, and `base.ref` when it is.
+
+Do not use `gh stack view` for detection: it reads only the branch currently
+checked out and takes no PR argument, so it fails with `current branch
+"<branch>" is not part of a stack` when run from any other branch, including
+the stack's own base branch.
+
+If the probe cannot run, treat a later `mergePullRequest`/`merge-async`
+rejection ("must be merged using the asynchronous merge REST API") as
+authoritative detection and switch to `references/github-native.md` § Merge
+rather than reporting failure.
+
 ## Required Model
 
 Represent each stack entry with:
@@ -51,6 +77,7 @@ Represent each stack entry with:
 | `pr_state` | Provider state |
 | `url` | Provider PR URL |
 | `checks` | Latest known validation or provider check state |
+| `native` | `true`/`false`/`unknown` from the Native Stack Detection probe |
 
 ## Stop Conditions
 

--- a/skills/stacked-prs/references/sync-algorithm.md
+++ b/skills/stacked-prs/references/sync-algorithm.md
@@ -31,14 +31,14 @@ Use the local parent branch after rebasing it. Do not rebase children onto stale
 
 ## Retargeting After Parent Merge
 
-When a parent lands into `main`, the child must be rebased onto `origin/main` and its PR base retargeted to `main`:
+When a parent lands into `<base>`, the child must be rebased onto `origin/<base>` and its PR base retargeted to `<base>`:
 
 ```bash
 git fetch origin --prune
 git switch <child-branch>
-git rebase origin/main
+git rebase origin/<base>
 git push --force-with-lease origin <child-branch>
-gh pr edit <child-pr> --base main
+gh pr edit <child-pr> --base <base>
 ```
 
 Then repeat for the next child.


### PR DESCRIPTION
## Summary

A real two-PR stack merge (`Retailogists/orca-shopify`, 2026-08-28, `staging` base) surfaced six defects in the `stacked-prs` skill's GitHub-native handling. The skill's *documented* merge path was rejected outright by GitHub — `gh pr merge --squash` failed with `This pull request is part of a stack and must be merged using the asynchronous merge REST API` — and recovering manually surfaced five more. All six were verified against GitHub's public-preview docs (`docs.github.com/en/pull-requests/reference/stacked-pull-requests-*`, `stacked-prs-cli-commands`, the REST schema for `GET /pulls/{n}`, and the GraphQL `PullRequest.stack`/`stackEntry` fields) before being fixed — none were accepted on the strength of the incident report alone.

Bumps `stacked-prs` `0.2.0` → `0.3.0`. Deployed copy at `~/.claude/skills/stacked-prs` (symlinked to `~/.agents/skills/stacked-prs`) already synced locally; unrelated to this PR's merge.

## Defects fixed

### D1 — Inspect had no native-stack detection (`feat` commit)
`gh stack view` is current-branch-only and takes no PR argument — it fails with `current branch "<branch>" is not part of a stack` from any branch but the one checked out, including the stack's own base. The skill only discovered a stack was native when the merge mutation was rejected. Added a non-mutating probe confirmed against the REST schema — `GET /repos/{owner}/{repo}/pulls/{n}` documents a `stack` field, `null` when the PR isn't a member — as a mandatory Inspect step (`stack-model.md` § Native Stack Detection, new `native` column in the stack model table and SKILL.md's Inspect output).

### D2 — eligibility condition inverted the default (`fix` commit)
`github-native.md`'s condition 6 made user consent gate *all* native operations, including merging a stack GitHub already treats as native — which is not optional (`mergePullRequest`/legacy sync merge is refused outright for any stack member; confirmed against `stacked-pull-requests-apis-and-webhooks`). Split eligibility into two operations with different opt-in rules: **creating** native state (`gh stack link`) stays opt-in; **operating on** a stack Inspect already found native is mandatory once safety conditions 1-4 hold, with no consent gate and no manual fallback.

### D3 — merge-mode trailer table was factually wrong (`fix` commit)
`provenance.md` claimed squash "discards" commit messages unless folded into the squash body, and `github-native.md` keyed the manual/squash-body decision on whether a repo is "squash-only." Both wrong: GitHub's REST schema documents `squash_merge_commit_message` as `COMMIT_MESSAGES | PR_BODY | BLANK`, and `COMMIT_MESSAGES` (the observed default) concatenates every squashed commit's *full* message, trailers included — confirmed on the real merge, where a `Stack-Id` trailer survived a native squash across four commits with no squash-body path and no `--body` flag. Replaced the blanket claim everywhere it appeared (`provenance.md`, `provider-adapters.md`, `merge-discipline.md`, `SKILL.md`, `github-native.md`) with a policy check keyed on the chosen merge method + `squash_merge_commit_message`.

### D4 — local-branch deletion proof was unreachable after squash (`fix` commit)
`merge-discipline.md` required `git branch --merged <base>` to prove a branch was safe to delete, while separately requiring explicit user consent for any `-D`. A squash/rebase merge creates a commit with no ancestry link to the local branch, so `--merged` never lists it and `-d` always refuses — an unreachable combination for the common squash case (reproduced on the real merge: `-D` was used only after proving content equivalence by hand). Added a merge-mode-aware proof: `git branch --merged <base>` for merge-commit landings, `git diff --quiet origin/<base> <branch>` / `git cherry <base> <branch>` for squash/rebase landings, sanctioning `-D` once it passes.

### D5 — `main` was hardcoded (`fix` commit)
`SKILL.md`, `merge-discipline.md`, and `sync-algorithm.md` hardcoded literal `main` in rebase/retarget/cleanup commands (`git rebase origin/main`, `gh pr edit --base main`, `git branch --merged main`, etc.). The real stack's base was `staging`; following these literally would have retargeted a child PR to the wrong branch. Parameterized every occurrence as `<base>`, resolved from the root PR's `baseRefName` rather than `origin/HEAD` (a stack's trunk need not be the repo's default branch). `sync-algorithm.md`'s identical bug wasn't named in the original incident report but was caught and fixed for consistency.

### D6 — no guidance on the commit-message control `gh stack merge` gives up (`fix` commit)
`gh stack merge` exposes only `--merge`, `--merge-method`, `--rebase`, `--squash`, `--yes` — confirmed against the CLI reference, no `--subject`/`--body`. Under `squash_merge_commit_title: COMMIT_OR_PR_TITLE` (GitHub's default), a PR squashing a single commit takes that commit's headline, not the PR title, on the base branch — reproduced on the real merge (PR titled "add the Orders Backlog Details report..." landed as "list the dashboards and give each one its own page (#195)", its commit headline). Documented the trap and the pre-merge workaround (amend the commit headline before merging, since it can't be fixed after without rewriting pushed history).

## Evals

17 → 22 cases in `evals/cases.yaml`:
- Rewrote `squash_only_merge_preserves_stack_id` off the D3 false premise (was asserting an impossible unconditional `--squash --body Stack-Id` command).
- Added `github_native_prefix_merge_squash` — squash variant of the native prefix-merge case, asserting trailers survive under `COMMIT_MESSAGES` with no `--body` override.
- Added `github_native_detection_forces_native_merge` — the missing inverse of the existing unavailable-fallback case: native detected → native path is mandatory, manual `gh pr merge` must not be attempted.
- Added `native_stack_detected_during_inspect` (D1), `squash_merged_local_branch_cleanup` (D4), `stack_base_is_not_main` (D5).

## Verification

```
uv run python scripts/validate_evals.py     → pass (82 skills validated)
uv run python scripts/generate_manifest.py  → clean diff, stacked-prs 0.2.0 → 0.3.0 only
uv run python scripts/evaluate_package.py --path skills/stacked-prs → static conformance PASS
```

Code-fence balance and YAML parse checked clean on every touched file at every commit in the series (each intermediate commit was reconstructed and independently verified, not just the final tree).

## Commits

1. `feat(stacked-prs): detect GitHub-native stack membership during Inspect` — D1
2. `fix(stacked-prs): require GitHub-native merge once Inspect detects it` — D2
3. `fix(stacked-prs): key squash trailer survival on message policy` — D3
4. `fix(stacked-prs): document gh stack merge's missing commit-subject override` — D6
5. `fix(stacked-prs): resolve stack base from baseRefName, not hardcoded main` — D5
6. `fix(stacked-prs): make squash/rebase-merged branch cleanup provable` — D4
7. `chore(stacked-prs): bump to 0.3.0 and regenerate manifest`

## Files touched

- `skills/stacked-prs/SKILL.md`
- `skills/stacked-prs/evals/cases.yaml`
- `skills/stacked-prs/references/github-native.md`
- `skills/stacked-prs/references/merge-discipline.md`
- `skills/stacked-prs/references/provenance.md`
- `skills/stacked-prs/references/provider-adapters.md`
- `skills/stacked-prs/references/stack-model.md`
- `skills/stacked-prs/references/sync-algorithm.md`
- `manifest.yaml`
