### PR TITLE
feat(architecture-diagram): emit a deterministic geometry receipt

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -52,6 +52,7 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
    python3 scripts/render.py validate spec.yaml --quality showcase --json
    ```
    The receipt contains exact spec and candidate-artifact SHA-256 digests, validation counts, quality profile, composition status, and coded diagnostics. `validate` never touches an output path.
+   Use `--layout-json` instead of `--json` when an agent needs the exact emitted node boxes, zone membership and boxes, routed edge waypoints, and edge-label rectangles for review. It also never writes SVG output.
 6. **Deliver only a clean candidate:**
    ```bash
    python3 scripts/render.py deliver spec.yaml -o diagram.svg --quality showcase --json

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -1621,6 +1621,9 @@ def check_editability(svg_text: str) -> list[Diagnostic]:
 class RenderResult:
     svg: str
     diagnostics: list[Diagnostic] = field(default_factory=list)
+    node_boxes: dict[str, Box] = field(default_factory=dict)
+    zone_boxes: dict[str, Box] = field(default_factory=dict)
+    routed_edges: list[RoutedEdge] = field(default_factory=list)
 
     @property
     def errors(self) -> list[Diagnostic]:
@@ -1654,7 +1657,13 @@ def render(
     svg = emit_svg(spec, node_boxes, zone_boxes, routed_edges, icons, diagnostics)
     diagnostics += check_editability(svg)
     diagnostics = apply_quality_profile(suppress_derived(diagnostics), quality)
-    return RenderResult(svg=svg, diagnostics=diagnostics)
+    return RenderResult(
+        svg=svg,
+        diagnostics=diagnostics,
+        node_boxes=node_boxes,
+        zone_boxes=zone_boxes,
+        routed_edges=routed_edges,
+    )
 
 
 EXIT_OK = 0
@@ -1766,6 +1775,49 @@ def _receipt(
     return receipt
 
 
+def _layout_report(spec: Spec, result: RenderResult) -> dict[str, object]:
+    """Expose the exact boxes and waypoints used by SVG emission."""
+    return {
+        "nodes": [
+            {"id": node.id, "box": _box_evidence(result.node_boxes[node.id])}
+            for node in spec.nodes
+        ],
+        "zones": [
+            {
+                "id": zone.id,
+                "label": zone.label,
+                "parent": zone.parent,
+                "members": [node.id for node in spec.nodes if node.zone == zone.id],
+                "box": _box_evidence(result.zone_boxes[zone.id]),
+            }
+            for zone in spec.zones
+        ],
+        "edges": [
+            {
+                "from": routed.edge.src,
+                "to": routed.edge.dst,
+                "label": routed.edge.label,
+                "type": routed.edge.type,
+                "points": [{"x": x, "y": y} for x, y in routed.points],
+                "label_position": {
+                    "x": routed.label_pos[0],
+                    "y": routed.label_pos[1],
+                },
+            }
+            for routed in result.routed_edges
+        ],
+        "labels": [
+            {
+                "edge": {"from": routed.edge.src, "to": routed.edge.dst},
+                "text": routed.edge.label,
+                "box": _box_evidence(_edge_label_box(routed)),
+            }
+            for routed in result.routed_edges
+            if routed.edge.label
+        ],
+    }
+
+
 def _report(
     receipt: dict[str, object], as_json: bool, diagnostics: list[Diagnostic]
 ) -> None:
@@ -1836,13 +1888,13 @@ def _icon_lookup(cache_dir: Path | None, sha: str | None) -> IconLookup:
 
 def _render_candidate(
     spec_text: str, lookup: IconLookup, quality: str
-) -> tuple[RenderResult | None, bytes | None, list[Diagnostic]]:
+) -> tuple[Spec | None, RenderResult | None, bytes | None, list[Diagnostic]]:
     try:
         spec = load_spec(spec_text)
     except SpecError as exc:
-        return None, None, [exc.diagnostic]
+        return None, None, None, [exc.diagnostic]
     result = render(spec, lookup, quality=quality)
-    return result, result.svg.encode("utf-8"), result.diagnostics
+    return spec, result, result.svg.encode("utf-8"), result.diagnostics
 
 
 def _validate(
@@ -1850,12 +1902,13 @@ def _validate(
     cache_dir: Path | None,
     sha: str | None,
     quality: str,
+    layout_json: bool,
 ) -> tuple[int, dict[str, object], list[Diagnostic]]:
     loaded = _read_spec("validate", spec_path, None, quality)
     if len(loaded) == 3:
         return loaded
     spec_bytes, spec_text = loaded
-    result, artifact_bytes, diagnostics = _render_candidate(
+    spec, result, artifact_bytes, diagnostics = _render_candidate(
         spec_text, _icon_lookup(cache_dir, sha), quality
     )
     if artifact_bytes is not None:
@@ -1874,6 +1927,8 @@ def _validate(
         quality,
         delivery_stage="check" if result is not None and not result.ok else None,
     )
+    if layout_json and spec is not None and result is not None:
+        receipt["layout"] = _layout_report(spec, result)
     return (EXIT_OK if receipt["ok"] else EXIT_FAILURE), receipt, diagnostics
 
 
@@ -1933,7 +1988,7 @@ def _deliver(
             if os.stat(stage_dir).st_dev != os.stat(output_parent).st_dev:
                 raise OSError("staging directory is not on the output filesystem")
             (stage_dir / "specification.yaml").write_bytes(spec_bytes)
-            result, artifact_bytes, diagnostics = _render_candidate(
+            _, result, artifact_bytes, diagnostics = _render_candidate(
                 spec_text, _icon_lookup(cache_dir, sha), quality
             )
             if artifact_bytes is None:
@@ -2033,6 +2088,11 @@ def main(argv: list[str] | None = None) -> int:
         "validate", help="render and validate without writing an output artifact"
     )
     _add_common_arguments(validate_parser)
+    validate_parser.add_argument(
+        "--layout-json",
+        action="store_true",
+        help="print the exact emitted layout geometry without writing an SVG",
+    )
     deliver_parser = commands.add_parser(
         "deliver", help="validate, stage, and atomically commit an SVG artifact"
     )
@@ -2044,13 +2104,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "validate":
         code, receipt, diagnostics = _validate(
-            args.spec, args.cache_dir, args.sha, args.quality
+            args.spec, args.cache_dir, args.sha, args.quality, args.layout_json
         )
     else:
         code, receipt, diagnostics = _deliver(
             args.spec, args.output, args.cache_dir, args.sha, args.quality
         )
-    _report(receipt, args.as_json, diagnostics)
+    _report(receipt, args.as_json or getattr(args, "layout_json", False), diagnostics)
     return code
 
 

--- a/skills/architecture-diagram/tests/fixtures/example-serverless.layout.json
+++ b/skills/architecture-diagram/tests/fixtures/example-serverless.layout.json
@@ -1,0 +1,227 @@
+{
+  "edges": [
+    {
+      "from": "cf",
+      "label": "HTTPS",
+      "label_position": {
+        "x": 146.0,
+        "y": 152.5
+      },
+      "points": [
+        {
+          "x": 124.0,
+          "y": 149.0
+        },
+        {
+          "x": 140.0,
+          "y": 149.0
+        },
+        {
+          "x": 140.0,
+          "y": 133.0
+        },
+        {
+          "x": 156.0,
+          "y": 133.0
+        },
+        {
+          "x": 156.0,
+          "y": 156.0
+        },
+        {
+          "x": 264.0,
+          "y": 156.0
+        }
+      ],
+      "to": "apigw",
+      "type": "realtime"
+    },
+    {
+      "from": "apigw",
+      "label": "invoke",
+      "label_position": {
+        "x": 480.0,
+        "y": 156.0
+      },
+      "points": [
+        {
+          "x": 334.0,
+          "y": 156.0
+        },
+        {
+          "x": 474.0,
+          "y": 156.0
+        }
+      ],
+      "to": "fn",
+      "type": "realtime"
+    },
+    {
+      "from": "fn",
+      "label": "query",
+      "label_position": {
+        "x": 690.0,
+        "y": 156.0
+      },
+      "points": [
+        {
+          "x": 544.0,
+          "y": 156.0
+        },
+        {
+          "x": 684.0,
+          "y": 156.0
+        }
+      ],
+      "to": "ddb",
+      "type": "realtime"
+    },
+    {
+      "from": "cf",
+      "label": "origin",
+      "label_position": {
+        "x": 162.0,
+        "y": 240.5
+      },
+      "points": [
+        {
+          "x": 124.0,
+          "y": 163.0
+        },
+        {
+          "x": 156.0,
+          "y": 163.0
+        },
+        {
+          "x": 156.0,
+          "y": 318.0
+        },
+        {
+          "x": 264.0,
+          "y": 318.0
+        }
+      ],
+      "to": "s3",
+      "type": "batch"
+    }
+  ],
+  "labels": [
+    {
+      "box": {
+        "height": 10.0,
+        "width": 28.000000000000004,
+        "x": 146.0,
+        "y": 142.5
+      },
+      "edge": {
+        "from": "cf",
+        "to": "apigw"
+      },
+      "text": "HTTPS"
+    },
+    {
+      "box": {
+        "height": 10.0,
+        "width": 31.200000000000003,
+        "x": 480.0,
+        "y": 146.0
+      },
+      "edge": {
+        "from": "apigw",
+        "to": "fn"
+      },
+      "text": "invoke"
+    },
+    {
+      "box": {
+        "height": 10.0,
+        "width": 28.000000000000004,
+        "x": 690.0,
+        "y": 146.0
+      },
+      "edge": {
+        "from": "fn",
+        "to": "ddb"
+      },
+      "text": "query"
+    },
+    {
+      "box": {
+        "height": 10.0,
+        "width": 28.799999999999997,
+        "x": 162.0,
+        "y": 230.5
+      },
+      "edge": {
+        "from": "cf",
+        "to": "s3"
+      },
+      "text": "origin"
+    }
+  ],
+  "nodes": [
+    {
+      "box": {
+        "height": 118,
+        "width": 120,
+        "x": 32,
+        "y": 124
+      },
+      "id": "cf"
+    },
+    {
+      "box": {
+        "height": 118,
+        "width": 120,
+        "x": 242,
+        "y": 124
+      },
+      "id": "apigw"
+    },
+    {
+      "box": {
+        "height": 118,
+        "width": 120,
+        "x": 452,
+        "y": 124
+      },
+      "id": "fn"
+    },
+    {
+      "box": {
+        "height": 118,
+        "width": 120,
+        "x": 662,
+        "y": 124
+      },
+      "id": "ddb"
+    },
+    {
+      "box": {
+        "height": 118,
+        "width": 120,
+        "x": 242,
+        "y": 286
+      },
+      "id": "s3"
+    }
+  ],
+  "zones": [
+    {
+      "box": {
+        "height": 188,
+        "width": 584,
+        "x": 220,
+        "y": 76
+      },
+      "id": "vpc",
+      "label": "VPC 10.0.0.0/16",
+      "members": [
+        "apigw",
+        "fn",
+        "ddb"
+      ],
+      "parent": null
+    }
+  ]
+}

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import fetch_icons
 import render
 from render import (
     COL_GAP,
@@ -1136,7 +1137,11 @@ class TestCliContract:
     ) -> tuple[int, dict[str, object], str]:
         code = render.main(list(argv))
         captured = capsys.readouterr()
-        payload = json.loads(captured.out) if "--json" in argv else {}
+        payload = (
+            json.loads(captured.out)
+            if "--json" in argv or "--layout-json" in argv
+            else {}
+        )
         return code, payload, captured.err
 
     def test_validate_returns_a_parsable_receipt_without_an_artifact(
@@ -1309,6 +1314,68 @@ class TestCliContract:
         assert code == render.EXIT_USAGE
         assert payload["delivery_stage"] == "input"
         assert [d["code"] for d in payload["diagnostics"]] == ["usage/spec-unreadable"]
+
+    def test_layout_json_is_stable_and_matches_emitted_geometry(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        cache_entries = [
+            fetch_icons.IconEntry(
+                slug=service,
+                name=service,
+                view_box="0 0 1 1",
+                body="<path/>",
+                source="fixture",
+            )
+            for service in ("cloudfront", "api-gateway", "lambda", "dynamodb", "s3")
+        ]
+        cache_stats = fetch_icons.write_cache(
+            tmp_path, "fixture-sha", "aws", cache_entries
+        )
+        fetch_icons.update_manifest(tmp_path, "fixture-sha", "aws", cache_stats)
+        spec_path = Path(__file__).parent.parent / "assets" / "example-serverless.yaml"
+        argv = (
+            "validate",
+            str(spec_path),
+            "--cache-dir",
+            str(tmp_path),
+            "--sha",
+            "fixture-sha",
+            "--quality",
+            "showcase",
+            "--layout-json",
+        )
+
+        first_code = render.main(list(argv))
+        first_capture = capsys.readouterr()
+        second_code = render.main(list(argv))
+        second_capture = capsys.readouterr()
+        first_payload = json.loads(first_capture.out)
+        expected_layout = json.loads(
+            (
+                Path(__file__).parent / "fixtures" / "example-serverless.layout.json"
+            ).read_text()
+        )
+        result = do_render(load_spec(spec_path.read_text()), _icon_lookup, "showcase")
+
+        assert first_code == second_code == render.EXIT_OK
+        assert first_capture.out == second_capture.out
+        assert first_capture.err == second_capture.err == ""
+        assert first_payload["layout"] == expected_layout
+        assert not list(tmp_path.glob("*.svg"))
+        for reported, routed in zip(
+            first_payload["layout"]["edges"], result.routed_edges, strict=True
+        ):
+            assert reported["points"] == [{"x": x, "y": y} for x, y in routed.points]
+            assert f'd="{routed.path_d}"' in result.svg
+        assert first_payload["layout"]["labels"] == [
+            {
+                "edge": {"from": routed.edge.src, "to": routed.edge.dst},
+                "text": routed.edge.label,
+                "box": render._box_evidence(render._edge_label_box(routed)),
+            }
+            for routed in result.routed_edges
+            if routed.edge.label
+        ]
 
     def test_script_entrypoint_runs_validate(self, tmp_path: Path) -> None:
         spec = tmp_path / "s.yaml"


### PR DESCRIPTION
## What

Add `validate --layout-json`, which returns the existing receipt plus the exact node and zone boxes, direct zone membership, edge waypoints, label positions, and label rectangles used in the emitted SVG.

## Why

Review tooling needs deterministic geometry without parsing SVG or recomputing routes. `validate` remains non-writing.

## Verification

- Approval fixture for `assets/example-serverless.yaml`.
- Two `--layout-json` invocations produce byte-identical JSON.
- The test matches receipt waypoints and label boxes to the renderer objects and verifies every route's emitted SVG path.
- `uv run pytest skills/architecture-diagram/tests -q`.