### PR TITLE
feat(architecture-diagram): report findings as coded diagnostics

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -49,7 +49,7 @@ packages:
     difficulty: intermediate
     phase: ship
   - name: architecture-diagram
-    version: 2.0.0
+    version: 2.1.0
     description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams,
       or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead
       of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram",

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -2,7 +2,7 @@
 name: architecture-diagram
 description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams, or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram", "topology diagram", "draw architecture", "AWS diagram", "Azure diagram", "GCP diagram", "cloud infrastructure diagram", "VPC diagram", "draw my AWS setup". Use when a user wants a static architecture diagram they can still edit afterward in Figma, Illustrator, or Inkscape. NOT for architecture reviews, use architecture-reviewer.'
 metadata:
-  version: 2.0.0
+  version: 2.1.0
   category: visualization
   tags: [architecture, diagram, svg, aws, azure, gcp, cloud, icons]
   difficulty: intermediate
@@ -51,9 +51,8 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
    ```bash
    python3 scripts/render.py spec.yaml -o diagram.svg
    ```
-   Read every line printed to stderr. `error:` lines mean the spec is invalid (fix and rerun). `warning:` lines mean the diagram rendered but something needs attention — a missing icon, an overflowing label, overlapping zones. Fix the spec's node/zone data, not the SVG output directly.
-6. **Verify before handing off** — see Verification below. Do not skip this step; a diagram with unresolved warnings looks unprofessional even though the file is technically valid SVG.
-7. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
+   Act on the exit code, not on prose — see Exit codes below. Every finding names a spec field to change; never repair one by editing the SVG.
+6. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
 
 ## Spec fields at a glance
 
@@ -196,34 +195,33 @@ edges:
 - Use `provider: generic` and the hand-drawn icon set when no cloud provider is specified or the architecture is vendor-neutral.
 - Ask for clarification only when the component list or topology is fundamentally unclear — never when a single icon is missing (fall back per Unsupported above).
 
-## Troubleshooting
+## Exit codes and diagnostics
 
-| Problem | Cause | Fix |
+Every finding is a coded diagnostic carrying `code`, `severity`, `message`, `subject` (what it is about), `evidence` (the numbers that locate it), `supported_fixes` (spec-level moves), and sometimes `suppresses`. The exit code is the verdict:
+
+| Exit | Meaning | Action |
 |---|---|---|
-| `error: could not fetch <provider> icons` | No network on first use, or a transient GitHub/CDN timeout | Rerun `fetch_icons.py` for that provider — it retries individual file fetches automatically; a full retry from scratch is cheap since already-cached icons are skipped |
-| `warning: no icon for node 'x'` | The `service` slug doesn't exist in that provider's cache, or the icon cache for that provider was never fetched | Check `references/services-aws.yaml` (or the `-azure`/`-gcp` equivalent) for the exact slug; run `fetch_icons.py --provider aws` (or `azure`/`gcp`) if the cache is cold |
-| `warning: zone overlap` | Two zones' member nodes are interleaved in rank/order so their bounding boxes collide | Reorder the spec's `nodes` list so each zone's members are listed together, or check the zone assignments are correct |
-| `warning: label may overflow its node box` | A node or edge label is too long for the fixed-width node box | Shorten the label, or move detail into `sublabel` |
-| Diagram looks fine locally but breaks when reopened elsewhere | Should not happen — `render.py` never emits `<image>`, `<use>`, or external `href`s (enforced by `check_editability`, run automatically on every render) | If this happens anyway, file it as a bug — it means the invariant broke |
-| Icons render as plain colored squares with an initial letter, no glyph | The node has no `service` set, or the slug wasn't found — this is the deliberate fallback, not a crash | Add the correct `service` slug from the provider's reference table |
+| 0 | No error-severity findings | Hand off the SVG; any warnings are deliberate, explainable tradeoffs |
+| 1 | A blocking finding, or a spec the renderer cannot answer | Apply one of the finding's `supported_fixes` to the spec and rerun |
+| 2 | Usage error — unreadable spec path, unknown flag or profile value | Correct the command |
 
-## Verification
+`--json` prints the whole envelope (`schema_version`, `ok`, `quality`, `output`, `written`, `artifact_bytes`, `counts`, `diagnostics`) to stdout and nothing else. `--quality showcase` raises `composition/*` route-geometry findings to errors; the default `standard` keeps them as warnings.
 
-Before handing a diagram to the user, confirm:
+| Code | Meaning | Fix |
+|---|---|---|
+| `spec/*` | The spec is unanswerable: no nodes, duplicate or missing ids, unknown zone/parent/edge endpoint, zone cycle, empty zone | Each diagnostic's `supported_fixes` names the field to change |
+| `icon/not-found` | The `service` slug is absent from that provider's cache, or the cache was never fetched | Use the exact slug from that provider's reference service map, or run `fetch_icons.py --provider <name>`; drop `service` to take the labeled placeholder deliberately |
+| `layout/node-overlap` | Two node boxes collide | Separate the nodes across ranks, or remove the duplicate |
+| `layout/zone-overlap` | Two unrelated zone boxes collide because their member nodes are interleaved | List each zone's members contiguously in `nodes`, or fix the `zone` assignments |
+| `layout/label-overflow` | A `label` or `sublabel` is wider than its node box (warning) | Shorten it, or move detail into `sublabel` |
+| `editability/*` | The output contains raster, `<use>`, or an external reference | Renderer bug — a spec cannot cause this; report it |
+| `usage/spec-unreadable` | The spec path does not exist or cannot be read | Pass an existing, readable YAML path |
 
-- [ ] `render.py` exited 0 (a nonzero exit means an editability violation slipped through — treat as a bug, not something to work around)
-- [ ] Every `warning:` line printed to stderr has been addressed or is a deliberate, explainable tradeoff (e.g. "no icon exists for this service, using a placeholder")
-- [ ] Zone containment matches the described architecture (open the SVG or render it to PNG and look — `rsvg-convert diagram.svg -o /tmp/check.png`)
-- [ ] Every node the user asked for is present and labeled
-- [ ] Connection types match the described data flows, and the legend appears only when more than one type is used
+A fetch failure (`could not fetch <provider> icons`) is a network problem, not a spec problem: rerun `fetch_icons.py` for that provider, which skips already-cached icons.
 
 ## Output
 
-Write the final SVG to the working directory (or the user-specified path) and report:
-
-- The output path
-- Any warnings that were left unresolved and why
-- Whether this was the first render for a given provider (mention the icon-cache fetch cost only once, not on every subsequent render)
+Report the output path, any warning-severity findings left unresolved and why, and — only on the first render for a given provider — the icon-cache fetch cost.
 
 ## Reference table
 

--- a/skills/architecture-diagram/evals/cases.yaml
+++ b/skills/architecture-diagram/evals/cases.yaml
@@ -7,6 +7,7 @@ cases:
       - "Output includes real <text> labels for every component, not outlined paths"
       - "Output includes connection lines or arrows between components"
       - "Output does not use raster images or <use> clones for icons"
+      - "Reports the render's exit status, and resolves any reported finding by changing the spec rather than editing the SVG"
     trigger_expected: true
     assertions:
       - type: matches_regex
@@ -35,6 +36,7 @@ cases:
       - "Output shows containment hierarchy (e.g., VPC zone containing service nodes)"
       - "Output uses AWS-native icon geometry, not generic placeholder icons"
       - "Output is valid, self-contained SVG"
+      - "If an icon lookup fails, warms the provider cache or corrects the service slug instead of shipping the placeholder silently"
     trigger_expected: true
     assertions:
       - type: matches_regex

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -73,6 +73,112 @@ def _escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+# --- diagnostics -------------------------------------------------------------
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+_SEVERITIES = (SEVERITY_ERROR, SEVERITY_WARNING)
+
+QUALITY_STANDARD = "standard"
+QUALITY_SHOWCASE = "showcase"
+QUALITY_PROFILES = (QUALITY_STANDARD, QUALITY_SHOWCASE)
+
+# Codes in this namespace describe how the drawing reads rather than whether
+# the spec is answerable: two routes crossing, a label sitting on a route.
+# They are warnings under the standard profile and errors under showcase, so
+# stricter geometry rules can ship without breaking specs that already render.
+PROFILE_SENSITIVE_NAMESPACE = "composition/"
+
+DIAGNOSTIC_SCHEMA_VERSION = 1
+
+
+@dataclass
+class Diagnostic:
+    """One machine-readable finding.
+
+    The predecessor of this type was `list[str]` of English prose printed to
+    stderr, which forced the calling agent to regex sentences and left it to
+    invent its own repair — usually by editing the SVG, which is exactly the
+    move that destroys the reproducibility this renderer exists to provide.
+    `code` is the stable identity, `subject` says what the finding is about,
+    `evidence` carries the numbers needed to locate it, and
+    `supported_fixes` bounds the repair to changes an author can make in the
+    spec.
+    """
+
+    code: str
+    severity: str
+    message: str
+    subject: dict[str, object] = field(default_factory=dict)
+    evidence: dict[str, object] = field(default_factory=dict)
+    supported_fixes: tuple[str, ...] = ()
+    # Codes this finding makes redundant. A derived diagnostic reported
+    # alongside its cause sends the agent chasing symptoms.
+    suppresses: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.severity not in _SEVERITIES:
+            raise ValueError(
+                f"diagnostic {self.code!r} has unknown severity {self.severity!r}; "
+                f"expected one of {_SEVERITIES}"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "subject": dict(self.subject),
+            "evidence": dict(self.evidence),
+            "supported_fixes": list(self.supported_fixes),
+        }
+        if self.suppresses:
+            payload["suppresses"] = list(self.suppresses)
+        return payload
+
+
+def apply_quality_profile(
+    diagnostics: list[Diagnostic], quality: str
+) -> list[Diagnostic]:
+    """Raise profile-sensitive findings to errors under the showcase profile."""
+    if quality not in QUALITY_PROFILES:
+        raise ValueError(f"unknown quality profile {quality!r}; expected one of {QUALITY_PROFILES}")
+    if quality != QUALITY_SHOWCASE:
+        return list(diagnostics)
+    out = []
+    for d in diagnostics:
+        if d.code.startswith(PROFILE_SENSITIVE_NAMESPACE) and d.severity != SEVERITY_ERROR:
+            out.append(
+                Diagnostic(
+                    code=d.code,
+                    severity=SEVERITY_ERROR,
+                    message=d.message,
+                    subject=d.subject,
+                    evidence=d.evidence,
+                    supported_fixes=d.supported_fixes,
+                    suppresses=d.suppresses,
+                )
+            )
+        else:
+            out.append(d)
+    return out
+
+
+def suppress_derived(diagnostics: list[Diagnostic]) -> list[Diagnostic]:
+    """Drop findings whose cause is already reported."""
+    suppressed: set[str] = set()
+    for d in diagnostics:
+        suppressed.update(d.suppresses)
+    return [d for d in diagnostics if d.code not in suppressed]
+
+
+def count_by_severity(diagnostics: list[Diagnostic]) -> dict[str, int]:
+    return {
+        "errors": sum(1 for d in diagnostics if d.severity == SEVERITY_ERROR),
+        "warnings": sum(1 for d in diagnostics if d.severity == SEVERITY_WARNING),
+    }
+
+
 # --- spec -------------------------------------------------------------------
 
 
@@ -113,22 +219,67 @@ class Spec:
 
 
 class SpecError(ValueError):
-    pass
+    """A spec the renderer cannot answer.
+
+    Carries the `Diagnostic` so callers get the same coded record they get
+    for every other finding; the exception message stays human-readable for
+    tracebacks.
+    """
+
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        super().__init__(diagnostic.message)
+        self.diagnostic = diagnostic
+
+
+def _spec_error(
+    code: str,
+    message: str,
+    subject: dict[str, object] | None = None,
+    evidence: dict[str, object] | None = None,
+    supported_fixes: tuple[str, ...] = (),
+) -> SpecError:
+    return SpecError(
+        Diagnostic(
+            code=code,
+            severity=SEVERITY_ERROR,
+            message=message,
+            subject=subject or {},
+            evidence=evidence or {},
+            supported_fixes=supported_fixes,
+        )
+    )
 
 
 def load_spec(text: str) -> Spec:
     data = yaml.safe_load(text) or {}
     if "nodes" not in data or not data["nodes"]:
-        raise SpecError("spec has no nodes")
+        raise _spec_error(
+            "spec/no-nodes",
+            "spec has no nodes",
+            supported_fixes=("add at least one entry under `nodes`",),
+        )
 
     provider = data.get("provider", "generic")
     node_ids = set()
     nodes = []
     for raw in data["nodes"]:
         if "id" not in raw:
-            raise SpecError(f"node missing id: {raw}")
+            raise _spec_error(
+                "spec/node-missing-id",
+                f"node missing id: {raw}",
+                evidence={"node": raw},
+                supported_fixes=("give the node a unique `id`",),
+            )
         if raw["id"] in node_ids:
-            raise SpecError(f"duplicate node id: {raw['id']}")
+            raise _spec_error(
+                "spec/duplicate-node-id",
+                f"duplicate node id: {raw['id']}",
+                subject={"node": raw["id"]},
+                supported_fixes=(
+                    "rename one of the nodes so every `id` is unique",
+                    "delete the duplicate node entry",
+                ),
+            )
         node_ids.add(raw["id"])
         nodes.append(
             Node(
@@ -146,7 +297,12 @@ def load_spec(text: str) -> Spec:
     zones = []
     for raw in data.get("zones", []) or []:
         if "id" not in raw:
-            raise SpecError(f"zone missing id: {raw}")
+            raise _spec_error(
+                "spec/zone-missing-id",
+                f"zone missing id: {raw}",
+                evidence={"zone": raw},
+                supported_fixes=("give the zone a unique `id`",),
+            )
         zone_ids.add(raw["id"])
         zones.append(
             Zone(
@@ -157,17 +313,53 @@ def load_spec(text: str) -> Spec:
         )
     for n in nodes:
         if n.zone is not None and n.zone not in zone_ids:
-            raise SpecError(f"node {n.id!r} references unknown zone {n.zone!r}")
+            raise _spec_error(
+                "spec/unknown-zone",
+                f"node {n.id!r} references unknown zone {n.zone!r}",
+                subject={"node": n.id},
+                evidence={"zone": n.zone, "known_zones": sorted(zone_ids)},
+                supported_fixes=(
+                    "declare the zone under `zones`",
+                    "point the node's `zone` at an existing zone id",
+                    "drop the node's `zone` field",
+                ),
+            )
     for z in zones:
         if z.parent is not None and z.parent not in zone_ids:
-            raise SpecError(f"zone {z.id!r} references unknown parent {z.parent!r}")
+            raise _spec_error(
+                "spec/unknown-zone-parent",
+                f"zone {z.id!r} references unknown parent {z.parent!r}",
+                subject={"zone": z.id},
+                evidence={"parent": z.parent, "known_zones": sorted(zone_ids)},
+                supported_fixes=(
+                    "declare the parent zone under `zones`",
+                    "point `parent` at an existing zone id",
+                    "drop `parent` to make this a top-level zone",
+                ),
+            )
         if z.parent == z.id:
-            raise SpecError(f"zone {z.id!r} cannot be its own parent")
+            raise _spec_error(
+                "spec/zone-self-parent",
+                f"zone {z.id!r} cannot be its own parent",
+                subject={"zone": z.id},
+                supported_fixes=(
+                    "drop `parent` to make this a top-level zone",
+                    "point `parent` at the enclosing zone",
+                ),
+            )
 
     edges = []
     for raw in data.get("edges", []) or []:
         if raw.get("from") not in node_ids or raw.get("to") not in node_ids:
-            raise SpecError(f"edge references unknown node: {raw}")
+            raise _spec_error(
+                "spec/unknown-edge-node",
+                f"edge references unknown node: {raw}",
+                evidence={"edge": raw, "known_nodes": sorted(node_ids)},
+                supported_fixes=(
+                    "point `from` and `to` at existing node ids",
+                    "declare the missing node under `nodes`",
+                ),
+            )
         edges.append(
             Edge(
                 src=raw["from"],
@@ -334,11 +526,28 @@ def compute_zone_boxes(spec: Spec, node_boxes: dict[str, Box]) -> dict[str, Box]
         if zone_id in boxes:
             return boxes[zone_id]
         if zone_id in stack:
-            raise SpecError(f"zone cycle detected at {zone_id!r}")
+            raise _spec_error(
+                "spec/zone-cycle",
+                f"zone cycle detected at {zone_id!r}",
+                subject={"zone": zone_id},
+                evidence={"chain": sorted(stack)},
+                supported_fixes=(
+                    "break the cycle so every zone's `parent` chain ends at a top-level zone",
+                ),
+            )
         parts = [node_boxes[nid] for nid in members[zone_id]]
         parts += [resolve(cid, stack | {zone_id}) for cid in children[zone_id]]
         if not parts:
-            raise SpecError(f"zone {zone_id!r} has no member nodes or child zones")
+            raise _spec_error(
+                "spec/empty-zone",
+                f"zone {zone_id!r} has no member nodes or child zones",
+                subject={"zone": zone_id},
+                supported_fixes=(
+                    "assign at least one node to the zone via that node's `zone` field",
+                    "nest a child zone under it",
+                    "delete the zone",
+                ),
+            )
         x0 = min(p.x for p in parts) - ZONE_PAD
         y0 = min(p.y for p in parts) - ZONE_PAD - ZONE_LABEL_H
         x1 = max(p.x2 for p in parts) + ZONE_PAD
@@ -427,16 +636,31 @@ def route_edges(spec: Spec, node_boxes: dict[str, Box]) -> list[RoutedEdge]:
 
 def check_layout(
     spec: Spec, node_boxes: dict[str, Box], zone_boxes: dict[str, Box]
-) -> list[str]:
-    """Hard assertions replacing the prose self-check rules prior art asks
-    the model to apply by eye ("no edge crosses an unrelated icon", "no two
-    edges overlap")."""
-    warnings = []
+) -> list[Diagnostic]:
+    """Hard assertions replacing the prose self-check rules prior art in this
+    space asks the model to apply by eye ("no edge crosses an unrelated
+    icon", "no two edges overlap")."""
+    out: list[Diagnostic] = []
     ids = list(node_boxes)
     for i, a_id in enumerate(ids):
         for b_id in ids[i + 1 :]:
             if node_boxes[a_id].overlaps(node_boxes[b_id]):
-                warnings.append(f"node overlap: {a_id!r} and {b_id!r}")
+                out.append(
+                    Diagnostic(
+                        code="layout/node-overlap",
+                        severity=SEVERITY_ERROR,
+                        message=f"node overlap: {a_id!r} and {b_id!r}",
+                        subject={"nodes": [a_id, b_id]},
+                        evidence={
+                            a_id: _box_evidence(node_boxes[a_id]),
+                            b_id: _box_evidence(node_boxes[b_id]),
+                        },
+                        supported_fixes=(
+                            "split the two nodes across different ranks by adding an edge between them",
+                            "remove one of the duplicated nodes",
+                        ),
+                    )
+                )
     zids = list(zone_boxes)
     for i, a_id in enumerate(zids):
         for b_id in zids[i + 1 :]:
@@ -444,10 +668,28 @@ def check_layout(
             if b_id in a_parent_chain or a_id in _zone_ancestors(spec, b_id):
                 continue  # nested zones are expected to overlap their ancestor
             if zone_boxes[a_id].overlaps(zone_boxes[b_id]):
-                warnings.append(
-                    f"zone overlap: {a_id!r} and {b_id!r} — group their member nodes contiguously"
+                out.append(
+                    Diagnostic(
+                        code="layout/zone-overlap",
+                        severity=SEVERITY_ERROR,
+                        message=f"zone overlap: {a_id!r} and {b_id!r}",
+                        subject={"zones": [a_id, b_id]},
+                        evidence={
+                            a_id: _box_evidence(zone_boxes[a_id]),
+                            b_id: _box_evidence(zone_boxes[b_id]),
+                        },
+                        supported_fixes=(
+                            "list each zone's member nodes contiguously in `nodes`",
+                            "correct the `zone` field on the interleaved nodes",
+                            "nest one zone inside the other via `parent` if containment was intended",
+                        ),
+                    )
                 )
-    return warnings
+    return out
+
+
+def _box_evidence(box: Box) -> dict[str, float]:
+    return {"x": box.x, "y": box.y, "width": box.w, "height": box.h}
 
 
 def _zone_ancestors(spec: Spec, zone_id: str) -> set[str]:
@@ -531,7 +773,51 @@ class CompositeIconLookup:
 # --- emit ----------------------------------------------------------------------
 
 
-def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -> str:
+def _label_overflow(
+    node_id: str, field_name: str, text: str, font_size: float, available: float
+) -> Diagnostic:
+    return Diagnostic(
+        code="layout/label-overflow",
+        severity=SEVERITY_WARNING,
+        message=f"{field_name} may overflow its node box: {text!r} on {node_id!r}",
+        subject={"node": node_id, "field": field_name},
+        evidence={
+            "text": text,
+            "estimated_width": round(_text_width(text, font_size), 2),
+            "available_width": available,
+        },
+        supported_fixes=(
+            "shorten the text",
+            "move the detail into `sublabel`",
+        ),
+    )
+
+
+def _icon_not_found(node: Node) -> Diagnostic:
+    fixes = ["use the exact slug from that provider's reference service map"]
+    # The generic set is bundled in the package, so telling the author to
+    # fetch a cache for it would send them after a cache that never exists.
+    if node.provider != "generic":
+        fixes.insert(0, f"warm the icon cache: fetch_icons.py --provider {node.provider}")
+    fixes.append(
+        "drop the node's `service` field to render the labeled placeholder deliberately"
+    )
+    return Diagnostic(
+        code="icon/not-found",
+        severity=SEVERITY_ERROR,
+        message=(
+            f"no icon for node {node.id!r} "
+            f"(service={node.service!r}, provider={node.provider!r})"
+        ),
+        subject={"node": node.id},
+        evidence={"service": node.service, "provider": node.provider},
+        supported_fixes=tuple(fixes),
+    )
+
+
+def _node_svg(
+    node: Node, box: Box, icon: IconRef | None, diagnostics: list[Diagnostic]
+) -> str:
     parts = [f'<g id="node-{_escape(node.id)}">']
     icon_pos = icon_box(box)
     parts.append(
@@ -545,9 +831,7 @@ def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -
         )
     else:
         if node.service:
-            warnings.append(
-                f"no icon for node {node.id!r} (service={node.service!r}, provider={node.provider!r})"
-            )
+            diagnostics.append(_icon_not_found(node))
         cx, cy = icon_pos.x + ICON / 2, icon_pos.y + ICON / 2
         initial = _escape(node.label[:1].upper() or "?")
         parts.append(
@@ -556,8 +840,8 @@ def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -
     label_y = box.y + ICON + 18
     label_font_size = 12.0
     if _text_width(node.label, label_font_size) > box.w - 8:
-        warnings.append(
-            f"label may overflow its node box: {node.label!r} on {node.id!r}"
+        diagnostics.append(
+            _label_overflow(node.id, "label", node.label, label_font_size, box.w - 8)
         )
     parts.append(
         f'<text x="{box.x + box.w / 2:g}" y="{label_y:g}" font-size="{label_font_size:g}" font-weight="600" '
@@ -566,8 +850,10 @@ def _node_svg(node: Node, box: Box, icon: IconRef | None, warnings: list[str]) -
     if node.sublabel:
         sub_font_size = 10.5
         if _text_width(node.sublabel, sub_font_size) > box.w - 8:
-            warnings.append(
-                f"sublabel may overflow its node box: {node.sublabel!r} on {node.id!r}"
+            diagnostics.append(
+                _label_overflow(
+                    node.id, "sublabel", node.sublabel, sub_font_size, box.w - 8
+                )
             )
         parts.append(
             f'<text x="{box.x + box.w / 2:g}" y="{label_y + 15:g}" font-size="{sub_font_size:g}" '
@@ -626,7 +912,7 @@ def emit_svg(
     zone_boxes: dict[str, Box],
     routed_edges: list[RoutedEdge],
     icons: dict[str, IconRef | None],
-    warnings: list[str],
+    diagnostics: list[Diagnostic],
 ) -> str:
     zone_by_id = {z.id: z for z in spec.zones}
     all_extents = [b for b in node_boxes.values()] + [b for b in zone_boxes.values()]
@@ -667,7 +953,7 @@ def emit_svg(
         parts.append(_edge_svg(routed))
 
     for n in spec.nodes:
-        parts.append(_node_svg(n, node_boxes[n.id], icons.get(n.id), warnings))
+        parts.append(_node_svg(n, node_boxes[n.id], icons.get(n.id), diagnostics))
 
     if show_legend:
         parts.append(_legend_svg(edge_types, MARGIN, height - legend_h + 6))
@@ -681,18 +967,40 @@ def emit_svg(
 _FORBIDDEN_MARKERS = ("<image", "base64,", "<use ", "<use>")
 
 
-def check_editability(svg_text: str) -> list[str]:
+def check_editability(svg_text: str) -> list[Diagnostic]:
     """Enforce the output contract this rewrite exists to deliver: no raster
     fallback, no `<use>` clones (Inkscape/MDN both document that clone nodes
     aren't independently node-editable — see `references/editability.md`),
     no external references. A regression here means a future change quietly
     reintroduced one of the failure modes the whole design avoids."""
-    found = [m for m in _FORBIDDEN_MARKERS if m in svg_text]
-    warnings = [f"editability violation: found {m!r}" for m in found]
+    out: list[Diagnostic] = []
+    for marker in _FORBIDDEN_MARKERS:
+        if marker in svg_text:
+            out.append(
+                Diagnostic(
+                    code="editability/forbidden-markup",
+                    severity=SEVERITY_ERROR,
+                    message=f"editability violation: found {marker!r}",
+                    evidence={"marker": marker},
+                    supported_fixes=(
+                        "file this as a renderer bug: the spec cannot introduce this markup",
+                    ),
+                )
+            )
     for marker in ('href="http', 'xlink:href="http'):
         if marker in svg_text:
-            warnings.append(f"editability violation: external reference ({marker!r})")
-    return warnings
+            out.append(
+                Diagnostic(
+                    code="editability/external-reference",
+                    severity=SEVERITY_ERROR,
+                    message=f"editability violation: external reference ({marker!r})",
+                    evidence={"marker": marker},
+                    supported_fixes=(
+                        "file this as a renderer bug: the output must stay self-contained",
+                    ),
+                )
+            )
+    return out
 
 
 # --- top-level render ----------------------------------------------------------
@@ -701,25 +1009,76 @@ def check_editability(svg_text: str) -> list[str]:
 @dataclass
 class RenderResult:
     svg: str
-    warnings: list[str] = field(default_factory=list)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[Diagnostic]:
+        return [d for d in self.diagnostics if d.severity == SEVERITY_ERROR]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
 
 
-def render(spec: Spec, icon_lookup: IconLookup) -> RenderResult:
-    warnings: list[str] = []
+def render(
+    spec: Spec, icon_lookup: IconLookup, quality: str = QUALITY_STANDARD
+) -> RenderResult:
+    diagnostics: list[Diagnostic] = []
     rank = assign_ranks(spec)
     order = order_within_ranks(spec, rank)
     node_boxes = compute_positions(spec, rank, order)
     zone_boxes = compute_zone_boxes(spec, node_boxes) if spec.zones else {}
-    warnings += check_layout(spec, node_boxes, zone_boxes)
+    diagnostics += check_layout(spec, node_boxes, zone_boxes)
     routed_edges = route_edges(spec, node_boxes)
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:
         icons[n.id] = icon_lookup(n.provider, n.service) if n.service else None
 
-    svg = emit_svg(spec, node_boxes, zone_boxes, routed_edges, icons, warnings)
-    warnings += check_editability(svg)
-    return RenderResult(svg=svg, warnings=warnings)
+    svg = emit_svg(spec, node_boxes, zone_boxes, routed_edges, icons, diagnostics)
+    diagnostics += check_editability(svg)
+    diagnostics = apply_quality_profile(suppress_derived(diagnostics), quality)
+    return RenderResult(svg=svg, diagnostics=diagnostics)
+
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+
+
+def _envelope(
+    ok: bool,
+    quality: str,
+    diagnostics: list[Diagnostic],
+    output: Path | None = None,
+    artifact_bytes: int | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": DIAGNOSTIC_SCHEMA_VERSION,
+        "ok": ok,
+        "quality": quality,
+        "output": str(output) if output is not None else None,
+        "written": artifact_bytes is not None,
+        "artifact_bytes": artifact_bytes,
+        "counts": count_by_severity(diagnostics),
+        "diagnostics": [d.to_dict() for d in diagnostics],
+    }
+
+
+def _report(
+    envelope: dict[str, object], as_json: bool, diagnostics: list[Diagnostic]
+) -> None:
+    """Under --json, stdout carries the envelope and nothing else, so a
+    caller can parse it without stripping human lines."""
+    if as_json:
+        print(json.dumps(envelope, indent=2, sort_keys=True))
+        return
+    if envelope["written"]:
+        print(f"wrote {envelope['output']} ({envelope['artifact_bytes']} bytes)")
+    for d in diagnostics:
+        print(f"{d.severity}: [{d.code}] {d.message}", file=sys.stderr)
+        for fix in d.supported_fixes:
+            print(f"  fix: {fix}", file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -728,7 +1087,33 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("-o", "--output", type=Path, default=Path("diagram.svg"))
     parser.add_argument("--cache-dir", type=Path, default=None)
     parser.add_argument("--sha", default=None)
+    parser.add_argument(
+        "--quality",
+        choices=QUALITY_PROFILES,
+        default=QUALITY_STANDARD,
+        help="showcase raises composition findings from warnings to errors",
+    )
+    parser.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="print the diagnostic envelope to stdout and nothing else",
+    )
     args = parser.parse_args(argv)
+
+    try:
+        spec_text = args.spec.read_text()
+    except OSError as exc:
+        unreadable = Diagnostic(
+            code="usage/spec-unreadable",
+            severity=SEVERITY_ERROR,
+            message=f"cannot read spec {str(args.spec)!r}: {exc.strerror or exc}",
+            subject={"path": str(args.spec)},
+            supported_fixes=("pass the path to an existing, readable YAML spec",),
+        )
+        envelope = _envelope(False, args.quality, [unreadable], args.output)
+        _report(envelope, args.as_json, [unreadable])
+        return EXIT_USAGE
 
     import fetch_icons  # local import: keeps render.py importable without pulling in networking deps for pure-layout tests
 
@@ -739,17 +1124,23 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     try:
-        spec = load_spec(args.spec.read_text())
+        spec = load_spec(spec_text)
     except SpecError as exc:
-        print(f"error: invalid spec — {exc}", file=sys.stderr)
-        return 1
+        envelope = _envelope(False, args.quality, [exc.diagnostic], args.output)
+        _report(envelope, args.as_json, [exc.diagnostic])
+        return EXIT_FAILURE
 
-    result = render(spec, lookup)
+    result = render(spec, lookup, quality=args.quality)
     args.output.write_text(result.svg)
-    print(f"wrote {args.output} ({len(result.svg)} bytes)")
-    for w in result.warnings:
-        print(f"warning: {w}", file=sys.stderr)
-    return 1 if any("editability violation" in w for w in result.warnings) else 0
+    envelope = _envelope(
+        result.ok,
+        args.quality,
+        result.diagnostics,
+        args.output,
+        artifact_bytes=len(result.svg),
+    )
+    _report(envelope, args.as_json, result.diagnostics)
+    return EXIT_OK if result.ok else EXIT_FAILURE
 
 
 if __name__ == "__main__":

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -165,10 +165,18 @@ def apply_quality_profile(
 
 
 def suppress_derived(diagnostics: list[Diagnostic]) -> list[Diagnostic]:
-    """Drop findings whose cause is already reported."""
-    suppressed: set[str] = set()
-    for d in diagnostics:
-        suppressed.update(d.suppresses)
+    """Drop findings a reported cause makes redundant.
+
+    Suppression is one level deep and keyed on `code`: a record is dropped
+    when any record in the input names its code, and a dropped record still
+    suppresses. Resolving chains instead has no well-founded answer — if A
+    suppresses B and C suppresses A, then removing B leaves it hidden with
+    no visible cause, while keeping B oscillates on the next pass, and a
+    mutual pair has no defensible winner at all. Every emitter must
+    therefore declare `suppresses` only for a code it directly explains,
+    never for one that suppresses something else in turn.
+    """
+    suppressed = {code for d in diagnostics for code in d.suppresses}
     return [d for d in diagnostics if d.code not in suppressed]
 
 

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -777,6 +777,27 @@ class TestDerivedSuppression:
         b = render.Diagnostic(code="icon/not-found", severity="error", message="m")
         assert render.suppress_derived([a, b]) == [a, b]
 
+    def test_suppression_is_one_level_and_does_not_resolve_chains(self) -> None:
+        # Documented semantics: a dropped record still suppresses, so a
+        # chain removes everything below the top. Emitters must therefore
+        # declare `suppresses` only for a code they directly explain.
+        top = render.Diagnostic(
+            code="composition/top",
+            severity="error",
+            message="m",
+            suppresses=("composition/middle",),
+        )
+        middle = render.Diagnostic(
+            code="composition/middle",
+            severity="warning",
+            message="m",
+            suppresses=("composition/leaf",),
+        )
+        leaf = render.Diagnostic(
+            code="composition/leaf", severity="warning", message="m"
+        )
+        assert render.suppress_derived([top, middle, leaf]) == [top]
+
 
 class TestSpecErrorCodes:
     @pytest.mark.parametrize(

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -222,8 +222,7 @@ class TestPositions:
         rank = assign_ranks(spec)
         order = order_within_ranks(spec, rank)
         boxes = compute_positions(spec, rank, order)
-        warnings = check_layout(spec, boxes, {})
-        assert not any("overlap" in w for w in warnings)
+        assert check_layout(spec, boxes, {}) == []
 
 
 class TestZoneBoxes:
@@ -457,18 +456,20 @@ class TestEditabilityCheck:
 
     def test_detects_raster_image(self) -> None:
         svg = '<svg><image href="data:image/png;base64,abc"/></svg>'
-        warnings = check_editability(svg)
-        assert any("image" in w for w in warnings)
+        codes = [d.code for d in check_editability(svg)]
+        assert codes == ["editability/forbidden-markup"] * 2
 
     def test_detects_use_clone(self) -> None:
         svg = '<svg><defs><symbol id="x"/></defs><use href="#x"/></svg>'
-        warnings = check_editability(svg)
-        assert any("use" in w for w in warnings)
+        found = check_editability(svg)
+        assert [d.code for d in found] == ["editability/forbidden-markup"]
+        assert found[0].evidence["marker"] == "<use "
 
     def test_detects_external_href(self) -> None:
         svg = '<svg><a href="http://example.com/icon.svg"/></svg>'
-        warnings = check_editability(svg)
-        assert any("external" in w for w in warnings)
+        found = check_editability(svg)
+        assert [d.code for d in found] == ["editability/external-reference"]
+        assert all(d.severity == "error" for d in found)
 
 
 class TestEndToEndRender:
@@ -485,17 +486,21 @@ class TestEndToEndRender:
         for label in ("A", "B", "C"):
             assert f">{label}<" in result.svg
 
-    def test_missing_icon_falls_back_without_crashing_and_warns(self) -> None:
+    def test_missing_icon_falls_back_without_crashing_and_reports(self) -> None:
         spec_text = "nodes:\n  - id: a\n    label: A\n    service: missing\n"
         spec = load_spec(spec_text)
         result = do_render(spec, _icon_lookup)
-        assert "no icon for node" in " ".join(result.warnings)
+        found = [d for d in result.diagnostics if d.code == "icon/not-found"]
+        assert [d.subject["node"] for d in found] == ["a"]
+        assert found[0].severity == "error"
+        assert not result.ok
         assert result.svg.startswith("<svg")
 
-    def test_node_without_service_renders_placeholder_no_warning(self) -> None:
+    def test_node_without_service_renders_placeholder_without_diagnostic(self) -> None:
         spec = load_spec("nodes:\n  - id: a\n    label: A\n")
         result = do_render(spec, _icon_lookup)
-        assert not any("no icon" in w for w in result.warnings)
+        assert result.diagnostics == []
+        assert result.ok
 
     def test_zoned_spec_renders_zone_rect(self) -> None:
         spec = load_spec(ZONED_SPEC)
@@ -533,13 +538,17 @@ class TestEndToEndRender:
         result = do_render(spec, _icon_lookup)
         assert "stroke-dasharray" in result.svg
 
-    def test_overflowing_label_warns(self) -> None:
+    def test_overflowing_label_is_reported_as_a_warning(self) -> None:
         spec_text = (
             'nodes:\n  - id: a\n    label: "This Is A Genuinely Very Long Label Text"\n'
         )
         spec = load_spec(spec_text)
         result = do_render(spec, _icon_lookup)
-        assert any("overflow" in w for w in result.warnings)
+        found = [d for d in result.diagnostics if d.code == "layout/label-overflow"]
+        assert [d.subject for d in found] == [{"node": "a", "field": "label"}]
+        assert found[0].severity == "warning"
+        # A label that does not fit still renders; it is not a blocking finding.
+        assert result.ok
 
     def test_svg_has_valid_viewbox_matching_dimensions(self) -> None:
         spec = load_spec(LINEAR_SPEC)
@@ -593,8 +602,10 @@ class TestZoneOverlapAssertion:
         order = order_within_ranks(spec, rank)
         node_boxes = compute_positions(spec, rank, order)
         zone_boxes = compute_zone_boxes(spec, node_boxes)
-        warnings = check_layout(spec, node_boxes, zone_boxes)
-        assert any("zone overlap" in w for w in warnings)
+        found = check_layout(spec, node_boxes, zone_boxes)
+        assert [d.code for d in found] == ["layout/zone-overlap"]
+        assert sorted(found[0].subject["zones"]) == ["z1", "z2"]
+        assert found[0].severity == "error"
 
 
 class TestRealIconCacheIntegration:
@@ -689,3 +700,215 @@ class TestCompositeIconLookup:
 
         composite = render.CompositeIconLookup([always_none, always_none])
         assert composite("aws", "anything") is None
+
+
+class TestDiagnosticEnvelope:
+    def test_unknown_severity_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown severity"):
+            render.Diagnostic(code="spec/x", severity="fatal", message="m")
+
+    def test_empty_suppresses_is_omitted_from_the_payload(self) -> None:
+        payload = render.Diagnostic(
+            code="layout/node-overlap", severity="error", message="m"
+        ).to_dict()
+        assert "suppresses" not in payload
+        assert payload["supported_fixes"] == []
+
+    def test_suppresses_is_carried_when_set(self) -> None:
+        payload = render.Diagnostic(
+            code="composition/a",
+            severity="warning",
+            message="m",
+            suppresses=("composition/b",),
+        ).to_dict()
+        assert payload["suppresses"] == ["composition/b"]
+
+    def test_counts_split_by_severity(self) -> None:
+        diags = [
+            render.Diagnostic(code="a/x", severity="error", message="m"),
+            render.Diagnostic(code="b/y", severity="warning", message="m"),
+            render.Diagnostic(code="c/z", severity="warning", message="m"),
+        ]
+        assert render.count_by_severity(diags) == {"errors": 1, "warnings": 2}
+
+
+class TestQualityProfiles:
+    def _composition_warning(self) -> render.Diagnostic:
+        return render.Diagnostic(
+            code="composition/micro-segment", severity="warning", message="m"
+        )
+
+    def test_standard_leaves_composition_findings_as_warnings(self) -> None:
+        out = render.apply_quality_profile([self._composition_warning()], "standard")
+        assert [d.severity for d in out] == ["warning"]
+
+    def test_showcase_raises_composition_findings_to_errors(self) -> None:
+        out = render.apply_quality_profile([self._composition_warning()], "showcase")
+        assert [d.severity for d in out] == ["error"]
+        assert out[0].code == "composition/micro-segment"
+
+    def test_showcase_leaves_other_namespaces_alone(self) -> None:
+        warning = render.Diagnostic(
+            code="layout/label-overflow", severity="warning", message="m"
+        )
+        out = render.apply_quality_profile([warning], "showcase")
+        assert [d.severity for d in out] == ["warning"]
+
+    def test_unknown_profile_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown quality profile"):
+            render.apply_quality_profile([], "pretty")
+
+
+class TestDerivedSuppression:
+    def test_a_cause_removes_its_derivative(self) -> None:
+        cause = render.Diagnostic(
+            code="composition/cause",
+            severity="error",
+            message="m",
+            suppresses=("composition/derived",),
+        )
+        derived = render.Diagnostic(
+            code="composition/derived", severity="warning", message="m"
+        )
+        assert render.suppress_derived([cause, derived]) == [cause]
+
+    def test_unrelated_findings_survive(self) -> None:
+        a = render.Diagnostic(code="layout/node-overlap", severity="error", message="m")
+        b = render.Diagnostic(code="icon/not-found", severity="error", message="m")
+        assert render.suppress_derived([a, b]) == [a, b]
+
+
+class TestSpecErrorCodes:
+    @pytest.mark.parametrize(
+        ("spec_text", "code"),
+        [
+            ("title: empty\n", "spec/no-nodes"),
+            ("nodes:\n  - label: no id\n", "spec/node-missing-id"),
+            ("nodes:\n  - id: a\n  - id: a\n", "spec/duplicate-node-id"),
+            ("zones:\n  - label: z\nnodes:\n  - id: a\n", "spec/zone-missing-id"),
+            ("nodes:\n  - id: a\n    zone: ghost\n", "spec/unknown-zone"),
+            (
+                "zones:\n  - id: z\n    parent: ghost\nnodes:\n  - id: a\n    zone: z\n",
+                "spec/unknown-zone-parent",
+            ),
+            (
+                "zones:\n  - id: z\n    parent: z\nnodes:\n  - id: a\n    zone: z\n",
+                "spec/zone-self-parent",
+            ),
+            (
+                "nodes:\n  - id: a\nedges:\n  - from: a\n    to: ghost\n",
+                "spec/unknown-edge-node",
+            ),
+        ],
+    )
+    def test_each_rejection_carries_its_own_code(
+        self, spec_text: str, code: str
+    ) -> None:
+        with pytest.raises(SpecError) as exc:
+            load_spec(spec_text)
+        assert exc.value.diagnostic.code == code
+        assert exc.value.diagnostic.severity == "error"
+        assert exc.value.diagnostic.supported_fixes
+
+    def test_empty_zone_is_coded_at_geometry_time(self) -> None:
+        spec = load_spec("zones:\n  - id: z\nnodes:\n  - id: a\n")
+        rank = assign_ranks(spec)
+        order = order_within_ranks(spec, rank)
+        node_boxes = compute_positions(spec, rank, order)
+        with pytest.raises(SpecError) as exc:
+            compute_zone_boxes(spec, node_boxes)
+        assert exc.value.diagnostic.code == "spec/empty-zone"
+        assert exc.value.diagnostic.subject == {"zone": "z"}
+
+    def test_message_stays_human_readable(self) -> None:
+        with pytest.raises(SpecError, match="spec has no nodes"):
+            load_spec("title: empty\n")
+
+
+class TestCliContract:
+    def _run(
+        self, capsys: pytest.CaptureFixture[str], *argv: str
+    ) -> tuple[int, dict[str, object], str]:
+        code = render.main(list(argv))
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out) if "--json" in argv else {}
+        return code, payload, captured.err
+
+    def test_clean_render_exits_zero_with_a_parsable_envelope(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("nodes:\n  - id: a\n    label: A\n")
+        out = tmp_path / "d.svg"
+        code, payload, _ = self._run(
+            capsys, str(spec), "-o", str(out), "--cache-dir", str(tmp_path), "--json"
+        )
+        assert code == render.EXIT_OK
+        assert payload["ok"] is True
+        assert payload["written"] is True
+        assert payload["diagnostics"] == []
+        assert payload["schema_version"] == render.DIAGNOSTIC_SCHEMA_VERSION
+        assert payload["artifact_bytes"] == len(out.read_text())
+
+    def test_json_mode_puts_nothing_but_json_on_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("nodes:\n  - id: a\n    label: A\n    service: ghost\n")
+        code, payload, _ = self._run(
+            capsys,
+            str(spec),
+            "-o",
+            str(tmp_path / "d.svg"),
+            "--cache-dir",
+            str(tmp_path),
+            "--json",
+        )
+        # A finding is present, so this also proves diagnostics do not leak to
+        # stdout as prose alongside the envelope.
+        assert code == render.EXIT_FAILURE
+        assert [d["code"] for d in payload["diagnostics"]] == ["icon/not-found"]
+
+    def test_missing_icon_is_an_operational_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("nodes:\n  - id: a\n    label: A\n    service: ghost\n")
+        code, _, err = self._run(
+            capsys, str(spec), "-o", str(tmp_path / "d.svg"), "--cache-dir", str(tmp_path)
+        )
+        assert code == render.EXIT_FAILURE
+        assert "[icon/not-found]" in err
+        assert "fix: " in err
+
+    def test_invalid_spec_is_an_operational_failure_and_writes_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("title: empty\n")
+        out = tmp_path / "d.svg"
+        code, payload, _ = self._run(
+            capsys, str(spec), "-o", str(out), "--cache-dir", str(tmp_path), "--json"
+        )
+        assert code == render.EXIT_FAILURE
+        assert payload["written"] is False
+        assert [d["code"] for d in payload["diagnostics"]] == ["spec/no-nodes"]
+        assert not out.exists()
+
+    def test_unreadable_spec_path_is_a_usage_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        code, payload, _ = self._run(
+            capsys,
+            str(tmp_path / "nope.yaml"),
+            "-o",
+            str(tmp_path / "d.svg"),
+            "--json",
+        )
+        assert code == render.EXIT_USAGE
+        assert [d["code"] for d in payload["diagnostics"]] == ["usage/spec-unreadable"]
+
+    def test_unknown_quality_profile_is_a_usage_error(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            render.main([str(tmp_path / "s.yaml"), "--quality", "pretty"])
+        assert exc.value.code == render.EXIT_USAGE


### PR DESCRIPTION
## Stack

Stack-Id: `diagram-diagnostics-4f8c21`
Base: `ci/gate-package-tests`
Position: 2/2

1. `ci/gate-package-tests` -> #121
2. `feat/diagram-coded-diagnostics` -> this PR

Depends on: #121

## Why

Findings were `list[str]` of English prose printed to stderr, and the process exited `1` only when an editability violation slipped through. A caller had to regex sentences to learn what went wrong, and nothing told it what a legal repair was — so the available move was to edit the SVG, which is precisely what destroys the reproducibility deterministic layout exists to provide.

## What replaces it

Every finding is a `Diagnostic`:

| Field | Purpose |
|---|---|
| `code` | stable identity, e.g. `layout/zone-overlap` |
| `severity` | `error` or `warning`; anything else raises |
| `message` | human-readable line |
| `subject` | what the finding is about (`{"node": "a", "field": "label"}`) |
| `evidence` | the numbers needed to locate it (boxes, widths, markers) |
| `supported_fixes` | spec-level moves the author can actually make |
| `suppresses` | codes this finding makes redundant |

Codes minted: `spec/no-nodes`, `spec/node-missing-id`, `spec/duplicate-node-id`, `spec/zone-missing-id`, `spec/unknown-zone`, `spec/unknown-zone-parent`, `spec/zone-self-parent`, `spec/unknown-edge-node`, `spec/zone-cycle`, `spec/empty-zone`, `layout/node-overlap`, `layout/zone-overlap`, `layout/label-overflow`, `icon/not-found`, `editability/forbidden-markup`, `editability/external-reference`, `usage/spec-unreadable`.

`SpecError` now carries its `Diagnostic` while keeping its message, so tracebacks stay readable and callers get the same coded record they get everywhere else.

**No new checks.** This is a re-expression of what `load_spec`, `check_layout`, the icon lookup, and `check_editability` already detected. Rendering `assets/example-serverless.yaml` produces SVG byte-identical to the pre-change implementation (verified by rendering both trees and `cmp`).

### CLI contract

| Exit | Meaning |
|---|---|
| 0 | no error-severity findings |
| 1 | a blocking finding, or a spec the renderer cannot answer |
| 2 | usage error: unreadable spec path, unknown flag or profile value |

`--json` puts the envelope (`schema_version`, `ok`, `quality`, `output`, `written`, `artifact_bytes`, `counts`, `diagnostics`) on stdout and nothing else. `--quality standard|showcase` selects the profile.

### Two mechanisms with no emitters yet

`suppresses` and the `composition/*` quality profile are built and tested here but nothing emits them, because the geometry checks that need them are the next milestone's work. They are in this PR because they are envelope semantics: adding them later would be a breaking change to a contract callers had already started depending on.

### Deliberate deviations

- An unknown `severity` or `--quality` value **raises** rather than normalising to `error`. Both can only originate in renderer code, and silent normalisation is the fallback pattern `AGENTS.md` forbids.
- `icon/not-found` is an **error**, not a warning: a diagram that silently ships a placeholder where a service icon was requested misrepresents the architecture. SVG bytes are unchanged; the exit code for such a spec changes from 0 to 1.
- `layout/node-overlap` and `layout/zone-overlap` are errors for the same reason. `layout/label-overflow` stays a warning — the diagram still reads.
- The `icon/not-found` fix list omits the cache-warming step for `provider: generic`, whose icons are bundled and have no cache to warm.

## Docs

The prose Verification checklist is **replaced**, not supplemented: it asked the agent to confirm "every warning line has been addressed" and to open the SVG and eyeball zone containment — self-checks by eye, the exact failure mode deterministic layout removes. In its place: the exit-code table and a code-to-fix table. `SKILL.md` is 252 lines, down from 254.

Two eval rubrics now expect the agent to act on the render's verdict instead of narrating around it. `evals/cases.yaml` cannot assert an exit code — `scripts/validate_evals.py` allows only `contains`, `not_contains`, `matches_regex`, `output_format`, and `calls_tool`, and widening that schema would change a repo-wide contract from inside one package's PR.

## Validation

- `uv run python -m pytest skills/architecture-diagram/tests -q` — 152 passed (126 before, 26 new)
- `uv run python -m pytest tests/ -q` — 369 passed
- byte-identity: rendered `assets/example-serverless.yaml` on this branch and on the pre-change tree, `cmp` clean
- CLI smoke, human mode: warning and error lines each print `[code]` plus one `fix:` line per supported fix; exit 1
- CLI smoke, `--json`: whole stdout parses as one object; `counts` `{"errors": 1, "warnings": 1}`
- exit codes exercised: 0 clean, 1 missing icon, 1 invalid spec (nothing written), 2 unreadable path, 2 unknown `--quality`
- `uv run python scripts/validate_evals.py` — all passed
- `uv run python scripts/generate_manifest.py` then `git diff --exit-code manifest.yaml` — clean
- `uv run python scripts/validate_frontmatter.py` / `validate_references.py` — 142 packages, all passed
- `uv run python scripts/evaluate_package.py --path skills/architecture-diagram` — `Static conformance: PASS`

## Known, not fixed here

`assets/example-serverless.svg` is stale on `main`: it was committed at 758x472 while the current renderer emits 836x484. This PR does not change the renderer's output, so regenerating it is not this diff's business, and a test pinning it cannot run in CI — cloud icons are fetched per machine, never vendored. It belongs to the next milestone, which changes those bytes deliberately.

Version: 2.0.0 -> 2.1.0, with `manifest.yaml` regenerated in the same commit.

## Review round 1

One finding, addressed by pinning the semantics rather than changing them: `suppress_derived` drops a derived finding even when the record naming it was itself suppressed. Resolving chains has no well-founded answer — removing the derivative hides it with no visible cause, keeping it oscillates on the next pass, and a mutual pair has no defensible winner — so the one-level, code-keyed rule stands, is now stated in the docstring, and is pinned by a test asserting the chain case. The obligation lands on emitters: declare `suppresses` only for a code you directly explain. Nothing emits `suppresses` today.

The exit-code change for `icon/not-found` and the layout overlaps was raised and confirmed as intended; it is already documented above.
