### PR TITLE
feat(architecture-diagram): detect composition failures geometrically

### DIFF
--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from math import hypot
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -67,6 +68,10 @@ PROPER_CROSSING_EPSILON = 1e-4
 # Unrelated collinear paths sharing eight pixels or more read as one ambiguous
 # corridor rather than distinct connections.
 MIN_AMBIGUOUS_CORRIDOR = 8.0
+# Edge labels use the same glyph estimator as nodes. A route closer than four
+# pixels to the label mask makes the connection annotation unreadable.
+EDGE_LABEL_FONT_SIZE = 10.0
+LABEL_ROUTE_CLEARANCE = 4.0
 
 
 EDGE_COLORS = {
@@ -1121,6 +1126,81 @@ def check_ambiguous_corridors(routed_edges: list[RoutedEdge]) -> list[Diagnostic
     return out
 
 
+def _edge_label_box(routed: RoutedEdge) -> Box:
+    x, baseline = routed.label_pos
+    return Box(
+        x,
+        baseline - EDGE_LABEL_FONT_SIZE,
+        _text_width(routed.edge.label, EDGE_LABEL_FONT_SIZE),
+        EDGE_LABEL_FONT_SIZE,
+    )
+
+
+def _segment_box(start: tuple[float, float], end: tuple[float, float]) -> Box:
+    return Box(
+        min(start[0], end[0]),
+        min(start[1], end[1]),
+        abs(end[0] - start[0]),
+        abs(end[1] - start[1]),
+    )
+
+
+def _box_clearance(first: Box, second: Box) -> float:
+    horizontal = max(first.x - second.x2, second.x - first.x2, 0.0)
+    vertical = max(first.y - second.y2, second.y - first.y2, 0.0)
+    return hypot(horizontal, vertical)
+
+
+def check_label_route_clearance(routed_edges: list[RoutedEdge]) -> list[Diagnostic]:
+    """Detect a label mask that sits too close to a different relationship."""
+    out: list[Diagnostic] = []
+    for label_index, labeled in enumerate(routed_edges):
+        if not labeled.edge.label:
+            continue
+        label_box = _edge_label_box(labeled)
+        for route_index, routed in enumerate(routed_edges):
+            if route_index == label_index:
+                continue
+            for segment_index, (start, end) in enumerate(
+                zip(routed.points, routed.points[1:])
+            ):
+                clearance = _box_clearance(label_box, _segment_box(start, end))
+                if clearance >= LABEL_ROUTE_CLEARANCE:
+                    continue
+                out.append(
+                    Diagnostic(
+                        code="composition/label-route-clearance",
+                        severity=SEVERITY_WARNING,
+                        message=(
+                            f"label on edge {labeled.edge.src!r}->{labeled.edge.dst!r} "
+                            f"is {clearance:g}px from route "
+                            f"{routed.edge.src!r}->{routed.edge.dst!r}"
+                        ),
+                        subject={
+                            "label_edge": {
+                                "from": labeled.edge.src,
+                                "to": labeled.edge.dst,
+                            },
+                            "route_edge": {
+                                "from": routed.edge.src,
+                                "to": routed.edge.dst,
+                            },
+                        },
+                        evidence={
+                            "label_box": _box_evidence(label_box),
+                            "route_segment": segment_index,
+                            "clearance": clearance,
+                            "minimum": LABEL_ROUTE_CLEARANCE,
+                        },
+                        supported_fixes=(
+                            "reorder the affected nodes within their ranks",
+                            "shorten the edge label",
+                        ),
+                    )
+                )
+    return out
+
+
 def check_layout(
     spec: Spec, node_boxes: dict[str, Box], zone_boxes: dict[str, Box]
 ) -> list[Diagnostic]:
@@ -1374,7 +1454,7 @@ def _edge_svg(routed: RoutedEdge) -> str:
     if e.label:
         mx, my = routed.label_pos
         parts.append(
-            f'<text x="{mx:g}" y="{my:g}" font-size="10" fill="{color}">{_escape(e.label)}</text>'
+            f'<text x="{mx:g}" y="{my:g}" font-size="{EDGE_LABEL_FONT_SIZE:g}" fill="{color}">{_escape(e.label)}</text>'
         )
     parts.append("</g>")
     return "".join(parts)
@@ -1523,6 +1603,7 @@ def render(
     diagnostics += check_edge_through_node(node_boxes, routed_edges)
     diagnostics += check_proper_crossings(routed_edges)
     diagnostics += check_ambiguous_corridors(routed_edges)
+    diagnostics += check_label_route_clearance(routed_edges)
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -58,6 +58,9 @@ ARROW_HEAD_LENGTH = 6.0
 # a segment between two turns needs 16px to remain visually distinguishable.
 MIN_ROUTE_SEGMENT = 8.0
 MIN_INTERIOR_ROUTE_SEGMENT = 16.0
+# A route passing within two pixels of an unrelated node visually reads as
+# entering it. Expand every unrelated node by this clearance before testing.
+NODE_ROUTE_CLEARANCE = 2.0
 
 
 EDGE_COLORS = {
@@ -890,6 +893,76 @@ def check_route_rhythm(routed_edges: list[RoutedEdge]) -> list[Diagnostic]:
     return out
 
 
+def _expanded_box(box: Box, clearance: float) -> Box:
+    return Box(
+        box.x - clearance,
+        box.y - clearance,
+        box.w + 2 * clearance,
+        box.h + 2 * clearance,
+    )
+
+
+def _segment_intersects_box(
+    start: tuple[float, float], end: tuple[float, float], box: Box
+) -> bool:
+    x0, y0 = start
+    x1, y1 = end
+    if x0 == x1:
+        return box.x <= x0 <= box.x2 and max(min(y0, y1), box.y) <= min(
+            max(y0, y1), box.y2
+        )
+    if y0 == y1:
+        return box.y <= y0 <= box.y2 and max(min(x0, x1), box.x) <= min(
+            max(x0, x1), box.x2
+        )
+    raise ValueError("route segments must be orthogonal")
+
+
+def check_edge_through_node(
+    node_boxes: dict[str, Box], routed_edges: list[RoutedEdge]
+) -> list[Diagnostic]:
+    """Detect an unrelated node that touches a route or its 2px clearance."""
+    out: list[Diagnostic] = []
+    for routed in routed_edges:
+        edge = routed.edge
+        for node_id, node_box in node_boxes.items():
+            if node_id in (edge.src, edge.dst):
+                continue
+            expanded = _expanded_box(node_box, NODE_ROUTE_CLEARANCE)
+            for segment_index, (start, end) in enumerate(
+                zip(routed.points, routed.points[1:])
+            ):
+                if not _segment_intersects_box(start, end, expanded):
+                    continue
+                out.append(
+                    Diagnostic(
+                        code="composition/edge-through-node",
+                        severity=SEVERITY_WARNING,
+                        message=(
+                            f"edge {edge.src!r}->{edge.dst!r} crosses the "
+                            f"clearance around unrelated node {node_id!r}"
+                        ),
+                        subject={
+                            "from": edge.src,
+                            "to": edge.dst,
+                            "node": node_id,
+                        },
+                        evidence={
+                            "segment_index": segment_index,
+                            "start": list(start),
+                            "end": list(end),
+                            "clearance": NODE_ROUTE_CLEARANCE,
+                            "node_box": _box_evidence(node_box),
+                        },
+                        supported_fixes=(
+                            "split the flow into separate ranks with an intermediate node",
+                            "remove the unrelated connection",
+                        ),
+                    )
+                )
+    return out
+
+
 def check_layout(
     spec: Spec, node_boxes: dict[str, Box], zone_boxes: dict[str, Box]
 ) -> list[Diagnostic]:
@@ -1289,6 +1362,7 @@ def render(
     diagnostics += check_layout(spec, node_boxes, zone_boxes)
     routed_edges = route_edges(spec, node_boxes)
     diagnostics += check_route_rhythm(routed_edges)
+    diagnostics += check_edge_through_node(node_boxes, routed_edges)
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -64,6 +64,9 @@ NODE_ROUTE_CLEARANCE = 2.0
 # Cross-product signs closer than this are endpoint touches or collinear runs,
 # not an interior X that makes two unrelated relationships ambiguous.
 PROPER_CROSSING_EPSILON = 1e-4
+# Unrelated collinear paths sharing eight pixels or more read as one ambiguous
+# corridor rather than distinct connections.
+MIN_AMBIGUOUS_CORRIDOR = 8.0
 
 
 EDGE_COLORS = {
@@ -1045,6 +1048,79 @@ def check_proper_crossings(routed_edges: list[RoutedEdge]) -> list[Diagnostic]:
     return out
 
 
+def _collinear_overlap(
+    first_start: tuple[float, float],
+    first_end: tuple[float, float],
+    second_start: tuple[float, float],
+    second_end: tuple[float, float],
+) -> float:
+    if first_start[1] == first_end[1] == second_start[1] == second_end[1]:
+        return max(
+            0.0,
+            min(max(first_start[0], first_end[0]), max(second_start[0], second_end[0]))
+            - max(
+                min(first_start[0], first_end[0]), min(second_start[0], second_end[0])
+            ),
+        )
+    if first_start[0] == first_end[0] == second_start[0] == second_end[0]:
+        return max(
+            0.0,
+            min(max(first_start[1], first_end[1]), max(second_start[1], second_end[1]))
+            - max(
+                min(first_start[1], first_end[1]), min(second_start[1], second_end[1])
+            ),
+        )
+    return 0.0
+
+
+def check_ambiguous_corridors(routed_edges: list[RoutedEdge]) -> list[Diagnostic]:
+    """Find long collinear overlaps between relationships with no shared node."""
+    out: list[Diagnostic] = []
+    for first_index, first in enumerate(routed_edges):
+        for second in routed_edges[first_index + 1 :]:
+            if _related_edges(first.edge, second.edge):
+                continue
+            for first_segment, (first_start, first_end) in enumerate(
+                zip(first.points, first.points[1:])
+            ):
+                for second_segment, (second_start, second_end) in enumerate(
+                    zip(second.points, second.points[1:])
+                ):
+                    overlap = _collinear_overlap(
+                        first_start, first_end, second_start, second_end
+                    )
+                    if overlap < MIN_AMBIGUOUS_CORRIDOR:
+                        continue
+                    out.append(
+                        Diagnostic(
+                            code="composition/ambiguous-corridor",
+                            severity=SEVERITY_WARNING,
+                            message=(
+                                f"unrelated edges {first.edge.src!r}->{first.edge.dst!r} "
+                                f"and {second.edge.src!r}->{second.edge.dst!r} share "
+                                f"{overlap:g}px of route"
+                            ),
+                            subject={
+                                "edges": [
+                                    {"from": first.edge.src, "to": first.edge.dst},
+                                    {"from": second.edge.src, "to": second.edge.dst},
+                                ]
+                            },
+                            evidence={
+                                "first_segment": first_segment,
+                                "second_segment": second_segment,
+                                "overlap": overlap,
+                                "minimum": MIN_AMBIGUOUS_CORRIDOR,
+                            },
+                            supported_fixes=(
+                                "reorder the affected nodes within their ranks",
+                                "split one relationship through an intermediate node",
+                            ),
+                        )
+                    )
+    return out
+
+
 def check_layout(
     spec: Spec, node_boxes: dict[str, Box], zone_boxes: dict[str, Box]
 ) -> list[Diagnostic]:
@@ -1446,6 +1522,7 @@ def render(
     diagnostics += check_route_rhythm(routed_edges)
     diagnostics += check_edge_through_node(node_boxes, routed_edges)
     diagnostics += check_proper_crossings(routed_edges)
+    diagnostics += check_ambiguous_corridors(routed_edges)
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -61,6 +61,9 @@ MIN_INTERIOR_ROUTE_SEGMENT = 16.0
 # A route passing within two pixels of an unrelated node visually reads as
 # entering it. Expand every unrelated node by this clearance before testing.
 NODE_ROUTE_CLEARANCE = 2.0
+# Cross-product signs closer than this are endpoint touches or collinear runs,
+# not an interior X that makes two unrelated relationships ambiguous.
+PROPER_CROSSING_EPSILON = 1e-4
 
 
 EDGE_COLORS = {
@@ -963,6 +966,85 @@ def check_edge_through_node(
     return out
 
 
+def _cross_product(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    point: tuple[float, float],
+) -> float:
+    return (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (
+        point[0] - start[0]
+    )
+
+
+def _properly_crosses(
+    first_start: tuple[float, float],
+    first_end: tuple[float, float],
+    second_start: tuple[float, float],
+    second_end: tuple[float, float],
+) -> bool:
+    first_a = _cross_product(first_start, first_end, second_start)
+    first_b = _cross_product(first_start, first_end, second_end)
+    second_a = _cross_product(second_start, second_end, first_start)
+    second_b = _cross_product(second_start, second_end, first_end)
+    epsilon = PROPER_CROSSING_EPSILON
+    return (
+        (first_a > epsilon and first_b < -epsilon)
+        or (first_a < -epsilon and first_b > epsilon)
+    ) and (
+        (second_a > epsilon and second_b < -epsilon)
+        or (second_a < -epsilon and second_b > epsilon)
+    )
+
+
+def _related_edges(first: Edge, second: Edge) -> bool:
+    return bool({first.src, first.dst} & {second.src, second.dst})
+
+
+def check_proper_crossings(routed_edges: list[RoutedEdge]) -> list[Diagnostic]:
+    """Find interior X crossings between relationships with no shared node."""
+    out: list[Diagnostic] = []
+    for first_index, first in enumerate(routed_edges):
+        for second in routed_edges[first_index + 1 :]:
+            if _related_edges(first.edge, second.edge):
+                continue
+            for first_segment, (first_start, first_end) in enumerate(
+                zip(first.points, first.points[1:])
+            ):
+                for second_segment, (second_start, second_end) in enumerate(
+                    zip(second.points, second.points[1:])
+                ):
+                    if not _properly_crosses(
+                        first_start, first_end, second_start, second_end
+                    ):
+                        continue
+                    out.append(
+                        Diagnostic(
+                            code="composition/proper-crossing",
+                            severity=SEVERITY_WARNING,
+                            message=(
+                                f"unrelated edges {first.edge.src!r}->{first.edge.dst!r} "
+                                f"and {second.edge.src!r}->{second.edge.dst!r} cross"
+                            ),
+                            subject={
+                                "edges": [
+                                    {"from": first.edge.src, "to": first.edge.dst},
+                                    {"from": second.edge.src, "to": second.edge.dst},
+                                ]
+                            },
+                            evidence={
+                                "first_segment": first_segment,
+                                "second_segment": second_segment,
+                                "epsilon": PROPER_CROSSING_EPSILON,
+                            },
+                            supported_fixes=(
+                                "reorder the affected nodes within their ranks",
+                                "split one relationship through an intermediate node",
+                            ),
+                        )
+                    )
+    return out
+
+
 def check_layout(
     spec: Spec, node_boxes: dict[str, Box], zone_boxes: dict[str, Box]
 ) -> list[Diagnostic]:
@@ -1363,6 +1445,7 @@ def render(
     routed_edges = route_edges(spec, node_boxes)
     diagnostics += check_route_rhythm(routed_edges)
     diagnostics += check_edge_through_node(node_boxes, routed_edges)
+    diagnostics += check_proper_crossings(routed_edges)
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -22,6 +22,7 @@ from render import (
     assign_ranks,
     check_editability,
     check_layout,
+    check_edge_through_node,
     check_route_rhythm,
     compute_positions,
     compute_zone_boxes,
@@ -521,6 +522,59 @@ class TestRouting:
         second = do_render(spec, _icon_lookup)
 
         assert first.svg == second.svg
+
+
+class TestEdgeThroughNode:
+    def _route(self) -> RoutedEdge:
+        return RoutedEdge(
+            edge=Edge("a", "b"),
+            points=((0, 10), (40, 10)),
+            label_pos=(0, 0),
+        )
+
+    def test_reports_unrelated_node_within_clearance(self) -> None:
+        node_boxes = {
+            "a": Box(-10, 0, 10, 20),
+            "b": Box(40, 0, 10, 20),
+            "c": Box(15, 5, 10, 10),
+        }
+
+        findings = check_edge_through_node(node_boxes, [self._route()])
+
+        assert [d.code for d in findings] == ["composition/edge-through-node"]
+        assert findings[0].subject == {"from": "a", "to": "b", "node": "c"}
+
+    def test_clearance_boundary_and_endpoint_exemption(self) -> None:
+        route = self._route()
+        at_clearance = {
+            "a": Box(-10, 0, 10, 20),
+            "b": Box(40, 0, 10, 20),
+            "c": Box(15, 12, 10, 10),
+        }
+        beyond_clearance = {
+            "a": Box(-10, 0, 10, 20),
+            "b": Box(40, 0, 10, 20),
+            "c": Box(15, 12.01, 10, 10),
+        }
+
+        assert [d.code for d in check_edge_through_node(at_clearance, [route])] == [
+            "composition/edge-through-node"
+        ]
+        assert check_edge_through_node(beyond_clearance, [route]) == []
+
+    def test_quality_profiles_change_edge_through_node_severity(self) -> None:
+        node_boxes = {
+            "a": Box(-10, 0, 10, 20),
+            "b": Box(40, 0, 10, 20),
+            "c": Box(15, 5, 10, 10),
+        }
+        findings = check_edge_through_node(node_boxes, [self._route()])
+
+        standard = render.apply_quality_profile(findings, "standard")
+        showcase = render.apply_quality_profile(findings, "showcase")
+
+        assert [d.severity for d in standard] == ["warning"]
+        assert [d.severity for d in showcase] == ["error"]
 
 
 class TestEditabilityCheck:

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -24,6 +24,7 @@ from render import (
     check_layout,
     check_edge_through_node,
     check_ambiguous_corridors,
+    check_label_route_clearance,
     check_route_rhythm,
     check_proper_crossings,
     compute_positions,
@@ -642,6 +643,38 @@ class TestAmbiguousCorridor:
 
     def test_quality_profiles_change_corridor_severity(self) -> None:
         findings = check_ambiguous_corridors(self._routes(12))
+
+        standard = render.apply_quality_profile(findings, "standard")
+        showcase = render.apply_quality_profile(findings, "showcase")
+
+        assert [d.severity for d in standard] == ["warning"]
+        assert [d.severity for d in showcase] == ["error"]
+
+
+class TestLabelRouteClearance:
+    def _routes(self, route_y: float) -> list[RoutedEdge]:
+        return [
+            RoutedEdge(Edge("a", "b", label="X"), ((0, 0), (20, 0)), (0, 10)),
+            RoutedEdge(Edge("c", "d"), ((0, route_y), (20, route_y)), (0, 0)),
+        ]
+
+    def test_reports_other_route_inside_label_clearance(self) -> None:
+        findings = check_label_route_clearance(self._routes(13.99))
+
+        assert [d.code for d in findings] == ["composition/label-route-clearance"]
+        assert findings[0].subject["label_edge"] == {"from": "a", "to": "b"}
+        assert findings[0].subject["route_edge"] == {"from": "c", "to": "d"}
+
+    def test_clearance_boundary_and_own_route_are_exempt(self) -> None:
+        own_label_only = [
+            RoutedEdge(Edge("a", "b", label="X"), ((0, 0), (20, 0)), (0, 10))
+        ]
+
+        assert check_label_route_clearance(self._routes(14)) == []
+        assert check_label_route_clearance(own_label_only) == []
+
+    def test_quality_profiles_change_label_clearance_severity(self) -> None:
+        findings = check_label_route_clearance(self._routes(13.99))
 
         standard = render.apply_quality_profile(findings, "standard")
         showcase = render.apply_quality_profile(findings, "showcase")

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -23,6 +23,7 @@ from render import (
     check_editability,
     check_layout,
     check_edge_through_node,
+    check_ambiguous_corridors,
     check_route_rhythm,
     check_proper_crossings,
     compute_positions,
@@ -609,6 +610,38 @@ class TestProperCrossing:
 
     def test_quality_profiles_change_crossing_severity(self) -> None:
         findings = check_proper_crossings(self._crossing_routes())
+
+        standard = render.apply_quality_profile(findings, "standard")
+        showcase = render.apply_quality_profile(findings, "showcase")
+
+        assert [d.severity for d in standard] == ["warning"]
+        assert [d.severity for d in showcase] == ["error"]
+
+
+class TestAmbiguousCorridor:
+    def _routes(self, second_start: float) -> list[RoutedEdge]:
+        return [
+            RoutedEdge(Edge("a", "b"), ((0, 0), (20, 0)), (0, 0)),
+            RoutedEdge(Edge("c", "d"), ((second_start, 0), (30, 0)), (0, 0)),
+        ]
+
+    def test_reports_collinear_overlap_at_threshold(self) -> None:
+        findings = check_ambiguous_corridors(self._routes(12))
+
+        assert [d.code for d in findings] == ["composition/ambiguous-corridor"]
+        assert findings[0].evidence["overlap"] == 8
+
+    def test_shorter_overlap_and_shared_endpoint_are_exempt(self) -> None:
+        shared_endpoint = [
+            RoutedEdge(Edge("a", "b"), ((0, 0), (20, 0)), (0, 0)),
+            RoutedEdge(Edge("b", "c"), ((12, 0), (30, 0)), (0, 0)),
+        ]
+
+        assert check_ambiguous_corridors(self._routes(12.01)) == []
+        assert check_ambiguous_corridors(shared_endpoint) == []
+
+    def test_quality_profiles_change_corridor_severity(self) -> None:
+        findings = check_ambiguous_corridors(self._routes(12))
 
         standard = render.apply_quality_profile(findings, "standard")
         showcase = render.apply_quality_profile(findings, "showcase")

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -24,6 +24,7 @@ from render import (
     check_layout,
     check_edge_through_node,
     check_route_rhythm,
+    check_proper_crossings,
     compute_positions,
     compute_zone_boxes,
     icon_box,
@@ -569,6 +570,45 @@ class TestEdgeThroughNode:
             "c": Box(15, 5, 10, 10),
         }
         findings = check_edge_through_node(node_boxes, [self._route()])
+
+        standard = render.apply_quality_profile(findings, "standard")
+        showcase = render.apply_quality_profile(findings, "showcase")
+
+        assert [d.severity for d in standard] == ["warning"]
+        assert [d.severity for d in showcase] == ["error"]
+
+
+class TestProperCrossing:
+    def _crossing_routes(self) -> list[RoutedEdge]:
+        return [
+            RoutedEdge(Edge("a", "b"), ((0, 0), (20, 0)), (0, 0)),
+            RoutedEdge(Edge("c", "d"), ((10, -10), (10, 10)), (0, 0)),
+        ]
+
+    def test_reports_interior_crossing_between_unrelated_edges(self) -> None:
+        findings = check_proper_crossings(self._crossing_routes())
+
+        assert [d.code for d in findings] == ["composition/proper-crossing"]
+        assert findings[0].subject["edges"] == [
+            {"from": "a", "to": "b"},
+            {"from": "c", "to": "d"},
+        ]
+
+    def test_shared_endpoint_and_touch_are_exempt(self) -> None:
+        shared_endpoint = [
+            RoutedEdge(Edge("a", "b"), ((0, 0), (20, 0)), (0, 0)),
+            RoutedEdge(Edge("b", "c"), ((20, -10), (20, 10)), (0, 0)),
+        ]
+        endpoint_touch = [
+            RoutedEdge(Edge("a", "b"), ((0, 0), (20, 0)), (0, 0)),
+            RoutedEdge(Edge("c", "d"), ((20, -10), (20, 10)), (0, 0)),
+        ]
+
+        assert check_proper_crossings(shared_endpoint) == []
+        assert check_proper_crossings(endpoint_touch) == []
+
+    def test_quality_profiles_change_crossing_severity(self) -> None:
+        findings = check_proper_crossings(self._crossing_routes())
 
         standard = render.apply_quality_profile(findings, "standard")
         showcase = render.apply_quality_profile(findings, "showcase")


### PR DESCRIPTION
## Summary

- Detect edge-through-node, proper-crossing, ambiguous-corridor, and label-route-clearance failures from route geometry.
- Emit each finding as a profile-sensitive composition diagnostic with spec-level repairs.
- Cover failure and threshold boundaries for every geometry rule.

## Stack

Stack-Id: diagram-geometry-7c3f2d
Base: feat/diagram-port-spread
Position: 2/3

1. feat/diagram-port-spread -> #123
2. feat/diagram-composition-checks -> this PR
3. feat/diagram-label-fit -> #125

Depends on: #123
Upstack: #125

## Validation

- uv run python -m pytest skills/architecture-diagram/tests/test_render.py -q (106 passed at this slice)
- uv run ruff check skills/architecture-diagram/scripts/render.py skills/architecture-diagram/tests/test_render.py
