### PR TITLE
fix(architecture-diagram)!: never overwrite a good artifact with a failed render

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -47,12 +47,17 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
 2. **Resolve services to icons.** For each cloud component, read `references/services-aws.yaml`, `references/services-azure.yaml`, or `references/services-gcp.yaml` (whichever matches its provider) — or `references/icons-generic.md` for non-cloud — and note the exact slug to use as that node's `service` field. If a service genuinely has no icon in that provider's set (documented per-provider in each table), either pick the closest sibling category or leave `service` unset — the renderer falls back to a labeled placeholder rather than a wrong icon.
 3. **Ensure the icon cache is warm** for every provider used (see Prerequisites). Skip this for `provider: generic`.
 4. **Author the spec** — a small YAML file per `references/spec-format.md`: `title`, `direction` (`LR`/`TB`), `zones` (with `parent` for nesting), `nodes` (`id`, `label`, `service`, `zone`, `color`), `edges` (`from`, `to`, `label`, `type`).
-5. **Render:**
+5. **Validate without writing an artifact:**
    ```bash
-   python3 scripts/render.py spec.yaml -o diagram.svg
+   python3 scripts/render.py validate spec.yaml --quality showcase --json
    ```
-   Act on the exit code, not on prose — see Exit codes below. Every finding names a spec field to change; never repair one by editing the SVG.
-6. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
+   The receipt contains exact spec and candidate-artifact SHA-256 digests, validation counts, quality profile, composition status, and coded diagnostics. `validate` never touches an output path.
+6. **Deliver only a clean candidate:**
+   ```bash
+   python3 scripts/render.py deliver spec.yaml -o diagram.svg --quality showcase --json
+   ```
+   `deliver` stages the exact spec and candidate SVG beside the target, then atomically replaces the target only after every check passes. Every failure leaves a previous artifact unchanged.
+7. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
 
 ## Spec fields at a glance
 
@@ -201,11 +206,11 @@ Every finding is a coded diagnostic carrying `code`, `severity`, `message`, `sub
 
 | Exit | Meaning | Action |
 |---|---|---|
-| 0 | No error-severity findings | Hand off the SVG; any warnings are deliberate, explainable tradeoffs |
-| 1 | A blocking finding, or a spec the renderer cannot answer | Apply one of the finding's `supported_fixes` to the spec and rerun |
-| 2 | Usage error — unreadable spec path, unknown flag or profile value | Correct the command |
+| 0 | `validate` completed with no error findings, or `deliver` atomically committed a validated SVG | Hand off the receipt or SVG; any warnings are deliberate, explainable tradeoffs |
+| 1 | A blocking finding or operational delivery failure | Apply a diagnostic's `supported_fixes`, or correct the output path or filesystem permissions |
+| 2 | Usage error — missing subcommand, unreadable spec path, unknown flag or profile value | Correct the command |
 
-`--json` prints the whole envelope (`schema_version`, `ok`, `quality`, `output`, `written`, `artifact_bytes`, `counts`, `diagnostics`) to stdout and nothing else. `--quality showcase` raises `composition/*` route-geometry findings to errors; the default `standard` keeps them as warnings.
+`--json` prints the receipt and nothing else on stdout. It contains `input` and `artifact` SHA-256/byte records, `output.written`, `validation.checks_passed`/`checks_total`, quality, composition status, severity counts, and diagnostics. `--quality showcase` raises `composition/*` route-geometry findings to errors; the default `standard` keeps them as warnings.
 
 | Code | Meaning | Fix |
 |---|---|---|

--- a/skills/architecture-diagram/references/editability.md
+++ b/skills/architecture-diagram/references/editability.md
@@ -20,7 +20,7 @@ _FORBIDDEN_MARKERS = ("<image", "base64,", "<use ", "<use>")
 
 Plus a check for any `href="http..."` or `xlink:href="http..."` — an external reference the file depends on network access to resolve, which breaks the moment the SVG is moved, emailed, or committed somewhere the referenced URL isn't reachable.
 
-If any of these appear in the output, `render.py`'s CLI exits with status 1 and prints an `editability violation` warning even though a file was still written — treat this as a bug in the renderer, not something to route around by hand-editing the SVG afterward. It should not happen; the icon pipeline was built specifically to avoid every one of these failure modes, and the tests in `tests/test_render.py::TestEditabilityCheck` and the end-to-end assertions in `TestEndToEndRender` exist to catch a regression before it ships.
+If any of these appear in a candidate, `validate` and `deliver` exit with status 1 and report an `editability` diagnostic. `deliver` never replaces an existing SVG when that happens — treat it as a renderer bug, not something to route around by hand-editing the SVG afterward. It should not happen; the icon pipeline was built specifically to avoid every one of these failure modes, and the tests in `tests/test_render.py::TestEditabilityCheck` and the end-to-end assertions in `TestEndToEndRender` exist to catch a regression.
 
 ## What this buys, concretely
 

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -22,8 +22,11 @@ in Figma/Illustrator/Inkscape, and labels stay real `<text>`, never outlined.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import sys
+import tempfile
 from math import hypot
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1658,46 +1661,355 @@ EXIT_OK = 0
 EXIT_FAILURE = 1
 EXIT_USAGE = 2
 
+RECEIPT_SCHEMA_VERSION = 1
+_VALIDATION_CHECKS = (
+    "spec",
+    "layout",
+    "route-rhythm",
+    "edge-through-node",
+    "proper-crossing",
+    "ambiguous-corridor",
+    "label-route-clearance",
+    "icons",
+    "labels",
+    "editability",
+)
 
-def _envelope(
-    ok: bool,
-    quality: str,
-    diagnostics: list[Diagnostic],
-    output: Path | None = None,
-    artifact_bytes: int | None = None,
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _check_name(diagnostic: Diagnostic) -> str:
+    code = diagnostic.code
+    if code.startswith("spec/"):
+        return "spec"
+    if code in ("layout/node-overlap", "layout/zone-overlap"):
+        return "layout"
+    if code == "layout/label-overflow":
+        return "labels"
+    if code.startswith("composition/micro-segment") or code.startswith(
+        "composition/short-interior-segment"
+    ):
+        return "route-rhythm"
+    if code == "composition/edge-through-node":
+        return "edge-through-node"
+    if code == "composition/proper-crossing":
+        return "proper-crossing"
+    if code == "composition/ambiguous-corridor":
+        return "ambiguous-corridor"
+    if code == "composition/label-route-clearance":
+        return "label-route-clearance"
+    if code.startswith("icon/"):
+        return "icons"
+    return "editability"
+
+
+def _validation_receipt(
+    diagnostics: list[Diagnostic], quality: str
 ) -> dict[str, object]:
+    counts = count_by_severity(diagnostics)
+    composition = [d for d in diagnostics if d.code.startswith("composition/")]
+    if any(d.severity == SEVERITY_ERROR for d in composition):
+        composition_status = "failed"
+    elif composition:
+        composition_status = "warnings"
+    else:
+        composition_status = "passed"
+    failed_checks = {
+        _check_name(d) for d in diagnostics if d.severity == SEVERITY_ERROR
+    }
     return {
-        "schema_version": DIAGNOSTIC_SCHEMA_VERSION,
-        "ok": ok,
+        "checks_passed": len(_VALIDATION_CHECKS) - len(failed_checks),
+        "checks_total": len(_VALIDATION_CHECKS),
         "quality": quality,
-        "output": str(output) if output is not None else None,
-        "written": artifact_bytes is not None,
-        "artifact_bytes": artifact_bytes,
-        "counts": count_by_severity(diagnostics),
-        "diagnostics": [d.to_dict() for d in diagnostics],
+        "composition_status": composition_status,
+        "errors": counts["errors"],
+        "warnings": counts["warnings"],
     }
 
 
+def _receipt(
+    command: str,
+    input_path: Path,
+    input_bytes: bytes | None,
+    artifact_bytes: bytes | None,
+    diagnostics: list[Diagnostic],
+    quality: str,
+    output: Path | None = None,
+    written: bool = False,
+    delivery_stage: str | None = None,
+) -> dict[str, object]:
+    receipt: dict[str, object] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
+        "command": command,
+        "type": "architecture-diagram",
+        "input": {
+            "path": str(input_path),
+            "sha256": _sha256(input_bytes) if input_bytes is not None else None,
+            "bytes": len(input_bytes) if input_bytes is not None else None,
+        },
+        "artifact": {
+            "sha256": _sha256(artifact_bytes) if artifact_bytes is not None else None,
+            "bytes": len(artifact_bytes) if artifact_bytes is not None else None,
+        },
+        "output": {
+            "path": str(output) if output is not None else None,
+            "written": written,
+        },
+        "validation": _validation_receipt(diagnostics, quality),
+        "diagnostics": [d.to_dict() for d in diagnostics],
+    }
+    if delivery_stage is not None:
+        receipt["delivery_stage"] = delivery_stage
+    return receipt
+
+
 def _report(
-    envelope: dict[str, object], as_json: bool, diagnostics: list[Diagnostic]
+    receipt: dict[str, object], as_json: bool, diagnostics: list[Diagnostic]
 ) -> None:
-    """Under --json, stdout carries the envelope and nothing else, so a
-    caller can parse it without stripping human lines."""
+    """Under --json, stdout carries the receipt and nothing else."""
     if as_json:
-        print(json.dumps(envelope, indent=2, sort_keys=True))
+        print(json.dumps(receipt, indent=2, sort_keys=True))
         return
-    if envelope["written"]:
-        print(f"wrote {envelope['output']} ({envelope['artifact_bytes']} bytes)")
+    output = receipt["output"]
+    assert isinstance(output, dict)
+    if output["written"]:
+        artifact = receipt["artifact"]
+        assert isinstance(artifact, dict)
+        print(f"wrote {output['path']} ({artifact['bytes']} bytes)")
     for d in diagnostics:
         print(f"{d.severity}: [{d.code}] {d.message}", file=sys.stderr)
         for fix in d.supported_fixes:
             print(f"  fix: {fix}", file=sys.stderr)
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("spec", type=Path, help="path to a YAML spec")
-    parser.add_argument("-o", "--output", type=Path, default=Path("diagram.svg"))
+def _input_failure(
+    command: str, spec_path: Path, output: Path | None, quality: str, exc: Exception
+) -> tuple[int, dict[str, object], list[Diagnostic]]:
+    diagnostic = Diagnostic(
+        code="usage/spec-unreadable",
+        severity=SEVERITY_ERROR,
+        message=f"cannot read spec {str(spec_path)!r}: {exc}",
+        subject={"path": str(spec_path)},
+        supported_fixes=("pass the path to an existing UTF-8 YAML spec",),
+    )
+    return (
+        EXIT_USAGE,
+        _receipt(
+            command,
+            spec_path,
+            None,
+            None,
+            [diagnostic],
+            quality,
+            output=output,
+            delivery_stage="input",
+        ),
+        [diagnostic],
+    )
+
+
+def _read_spec(
+    command: str, spec_path: Path, output: Path | None, quality: str
+) -> tuple[bytes, str] | tuple[int, dict[str, object], list[Diagnostic]]:
+    try:
+        source = spec_path.read_bytes()
+        return source, source.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return _input_failure(command, spec_path, output, quality, exc)
+
+
+def _icon_lookup(cache_dir: Path | None, sha: str | None) -> IconLookup:
+    import fetch_icons  # local import keeps pure layout tests network-free
+
+    selected_cache_dir = cache_dir or fetch_icons.default_cache_dir()
+    selected_sha = sha or fetch_icons.DRAWIO_SHA
+    return CompositeIconLookup(
+        [
+            CacheIconLookup(cache_dir=selected_cache_dir, sha=selected_sha),
+            BundledGenericIconLookup(),
+        ]
+    )
+
+
+def _render_candidate(
+    spec_text: str, lookup: IconLookup, quality: str
+) -> tuple[RenderResult | None, bytes | None, list[Diagnostic]]:
+    try:
+        spec = load_spec(spec_text)
+    except SpecError as exc:
+        return None, None, [exc.diagnostic]
+    result = render(spec, lookup, quality=quality)
+    return result, result.svg.encode("utf-8"), result.diagnostics
+
+
+def _validate(
+    spec_path: Path,
+    cache_dir: Path | None,
+    sha: str | None,
+    quality: str,
+) -> tuple[int, dict[str, object], list[Diagnostic]]:
+    loaded = _read_spec("validate", spec_path, None, quality)
+    if len(loaded) == 3:
+        return loaded
+    spec_bytes, spec_text = loaded
+    result, artifact_bytes, diagnostics = _render_candidate(
+        spec_text, _icon_lookup(cache_dir, sha), quality
+    )
+    if artifact_bytes is not None:
+        with tempfile.TemporaryDirectory(
+            prefix=".architecture-diagram-validate-"
+        ) as path:
+            candidate = Path(path) / "candidate.svg"
+            candidate.write_bytes(artifact_bytes)
+            artifact_bytes = candidate.read_bytes()
+    receipt = _receipt(
+        "validate",
+        spec_path,
+        spec_bytes,
+        artifact_bytes,
+        diagnostics,
+        quality,
+        delivery_stage="check" if result is not None and not result.ok else None,
+    )
+    return (EXIT_OK if receipt["ok"] else EXIT_FAILURE), receipt, diagnostics
+
+
+def _delivery_failure(
+    spec_path: Path,
+    spec_bytes: bytes | None,
+    artifact_bytes: bytes | None,
+    output: Path,
+    quality: str,
+    stage: str,
+    exc: Exception,
+) -> tuple[int, dict[str, object], list[Diagnostic]]:
+    diagnostic = Diagnostic(
+        code=f"delivery/{stage}-failed",
+        severity=SEVERITY_ERROR,
+        message=f"delivery {stage} failed: {exc}",
+        subject={"output": str(output)},
+        supported_fixes=(
+            "correct the output path or filesystem permissions and rerun delivery",
+        ),
+    )
+    return (
+        EXIT_FAILURE,
+        _receipt(
+            "deliver",
+            spec_path,
+            spec_bytes,
+            artifact_bytes,
+            [diagnostic],
+            quality,
+            output=output,
+            delivery_stage=stage,
+        ),
+        [diagnostic],
+    )
+
+
+def _deliver(
+    spec_path: Path,
+    output: Path,
+    cache_dir: Path | None,
+    sha: str | None,
+    quality: str,
+) -> tuple[int, dict[str, object], list[Diagnostic]]:
+    loaded = _read_spec("deliver", spec_path, output, quality)
+    if len(loaded) == 3:
+        return loaded
+    spec_bytes, spec_text = loaded
+    output_parent = output.parent
+    try:
+        if not output_parent.is_dir():
+            raise OSError(f"output directory does not exist: {output_parent}")
+        with tempfile.TemporaryDirectory(
+            prefix=".architecture-diagram-delivery-", dir=output_parent
+        ) as stage_name:
+            stage_dir = Path(stage_name)
+            if os.stat(stage_dir).st_dev != os.stat(output_parent).st_dev:
+                raise OSError("staging directory is not on the output filesystem")
+            (stage_dir / "specification.yaml").write_bytes(spec_bytes)
+            result, artifact_bytes, diagnostics = _render_candidate(
+                spec_text, _icon_lookup(cache_dir, sha), quality
+            )
+            if artifact_bytes is None:
+                receipt = _receipt(
+                    "deliver",
+                    spec_path,
+                    spec_bytes,
+                    None,
+                    diagnostics,
+                    quality,
+                    output=output,
+                    delivery_stage="render",
+                )
+                return EXIT_FAILURE, receipt, diagnostics
+            candidate = stage_dir / "candidate.svg"
+            candidate.write_bytes(artifact_bytes)
+            if os.stat(candidate).st_dev != os.stat(output_parent).st_dev:
+                raise OSError("candidate artifact is not on the output filesystem")
+            if result is None or not result.ok:
+                receipt = _receipt(
+                    "deliver",
+                    spec_path,
+                    spec_bytes,
+                    artifact_bytes,
+                    diagnostics,
+                    quality,
+                    output=output,
+                    delivery_stage="check",
+                )
+                return EXIT_FAILURE, receipt, diagnostics
+            receipt = _receipt(
+                "deliver",
+                spec_path,
+                spec_bytes,
+                artifact_bytes,
+                diagnostics,
+                quality,
+                output=output,
+                written=True,
+                delivery_stage="commit",
+            )
+            try:
+                (stage_dir / "receipt.json").write_text(
+                    json.dumps(receipt, indent=2, sort_keys=True)
+                )
+            except OSError as exc:
+                return _delivery_failure(
+                    spec_path,
+                    spec_bytes,
+                    artifact_bytes,
+                    output,
+                    quality,
+                    "receipt",
+                    exc,
+                )
+            try:
+                os.replace(candidate, output)
+            except OSError as exc:
+                return _delivery_failure(
+                    spec_path,
+                    spec_bytes,
+                    artifact_bytes,
+                    output,
+                    quality,
+                    "commit",
+                    exc,
+                )
+            return EXIT_OK, receipt, diagnostics
+    except OSError as exc:
+        return _delivery_failure(
+            spec_path, spec_bytes, None, output, quality, "prepare", exc
+        )
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("spec", type=Path, help="path to a UTF-8 YAML spec")
     parser.add_argument("--cache-dir", type=Path, default=None)
     parser.add_argument("--sha", default=None)
     parser.add_argument(
@@ -1710,50 +2022,36 @@ def main(argv: list[str] | None = None) -> int:
         "--json",
         dest="as_json",
         action="store_true",
-        help="print the diagnostic envelope to stdout and nothing else",
+        help="print the machine-readable receipt to stdout and nothing else",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate_parser = commands.add_parser(
+        "validate", help="render and validate without writing an output artifact"
+    )
+    _add_common_arguments(validate_parser)
+    deliver_parser = commands.add_parser(
+        "deliver", help="validate, stage, and atomically commit an SVG artifact"
+    )
+    _add_common_arguments(deliver_parser)
+    deliver_parser.add_argument(
+        "-o", "--output", type=Path, required=True, help="target SVG path"
     )
     args = parser.parse_args(argv)
 
-    try:
-        spec_text = args.spec.read_text()
-    except OSError as exc:
-        unreadable = Diagnostic(
-            code="usage/spec-unreadable",
-            severity=SEVERITY_ERROR,
-            message=f"cannot read spec {str(args.spec)!r}: {exc.strerror or exc}",
-            subject={"path": str(args.spec)},
-            supported_fixes=("pass the path to an existing, readable YAML spec",),
+    if args.command == "validate":
+        code, receipt, diagnostics = _validate(
+            args.spec, args.cache_dir, args.sha, args.quality
         )
-        envelope = _envelope(False, args.quality, [unreadable], args.output)
-        _report(envelope, args.as_json, [unreadable])
-        return EXIT_USAGE
-
-    import fetch_icons  # local import: keeps render.py importable without pulling in networking deps for pure-layout tests
-
-    cache_dir = args.cache_dir or fetch_icons.default_cache_dir()
-    sha = args.sha or fetch_icons.DRAWIO_SHA
-    lookup = CompositeIconLookup(
-        [CacheIconLookup(cache_dir=cache_dir, sha=sha), BundledGenericIconLookup()]
-    )
-
-    try:
-        spec = load_spec(spec_text)
-    except SpecError as exc:
-        envelope = _envelope(False, args.quality, [exc.diagnostic], args.output)
-        _report(envelope, args.as_json, [exc.diagnostic])
-        return EXIT_FAILURE
-
-    result = render(spec, lookup, quality=args.quality)
-    args.output.write_text(result.svg)
-    envelope = _envelope(
-        result.ok,
-        args.quality,
-        result.diagnostics,
-        args.output,
-        artifact_bytes=len(result.svg),
-    )
-    _report(envelope, args.as_json, result.diagnostics)
-    return EXIT_OK if result.ok else EXIT_FAILURE
+    else:
+        code, receipt, diagnostics = _deliver(
+            args.spec, args.output, args.cache_dir, args.sha, args.quality
+        )
+    _report(receipt, args.as_json, diagnostics)
+    return code
 
 
 if __name__ == "__main__":

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -1137,21 +1139,56 @@ class TestCliContract:
         payload = json.loads(captured.out) if "--json" in argv else {}
         return code, payload, captured.err
 
-    def test_clean_render_exits_zero_with_a_parsable_envelope(
+    def test_validate_returns_a_parsable_receipt_without_an_artifact(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("nodes:\n  - id: a\n    label: A\n")
+        code, payload, _ = self._run(
+            capsys, "validate", str(spec), "--cache-dir", str(tmp_path), "--json"
+        )
+
+        assert code == render.EXIT_OK
+        assert payload["ok"] is True
+        assert payload["command"] == "validate"
+        assert payload["input"]["path"] == str(spec)
+        assert payload["input"]["bytes"] == len(spec.read_bytes())
+        assert payload["artifact"]["bytes"] > 0
+        assert payload["output"] == {"path": None, "written": False}
+        assert payload["validation"] == {
+            "checks_passed": 10,
+            "checks_total": 10,
+            "quality": "standard",
+            "composition_status": "passed",
+            "errors": 0,
+            "warnings": 0,
+        }
+        assert payload["diagnostics"] == []
+        assert payload["schema_version"] == render.RECEIPT_SCHEMA_VERSION
+
+    def test_deliver_commits_the_validated_candidate(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         spec = tmp_path / "s.yaml"
         spec.write_text("nodes:\n  - id: a\n    label: A\n")
         out = tmp_path / "d.svg"
         code, payload, _ = self._run(
-            capsys, str(spec), "-o", str(out), "--cache-dir", str(tmp_path), "--json"
+            capsys,
+            "deliver",
+            str(spec),
+            "-o",
+            str(out),
+            "--cache-dir",
+            str(tmp_path),
+            "--json",
         )
+
         assert code == render.EXIT_OK
         assert payload["ok"] is True
-        assert payload["written"] is True
-        assert payload["diagnostics"] == []
-        assert payload["schema_version"] == render.DIAGNOSTIC_SCHEMA_VERSION
-        assert payload["artifact_bytes"] == len(out.read_text())
+        assert payload["command"] == "deliver"
+        assert payload["output"] == {"path": str(out), "written": True}
+        assert payload["artifact"]["bytes"] == len(out.read_bytes())
+        assert payload["artifact"]["sha256"] == render._sha256(out.read_bytes())
 
     def test_json_mode_puts_nothing_but_json_on_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1160,15 +1197,14 @@ class TestCliContract:
         spec.write_text("nodes:\n  - id: a\n    label: A\n    service: ghost\n")
         code, payload, _ = self._run(
             capsys,
+            "validate",
             str(spec),
-            "-o",
-            str(tmp_path / "d.svg"),
             "--cache-dir",
             str(tmp_path),
             "--json",
         )
         # A finding is present, so this also proves diagnostics do not leak to
-        # stdout as prose alongside the envelope.
+        # stdout as prose alongside the receipt.
         assert code == render.EXIT_FAILURE
         assert [d["code"] for d in payload["diagnostics"]] == ["icon/not-found"]
 
@@ -1177,17 +1213,65 @@ class TestCliContract:
     ) -> None:
         spec = tmp_path / "s.yaml"
         spec.write_text("nodes:\n  - id: a\n    label: A\n    service: ghost\n")
-        code, _, err = self._run(
+        out = tmp_path / "d.svg"
+        code, payload, err = self._run(
             capsys,
+            "deliver",
             str(spec),
             "-o",
-            str(tmp_path / "d.svg"),
+            str(out),
             "--cache-dir",
             str(tmp_path),
+            "--json",
         )
         assert code == render.EXIT_FAILURE
-        assert "[icon/not-found]" in err
-        assert "fix: " in err
+        assert payload["delivery_stage"] == "check"
+        assert payload["output"]["written"] is False
+        assert not out.exists()
+        assert err == ""
+
+    def test_failed_showcase_delivery_preserves_the_last_good_artifact(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        good_spec = tmp_path / "good.yaml"
+        good_spec.write_text("nodes:\n  - id: a\n    label: A\n")
+        bad_spec = tmp_path / "bad.yaml"
+        bad_spec.write_text(
+            'nodes:\n  - id: a\n    label: "This Is A Genuinely Very Long Label Text"\n'
+        )
+        out = tmp_path / "diagram.svg"
+
+        good_code, _, _ = self._run(
+            capsys,
+            "deliver",
+            str(good_spec),
+            "-o",
+            str(out),
+            "--cache-dir",
+            str(tmp_path),
+            "--quality",
+            "showcase",
+            "--json",
+        )
+        last_good = out.read_bytes()
+        bad_code, payload, _ = self._run(
+            capsys,
+            "deliver",
+            str(bad_spec),
+            "-o",
+            str(out),
+            "--cache-dir",
+            str(tmp_path),
+            "--quality",
+            "showcase",
+            "--json",
+        )
+
+        assert good_code == render.EXIT_OK
+        assert bad_code == render.EXIT_FAILURE
+        assert payload["delivery_stage"] == "check"
+        assert [d["code"] for d in payload["diagnostics"]] == ["layout/label-overflow"]
+        assert out.read_bytes() == last_good
 
     def test_invalid_spec_is_an_operational_failure_and_writes_nothing(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1196,10 +1280,18 @@ class TestCliContract:
         spec.write_text("title: empty\n")
         out = tmp_path / "d.svg"
         code, payload, _ = self._run(
-            capsys, str(spec), "-o", str(out), "--cache-dir", str(tmp_path), "--json"
+            capsys,
+            "deliver",
+            str(spec),
+            "-o",
+            str(out),
+            "--cache-dir",
+            str(tmp_path),
+            "--json",
         )
         assert code == render.EXIT_FAILURE
-        assert payload["written"] is False
+        assert payload["output"]["written"] is False
+        assert payload["delivery_stage"] == "render"
         assert [d["code"] for d in payload["diagnostics"]] == ["spec/no-nodes"]
         assert not out.exists()
 
@@ -1208,15 +1300,44 @@ class TestCliContract:
     ) -> None:
         code, payload, _ = self._run(
             capsys,
+            "deliver",
             str(tmp_path / "nope.yaml"),
             "-o",
             str(tmp_path / "d.svg"),
             "--json",
         )
         assert code == render.EXIT_USAGE
+        assert payload["delivery_stage"] == "input"
         assert [d["code"] for d in payload["diagnostics"]] == ["usage/spec-unreadable"]
+
+    def test_script_entrypoint_runs_validate(self, tmp_path: Path) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text("nodes:\n  - id: a\n    label: A\n")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(Path(render.__file__).resolve()),
+                "validate",
+                str(spec),
+                "--cache-dir",
+                str(tmp_path),
+                "--json",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.returncode == render.EXIT_OK
+        assert json.loads(completed.stdout)["command"] == "validate"
+        assert completed.stderr == ""
+
+    def test_legacy_cli_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            render.main([str(tmp_path / "s.yaml"), "-o", str(tmp_path / "d.svg")])
+        assert exc.value.code == render.EXIT_USAGE
 
     def test_unknown_quality_profile_is_a_usage_error(self, tmp_path: Path) -> None:
         with pytest.raises(SystemExit) as exc:
-            render.main([str(tmp_path / "s.yaml"), "--quality", "pretty"])
+            render.main(["validate", str(tmp_path / "s.yaml"), "--quality", "pretty"])
         assert exc.value.code == render.EXIT_USAGE


### PR DESCRIPTION
## What

Make `validate` and `deliver` the only renderer commands. Rendered SVG candidates are staged beside the output, validated, and atomically committed with `os.replace` only after every check passes.

## Why

A failed validation previously overwrote the last-good SVG. This PR makes a failed delivery leave the existing artifact untouched and emits a machine-readable receipt with exact input and artifact SHA-256 values.

## Verification

- Regression proof against the pre-change tree: failed showcase delivery overwrote the target before this change.
- Mutation guard: placing the commit before diagnostics makes `test_failed_showcase_delivery_preserves_the_last_good_artifact` fail.
- `uv run pytest skills/architecture-diagram/tests -q`
- strict mypy for `scripts/render.py`

BREAKING CHANGE: invoke `render.py validate ...` or `render.py deliver ... -o ...`; the legacy positional renderer command is rejected.