### PR TITLE
feat(architecture-diagram): verify cached cloud icon integrity

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -155,21 +155,19 @@ Kosha's pre-registered real-model Gate-0 evaluation is also cited, as a measured
 
 **Re-sync policy:** Neither upstream is vendored, so there is nothing to diff. Revisit the Kosha citation if a later pre-registered Gate-0 run records a GO verdict, and revisit the OKF question separately — OKF bundles are linked Markdown documents with untyped links, not typed property graphs, so they are out of scope for this skill.
 
-### draw.io icon geometry — used by `architecture-diagram`
+### draw.io icon geometry and provider icon terms — used by `architecture-diagram`
 
-**Upstream repo:** [jgraph/drawio](https://github.com/jgraph/drawio)
-**License:** Apache-2.0
-**Pinned commit:** `a1f615b7f5a5237da71de2ce2f057b5fa70b0aeb` (`dev` branch, verified 2026-08-15)
+**Geometry source:** [jgraph/drawio](https://github.com/jgraph/drawio), Apache-2.0, pinned commit `a1f615b7f5a5237da71de2ce2f057b5fa70b0aeb` (`dev` branch, verified 2026-08-15).
 
-**Not traditional vendoring — no files are copied into this repository.** AWS, Azure, and GCP's own terms permit using their icons to build architecture diagrams, but none grant redistribution rights for the raw files, so `architecture-diagram` ships zero icon assets. Instead:
+**Not traditional vendoring — no cloud icon files are copied into this repository.** `scripts/stencil2svg.py` converts draw.io AWS/GCP stencil geometry and `scripts/svg_inline.py` inlines/namespaces draw.io Azure SVG geometry only in a user-local cache. `scripts/fetch_icons.py` records a SHA-256 digest, source path, and the provider-specific terms below for every cache entry; `render.py` rejects a requested entry whose digest differs.
 
-- `scripts/stencil2svg.py` converts draw.io's `mxgraph.aws4`/`mxgraph.gcp2` stencil XML (vector `move`/`line`/`curve`/`arc` primitives, no embedded rasters) into inline SVG, at render time, on the end user's own machine.
-- `scripts/svg_inline.py` inlines and namespaces draw.io's `azure2` real-SVG icon library the same way.
-- `scripts/fetch_icons.py` builds a local per-user cache pinned to the commit above, so output stays reproducible without this repository ever holding the icon files.
+| Provider | Official source and permitted use | Cache ledger |
+| --- | --- | --- |
+| AWS | [Architecture icons](https://aws.amazon.com/architecture/icons/): AWS allows customers and partners to use its toolkits and assets to create architecture diagrams, whitepapers, presentations, data sheets, and posters. | `license_note.aws`, each AWS cache entry's source path and digest |
+| Azure | [Azure Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/): Microsoft permits copying, distributing, and displaying icons only in architectural diagrams, training materials, or documentation; use icons as published and do not crop, flip, rotate, distort, or change their shape. | `license_note.azure`, each Azure cache entry's source path and digest |
+| Google Cloud | [Google Cloud product icons](https://cloud.google.com/icons): official icons for diagrams and technical documentation. | `license_note.gcp`, each Google Cloud cache entry's source path and digest |
 
-The pinned commit governs which stencil/icon geometry is used; bumping it is a deliberate, reviewable change to `scripts/fetch_icons.py`, not an implicit `dev`-branch tracking dependency.
-
-**Re-sync policy:** Nothing is vendored, so there is nothing to diff against upstream `dev` churn. Bump `DRAWIO_SHA` in `scripts/fetch_icons.py` only after re-running the full corpus conversion and confirming no new conversion warnings, per `references/editability.md`.
+The pinned commit governs which draw.io geometry is converted. Rebuild a provider cache with `fetch_icons.py --provider <provider> --force` after a digest failure or a pin bump; this does not fetch implicit `dev`-branch churn.
 
 ## Conceptual Inspiration
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -49,7 +49,7 @@ packages:
     difficulty: intermediate
     phase: ship
   - name: architecture-diagram
-    version: 2.2.0
+    version: 2.3.0
     description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams,
       or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead
       of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram",

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -2,7 +2,7 @@
 name: architecture-diagram
 description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams, or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram", "topology diagram", "draw architecture", "AWS diagram", "Azure diagram", "GCP diagram", "cloud infrastructure diagram", "VPC diagram", "draw my AWS setup". Use when a user wants a static architecture diagram they can still edit afterward in Figma, Illustrator, or Inkscape. NOT for architecture reviews, use architecture-reviewer.'
 metadata:
-  version: 2.2.0
+  version: 2.3.0
   category: visualization
   tags: [architecture, diagram, svg, aws, azure, gcp, cloud, icons]
   difficulty: intermediate
@@ -30,7 +30,7 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
 ## Prerequisites
 
 - `python3` with `pyyaml` installed (`uv run --with pyyaml python3 scripts/render.py ...` if not already available).
-- **Cloud-provider icons need a one-time, per-machine network fetch.** Icons are never bundled in this skill — AWS, Azure, and GCP's own terms permit using their icons to build diagrams but none grant redistribution rights, so nothing is vendored. The first time a diagram needs a given provider's icons, run:
+- **Cloud-provider icons need a one-time, per-machine network fetch.** Icons are never bundled in this skill; their providers publish diagram-use terms, so `architecture-diagram` records each provider's source and terms in the local cache rather than redistributing icon assets. The first time a diagram needs a given provider's icons, run:
 
   ```bash
   python3 scripts/fetch_icons.py --provider aws    # ~5s, 1037 icons
@@ -39,7 +39,7 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
   # or: --provider all
   ```
 
-  This builds a local cache (default `~/.cache/armory/cloud-icons`, override with `--cache-dir` or `$XDG_CACHE_HOME`) pinned to a specific `jgraph/drawio` commit, so output is reproducible. Subsequent renders reuse the cache — no network needed after the first fetch per provider. `provider: generic` needs no fetch at all; it uses the bundled hand-drawn icon set in `references/icons-generic.md`.
+  This builds a local cache (default `~/.cache/armory/cloud-icons`, override with `--cache-dir` or `$XDG_CACHE_HOME`) pinned to a specific `jgraph/drawio` commit, so output is reproducible. Each rendered cloud icon is verified against its manifest SHA-256 digest; `icon/digest-mismatch` fails closed and requires the provider cache to be rebuilt with `fetch_icons.py --provider <provider> --force`. Subsequent renders reuse the verified cache — no network needed after the first fetch per provider. `provider: generic` needs no fetch at all; it uses the bundled hand-drawn icon set in `references/icons-generic.md`.
 
 ## Workflow
 

--- a/skills/architecture-diagram/scripts/fetch_icons.py
+++ b/skills/architecture-diagram/scripts/fetch_icons.py
@@ -18,6 +18,7 @@ file, not something that happens implicitly on `dev` branch churn.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import http.client
 import json
 import os
@@ -45,13 +46,31 @@ STENCIL_PATHS = {
     "gcp": "src/main/webapp/stencils/gcp2.xml",
 }
 AZURE_TREE_PREFIX = "src/main/webapp/img/lib/azure2"
-LICENSE_NOTE = (
-    "Vector geometry sourced from jgraph/drawio (Apache-2.0): "
-    "https://github.com/jgraph/drawio/blob/dev/LICENSE. "
-    "AWS/Azure/GCP retain ownership of the underlying icon designs; this "
-    "cache exists for building your own diagrams under each provider's "
-    "'use in architecture diagrams' terms, not for redistribution."
-)
+CACHE_MANIFEST_VERSION = 2
+LICENSE_NOTE: dict[str, dict[str, str]] = {
+    "aws": {
+        "source": "https://aws.amazon.com/architecture/icons/",
+        "terms": (
+            "AWS permits customers and partners to use its architecture "
+            "assets in diagrams, whitepapers, presentations, datasheets, and posters."
+        ),
+    },
+    "azure": {
+        "source": "https://learn.microsoft.com/azure/architecture/icons/",
+        "terms": (
+            "Microsoft permits copying, distributing, and displaying Azure icons "
+            "only in architectural diagrams, training, and documentation; do not "
+            "crop, flip, rotate, distort, or otherwise modify them."
+        ),
+    },
+    "gcp": {
+        "source": "https://cloud.google.com/icons",
+        "terms": (
+            "Google provides the Cloud icon library for diagrams and technical "
+            "documentation; consult the provider page for current use terms."
+        ),
+    },
+}
 
 
 class Source(Protocol):
@@ -210,12 +229,77 @@ def convert_azure(source: Source, max_workers: int = 16) -> list[IconEntry]:
     return entries
 
 
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _empty_manifest(sha: str) -> dict[str, object]:
+    return {
+        "format_version": CACHE_MANIFEST_VERSION,
+        "sha": sha,
+        "license_note": LICENSE_NOTE,
+        "providers": {},
+    }
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, object] | None:
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return manifest if isinstance(manifest, dict) else None
+
+
+def _provider_cache_is_verified(cache_dir: Path, sha: str, provider: str) -> bool:
+    provider_dir = cache_dir / sha / provider
+    manifest = _read_manifest(cache_dir / sha / "manifest.json")
+    if (
+        manifest is None
+        or manifest.get("format_version") != CACHE_MANIFEST_VERSION
+        or manifest.get("sha") != sha
+    ):
+        return False
+    providers = manifest.get("providers")
+    if not isinstance(providers, dict):
+        return False
+    stats = providers.get(provider)
+    if not isinstance(stats, dict):
+        return False
+    icons = stats.get("icons")
+    if not isinstance(icons, dict):
+        return False
+    files = sorted(provider_dir.glob("*.json"))
+    if stats.get("count") != len(icons) or len(files) != len(icons):
+        return False
+    for icon_path in files:
+        record = icons.get(icon_path.name)
+        if not isinstance(record, dict):
+            return False
+        expected_digest = record.get("sha256")
+        if (
+            not isinstance(expected_digest, str)
+            or not isinstance(record.get("source"), str)
+            or not isinstance(record.get("terms"), str)
+        ):
+            return False
+        try:
+            actual_digest = _sha256(icon_path.read_bytes())
+        except OSError:
+            return False
+        if actual_digest != expected_digest:
+            return False
+    return True
+
+
 def write_cache(
     cache_dir: Path, sha: str, provider: str, entries: list[IconEntry]
 ) -> dict[str, object]:
     provider_dir = cache_dir / sha / provider
     provider_dir.mkdir(parents=True, exist_ok=True)
+    for old_entry in provider_dir.glob("*.json"):
+        old_entry.unlink()
     seen: dict[str, int] = {}
+    icons: dict[str, dict[str, str]] = {}
     warned = 0
     for entry in entries:
         # Two shapes can normalize to the same slug (e.g. "S3" and "s3 " after
@@ -235,13 +319,21 @@ def write_cache(
             "source": entry.source,
             "warnings": entry.warnings,
         }
-        (provider_dir / f"{key}.json").write_text(json.dumps(payload, indent=2))
+        filename = f"{key}.json"
+        payload_bytes = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        (provider_dir / filename).write_bytes(payload_bytes)
+        icons[filename] = {
+            "sha256": _sha256(payload_bytes),
+            "source": entry.source,
+            "terms": LICENSE_NOTE[provider]["terms"],
+        }
         if entry.warnings:
             warned += 1
     return {
-        "count": len(entries),
+        "count": len(icons),
         "warned": warned,
         "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "icons": icons,
     }
 
 
@@ -250,16 +342,20 @@ def update_manifest(
 ) -> None:
     manifest_path = cache_dir / sha / "manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    if manifest_path.exists():
-        manifest: dict[str, object] = json.loads(manifest_path.read_text())
-    else:
-        manifest = {"sha": sha, "license_note": LICENSE_NOTE, "providers": {}}
+    manifest = _read_manifest(manifest_path)
+    if (
+        manifest is None
+        or manifest.get("format_version") != CACHE_MANIFEST_VERSION
+        or manifest.get("sha") != sha
+    ):
+        manifest = _empty_manifest(sha)
     providers = manifest.get("providers")
     if not isinstance(providers, dict):
         providers = {}
         manifest["providers"] = providers
+    manifest["license_note"] = LICENSE_NOTE
     providers[provider] = stats
-    manifest_path.write_text(json.dumps(manifest, indent=2))
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 
 
 def default_cache_dir() -> Path:
@@ -271,15 +367,17 @@ def default_cache_dir() -> Path:
 def fetch_provider(
     source: Source, cache_dir: Path, sha: str, provider: str, force: bool
 ) -> dict[str, object]:
-    provider_dir = cache_dir / sha / provider
-    if provider_dir.exists() and any(provider_dir.glob("*.json")) and not force:
-        return {"skipped": True, "count": len(list(provider_dir.glob("*.json")))}
+    if provider not in ("aws", "azure", "gcp"):
+        raise ValueError(f"unknown provider: {provider}")
+    if not force and _provider_cache_is_verified(cache_dir, sha, provider):
+        return {
+            "skipped": True,
+            "count": len(list((cache_dir / sha / provider).glob("*.json"))),
+        }
     if provider == "azure":
         entries = convert_azure(source)
-    elif provider in ("aws", "gcp"):
-        entries = convert_stencil_provider(source, provider)
     else:
-        raise ValueError(f"unknown provider: {provider}")
+        entries = convert_stencil_provider(source, provider)
     stats = write_cache(cache_dir, sha, provider, entries)
     update_manifest(cache_dir, sha, provider, stats)
     return stats

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+import fetch_icons
 import yaml
 
 # --- layout constants -------------------------------------------------------
@@ -1292,19 +1293,117 @@ class IconLookup(Protocol):
     def __call__(self, provider: str, service_slug: str) -> IconRef | None: ...
 
 
+class IconCacheError(RuntimeError):
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        super().__init__(diagnostic.message)
+        self.diagnostic = diagnostic
+
+
 @dataclass
 class CacheIconLookup:
-    """Network-fetched cloud provider icons — see fetch_icons.py."""
+    """Verified local cloud-provider icon cache — see fetch_icons.py."""
 
     cache_dir: Path
     sha: str
 
+    def _error(
+        self,
+        code: str,
+        message: str,
+        provider: str,
+        service_slug: str,
+        evidence: dict[str, object],
+    ) -> IconCacheError:
+        return IconCacheError(
+            Diagnostic(
+                code=code,
+                severity=SEVERITY_ERROR,
+                message=message,
+                subject={"provider": provider, "service": service_slug},
+                evidence=evidence,
+                supported_fixes=(
+                    f"rebuild the {provider} icon cache: "
+                    f"fetch_icons.py --provider {provider} --force",
+                ),
+                suppresses=("icon/not-found",),
+            )
+        )
+
     def __call__(self, provider: str, service_slug: str) -> IconRef | None:
-        path = self.cache_dir / self.sha / provider / f"{service_slug}.json"
+        cache_root = self.cache_dir / self.sha
+        path = cache_root / provider / f"{service_slug}.json"
         if not path.exists():
             return None
-        data = json.loads(path.read_text())
-        return IconRef(view_box=data["viewBox"], body=data["body"])
+        manifest_path = cache_root / "manifest.json"
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            payload = path.read_bytes()
+        except (OSError, json.JSONDecodeError) as exc:
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has no readable integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path), "error": str(exc)},
+            ) from exc
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("format_version") != fetch_icons.CACHE_MANIFEST_VERSION
+            or manifest.get("sha") != self.sha
+            or not isinstance(manifest.get("providers"), dict)
+        ):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has an unsupported integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        provider_stats = manifest["providers"].get(provider)
+        if not isinstance(provider_stats, dict) or not isinstance(
+            provider_stats.get("icons"), dict
+        ):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} is absent from its integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        record = provider_stats["icons"].get(path.name)
+        expected_digest = record.get("sha256") if isinstance(record, dict) else None
+        actual_digest = hashlib.sha256(payload).hexdigest()
+        if not isinstance(expected_digest, str):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has no recorded content digest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        if actual_digest != expected_digest:
+            raise self._error(
+                "icon/digest-mismatch",
+                f"icon cache entry {path} does not match its recorded digest",
+                provider,
+                service_slug,
+                {
+                    "path": str(path),
+                    "expected_sha256": expected_digest,
+                    "actual_sha256": actual_digest,
+                },
+            )
+        try:
+            data = json.loads(payload)
+            return IconRef(view_box=data["viewBox"], body=data["body"])
+        except (KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise self._error(
+                "icon/cache-unverified",
+                f"verified icon cache entry {path} is not a usable icon",
+                provider,
+                service_slug,
+                {"path": str(path), "error": str(exc)},
+            ) from exc
 
 
 @dataclass
@@ -1652,7 +1751,14 @@ def render(
 
     icons: dict[str, IconRef | None] = {}
     for n in spec.nodes:
-        icons[n.id] = icon_lookup(n.provider, n.service) if n.service else None
+        if not n.service:
+            icons[n.id] = None
+            continue
+        try:
+            icons[n.id] = icon_lookup(n.provider, n.service)
+        except IconCacheError as exc:
+            diagnostics.append(exc.diagnostic)
+            icons[n.id] = None
 
     svg = emit_svg(spec, node_boxes, zone_boxes, routed_edges, icons, diagnostics)
     diagnostics += check_editability(svg)
@@ -1874,8 +1980,6 @@ def _read_spec(
 
 
 def _icon_lookup(cache_dir: Path | None, sha: str | None) -> IconLookup:
-    import fetch_icons  # local import keeps pure layout tests network-free
-
     selected_cache_dir = cache_dir or fetch_icons.default_cache_dir()
     selected_sha = sha or fetch_icons.DRAWIO_SHA
     return CompositeIconLookup(

--- a/skills/architecture-diagram/tests/test_fetch_icons.py
+++ b/skills/architecture-diagram/tests/test_fetch_icons.py
@@ -103,6 +103,11 @@ class TestCacheWriting:
         written = sorted(p.name for p in provider_dir.glob("*.json"))
         assert written == ["bigquery.json", "lambda.json"]
         assert stats["count"] == 2
+        icon_records = stats["icons"]
+        assert isinstance(icon_records, dict)
+        assert icon_records["lambda.json"]["sha256"] == fetch_icons._sha256(
+            (provider_dir / "lambda.json").read_bytes()
+        )
 
     def test_cache_entry_is_directly_usable_by_a_renderer(self, tmp_path: Path) -> None:
         entries = fetch_icons.convert_stencil_provider(_real_aws_gcp_source(), "aws")
@@ -145,19 +150,65 @@ class TestCacheWriting:
 
 
 class TestManifest:
-    def test_creates_manifest_with_provider_stats(self, tmp_path: Path) -> None:
-        fetch_icons.update_manifest(tmp_path, "sha1", "aws", {"count": 3, "warned": 0})
+    def test_creates_manifest_with_per_icon_digests_and_terms(
+        self, tmp_path: Path
+    ) -> None:
+        entry = fetch_icons.IconEntry(
+            slug="lambda",
+            name="lambda",
+            view_box="0 0 1 1",
+            body="<path/>",
+            source="fixture",
+        )
+        stats = fetch_icons.write_cache(tmp_path, "sha1", "aws", [entry])
+        fetch_icons.update_manifest(tmp_path, "sha1", "aws", stats)
         manifest = json.loads((tmp_path / "sha1" / "manifest.json").read_text())
+
+        assert manifest["format_version"] == fetch_icons.CACHE_MANIFEST_VERSION
         assert manifest["sha"] == "sha1"
-        assert manifest["providers"]["aws"]["count"] == 3
+        assert manifest["license_note"]["aws"] == fetch_icons.LICENSE_NOTE["aws"]
+        record = manifest["providers"]["aws"]["icons"]["lambda.json"]
+        assert record["sha256"] == fetch_icons._sha256(
+            (tmp_path / "sha1" / "aws" / "lambda.json").read_bytes()
+        )
+        assert record["source"] == "fixture"
+        assert record["terms"] == fetch_icons.LICENSE_NOTE["aws"]["terms"]
 
     def test_merges_across_multiple_providers(self, tmp_path: Path) -> None:
-        fetch_icons.update_manifest(tmp_path, "sha1", "aws", {"count": 3})
-        fetch_icons.update_manifest(tmp_path, "sha1", "gcp", {"count": 5})
+        aws = fetch_icons.write_cache(
+            tmp_path,
+            "sha1",
+            "aws",
+            [
+                fetch_icons.IconEntry(
+                    slug="lambda",
+                    name="lambda",
+                    view_box="0 0 1 1",
+                    body="<path/>",
+                    source="fixture",
+                )
+            ],
+        )
+        gcp = fetch_icons.write_cache(
+            tmp_path,
+            "sha1",
+            "gcp",
+            [
+                fetch_icons.IconEntry(
+                    slug="bigquery",
+                    name="bigquery",
+                    view_box="0 0 1 1",
+                    body="<path/>",
+                    source="fixture",
+                )
+            ],
+        )
+        fetch_icons.update_manifest(tmp_path, "sha1", "aws", aws)
+        fetch_icons.update_manifest(tmp_path, "sha1", "gcp", gcp)
         manifest = json.loads((tmp_path / "sha1" / "manifest.json").read_text())
         assert set(manifest["providers"]) == {"aws", "gcp"}
-        assert manifest["providers"]["aws"]["count"] == 3
-        assert manifest["providers"]["gcp"]["count"] == 5
+        assert manifest["providers"]["aws"]["count"] == 1
+        assert manifest["providers"]["gcp"]["count"] == 1
 
 
 class TestFetchProviderCaching:
@@ -175,6 +226,27 @@ class TestFetchProviderCaching:
         fetch_icons.fetch_provider(source, tmp_path, "sha1", "aws", force=False)
         fetch_icons.fetch_provider(source, tmp_path, "sha1", "aws", force=True)
         assert len(source.calls) == 2
+
+    def test_rebuilds_a_legacy_manifest_with_per_icon_digests(
+        self, tmp_path: Path
+    ) -> None:
+        source = _real_aws_gcp_source()
+        fetch_icons.fetch_provider(source, tmp_path, "sha1", "aws", force=False)
+        (tmp_path / "sha1" / "manifest.json").write_text(
+            json.dumps({"sha": "sha1", "providers": {"aws": {"count": 2}}})
+        )
+
+        stats = fetch_icons.fetch_provider(source, tmp_path, "sha1", "aws", force=False)
+        manifest = json.loads((tmp_path / "sha1" / "manifest.json").read_text())
+
+        assert len(source.calls) == 2
+        assert stats["count"] == 2
+        assert manifest["format_version"] == fetch_icons.CACHE_MANIFEST_VERSION
+        assert manifest["providers"]["aws"]["icons"]["lambda.json"]["sha256"] == (
+            fetch_icons._sha256(
+                (tmp_path / "sha1" / "aws" / "lambda.json").read_bytes()
+            )
+        )
 
     def test_unknown_provider_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="unknown provider"):

--- a/skills/architecture-diagram/tests/test_render.py
+++ b/skills/architecture-diagram/tests/test_render.py
@@ -868,20 +868,15 @@ class TestRealIconCacheIntegration:
     ) -> None:
         cache_dir = Path(str(tmp_path))
         sha = "deadbeef"
-        provider_dir = cache_dir / sha / "aws"
-        provider_dir.mkdir(parents=True)
-        (provider_dir / "lambda.json").write_text(
-            json.dumps(
-                {
-                    "viewBox": "0 0 54 56",
-                    "body": "<path/>",
-                    "name": "lambda",
-                    "slug": "lambda",
-                    "source": "x",
-                    "warnings": [],
-                }
-            )
+        entry = fetch_icons.IconEntry(
+            slug="lambda",
+            name="lambda",
+            view_box="0 0 54 56",
+            body="<path/>",
+            source="fixture",
         )
+        stats = fetch_icons.write_cache(cache_dir, sha, "aws", [entry])
+        fetch_icons.update_manifest(cache_dir, sha, "aws", stats)
         lookup = render.CacheIconLookup(cache_dir=cache_dir, sha=sha)
         icon = lookup("aws", "lambda")
         assert icon is not None
@@ -1212,6 +1207,45 @@ class TestCliContract:
         # stdout as prose alongside the receipt.
         assert code == render.EXIT_FAILURE
         assert [d["code"] for d in payload["diagnostics"]] == ["icon/not-found"]
+
+    def test_tampered_icon_cache_fails_closed_with_digest_mismatch(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "s.yaml"
+        spec.write_text(
+            "provider: aws\nnodes:\n  - id: a\n    label: A\n    service: lambda\n"
+        )
+        sha = "fixture-sha"
+        stats = fetch_icons.write_cache(
+            tmp_path,
+            sha,
+            "aws",
+            [
+                fetch_icons.IconEntry(
+                    slug="lambda",
+                    name="lambda",
+                    view_box="0 0 1 1",
+                    body="<path/>",
+                    source="fixture",
+                )
+            ],
+        )
+        fetch_icons.update_manifest(tmp_path, sha, "aws", stats)
+        (tmp_path / sha / "aws" / "lambda.json").write_text("{}")
+
+        code, payload, _ = self._run(
+            capsys,
+            "validate",
+            str(spec),
+            "--cache-dir",
+            str(tmp_path),
+            "--sha",
+            sha,
+            "--json",
+        )
+
+        assert code == render.EXIT_FAILURE
+        assert [d["code"] for d in payload["diagnostics"]] == ["icon/digest-mismatch"]
 
     def test_missing_icon_is_an_operational_failure(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## What

Version `architecture-diagram` 2.3.0. Add per-icon SHA-256 integrity records and provider-specific source and terms to the local icon-cache manifest. Rendering fails closed with `icon/digest-mismatch`; stale pre-integrity caches rebuild on the next provider fetch.

## Why

The renderer consumed unverified local icon JSON and the cache manifest held only aggregate provider counts. A changed cache entry could silently alter output.

## Verification

- Corrupted cached icon causes `validate` to exit 1 with only `icon/digest-mismatch`.
- Full fixture provider fetch rebuilds a legacy manifest with content digests.
- `uv run pytest skills/architecture-diagram/tests -q` — 180 passed.
- `scripts/validate_evals.py`, static package evaluation, strict mypy for both scripts, and regenerated `manifest.yaml` pass.

Refs: M3 transactional delivery and geometry receipt stack.