### PR TITLE
feat(architecture-diagram): add a fail-closed deployment profile

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -68,10 +68,12 @@ Full schema and worked examples: `references/spec-format.md`. Summary:
 title: string
 direction: LR | TB        # default LR
 provider: aws | azure | gcp | generic   # default provider for nodes that omit it
+profile: deployment-ownership             # opt-in blocking deployment checks
 zones:
   - id: string
     label: string
     parent: string | null # nesting — omit for a top-level zone
+    kind: generic | region | security # default generic
 nodes:
   - id: string             # unique
     label: string
@@ -80,12 +82,19 @@ nodes:
     provider: string       # overrides the top-level provider for this node
     zone: string | null    # zone id this node belongs to
     color: "#RRGGBB"       # icon fill color
+    owner: string          # required for non-external nodes under deployment-ownership
+    external: boolean      # default false
+    storage: boolean       # true requires a security zone under deployment-ownership
 edges:
   - from: string            # node id
     to: string              # node id
-    label: string           # optional
+    label: string           # required for security-boundary crossings under deployment-ownership
     type: realtime | batch | event | control | default
 ```
+
+### Deployment ownership validation
+
+Set `profile: deployment-ownership` only when the spec is a deployment ownership record rather than a visual-only diagram. The profile fails closed: every node must resolve to exactly one `kind: region`, every non-external node needs a non-blank `owner`, every `storage: true` node must be inside `kind: security`, and a cross-security-zone edge needs a non-blank label naming its mechanism. It never infers those facts from labels, icons, service slugs, or layout. Omit `profile` to preserve existing behavior.
 
 ## Connection type semantics
 

--- a/skills/architecture-diagram/references/spec-format.md
+++ b/skills/architecture-diagram/references/spec-format.md
@@ -8,12 +8,21 @@ The input to `scripts/render.py` is a small YAML file. This is the complete sche
 title: string              # optional; omit for no title bar
 direction: LR | TB         # optional, default LR
 provider: aws | azure | gcp | generic   # optional, default generic — sets the default for nodes that omit their own provider
+profile: deployment-ownership            # optional; opt-in deployment validation
 zones: [...]                # optional
 nodes: [...]                 # required, at least one
 edges: [...]                 # optional
 ```
 
 `direction` controls the layout axis: `LR` ranks flow left-to-right (use for request/data-flow diagrams — most architecture diagrams), `TB` ranks flow top-to-bottom (use for hierarchical or layered diagrams — network topology, layered architectures).
+
+### Deployment ownership profile
+
+`profile: deployment-ownership` enables blocking checks over facts explicitly authored in the YAML. Omitting `profile` keeps the default visual-only behavior unchanged. The profile never derives an owner, a storage role, a region, or a boundary mechanism from labels, service slugs, or layout.
+
+With the profile enabled, declare at least one `kind: region` zone and one `kind: security` zone. Every node must resolve through its zone ancestry to exactly one region; every `kind: security` zone and its member nodes must resolve to one region. Every non-external node requires a non-blank `owner`. Mark storage explicitly with `storage: true`; those nodes must be inside a security zone. An edge whose endpoints have different security-zone membership requires a non-blank `label` naming its crossing mechanism.
+
+The zone-kind enum is `generic` (the default), `region`, and `security`. `generic` remains decorative; the profile only enforces the facts above when explicitly enabled.
 
 ## `nodes`
 
@@ -26,6 +35,9 @@ nodes:
     provider: string        # optional, overrides the top-level provider for this node
     zone: string             # optional, id of the zone this node belongs to
     color: "#RRGGBB"          # optional, defaults to "#3A3A3A", the icon square's fill
+    owner: string             # required for non-external nodes under deployment-ownership
+    external: boolean         # optional, default false; external nodes do not require owner
+    storage: boolean          # optional, default false; true requires a security zone under deployment-ownership
 ```
 
 `service` is the exact cache slug from `references/services-aws.yaml`, `references/services-azure.yaml`, or `references/services-gcp.yaml` (cloud providers) or `references/icons-generic.md` (`provider: generic`) — not a free-text service name. A `service` slug with no matching cache entry produces a `warning: no icon for node` at render time and the node falls back to a labeled placeholder (a colored square with the label's first letter) rather than failing the render. A node with no `service` set at all renders the same placeholder silently — that's the correct default for a component with no natural icon, not an error.
@@ -37,6 +49,7 @@ zones:
   - id: string          # required, unique
     label: string          # optional, defaults to id
     parent: string           # optional, id of an enclosing zone — omit for a top-level zone
+    kind: generic | region | security   # optional, default generic
 ```
 
 Every zone must have at least one member node (directly assigned via that node's `zone` field) or at least one child zone (another zone whose `parent` points to it). An empty zone — no members, no children — is a spec error, not a warning; fix the spec rather than working around it.
@@ -56,6 +69,8 @@ edges:
 ```
 
 An edge referencing a node id that doesn't exist in `nodes` is a spec error. Edges do not need to respect zone boundaries — a node inside a zone can connect to one outside it freely; the router treats zones as a purely visual grouping, not a routing constraint.
+
+Under `profile: deployment-ownership`, a labeled cross-security-zone edge names the mechanism used at that boundary. The profile rejects an empty or whitespace-only label; it does not infer one from `type`, a service name, or endpoint labels.
 
 `type` drives both the connector's color/style and whether a legend renders — see the connection type table in `SKILL.md`. Cycles (a connects to b, b connects back to a) are fine; the rank-assignment algorithm terminates on them rather than looping, though a diagram with many cycles will look messier since rank order stops being a clean single flow direction.
 

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -247,6 +247,9 @@ class Node:
     zone: str | None = None
     color: str = "#3A3A3A"
     provider: str = "generic"
+    owner: str | None = None
+    external: bool = False
+    storage: bool = False
 
 
 @dataclass
@@ -254,6 +257,7 @@ class Zone:
     id: str
     label: str
     parent: str | None = None
+    kind: str = "generic"
 
 
 @dataclass
@@ -272,6 +276,7 @@ class Spec:
     nodes: list[Node]
     zones: list[Zone]
     edges: list[Edge]
+    profile: str | None = None
 
 
 class SpecError(ValueError):
@@ -316,6 +321,18 @@ def load_spec(text: str) -> Spec:
         )
 
     provider = data.get("provider", "generic")
+    profile = data.get("profile")
+    if profile not in (None, "deployment-ownership"):
+        raise _spec_error(
+            "spec/unknown-profile",
+            f"unknown profile: {profile!r}",
+            evidence={"profile": profile},
+            supported_fixes=(
+                "omit `profile` for the default visual-only validation",
+                "set `profile: deployment-ownership`",
+            ),
+        )
+
     node_ids = set()
     nodes = []
     for raw in data["nodes"]:
@@ -326,6 +343,19 @@ def load_spec(text: str) -> Spec:
                 evidence={"node": raw},
                 supported_fixes=("give the node a unique `id`",),
             )
+        for field_name in ("external", "storage"):
+            value = raw.get(field_name, False)
+            if not isinstance(value, bool):
+                raise _spec_error(
+                    "spec/invalid-node-boolean",
+                    f"node {raw['id']!r} field {field_name!r} must be boolean",
+                    subject={"node": raw["id"]},
+                    evidence={"field": field_name, "value": value},
+                    supported_fixes=(
+                        f"set `{field_name}` to true or false without quotes",
+                    ),
+                )
+
         if raw["id"] in node_ids:
             raise _spec_error(
                 "spec/duplicate-node-id",
@@ -346,6 +376,9 @@ def load_spec(text: str) -> Spec:
                 zone=raw.get("zone"),
                 color=raw.get("color", "#3A3A3A"),
                 provider=raw.get("provider", provider),
+                owner=raw.get("owner"),
+                external=raw.get("external", False),
+                storage=raw.get("storage", False),
             )
         )
 
@@ -360,11 +393,28 @@ def load_spec(text: str) -> Spec:
                 supported_fixes=("give the zone a unique `id`",),
             )
         zone_ids.add(raw["id"])
+        kind = raw.get("kind", "generic")
+        if kind not in ("generic", "region", "security"):
+            raise _spec_error(
+                "spec/invalid-zone-kind",
+                f"zone {raw['id']!r} has invalid kind {kind!r}",
+                subject={"zone": raw["id"]},
+                evidence={
+                    "kind": kind,
+                    "allowed_kinds": ["generic", "region", "security"],
+                },
+                supported_fixes=(
+                    "omit `kind` for a visual-only generic zone",
+                    "set `kind` to `generic`, `region`, or `security`",
+                ),
+            )
+
         zones.append(
             Zone(
                 id=raw["id"],
                 label=raw.get("label", raw["id"]),
                 parent=raw.get("parent"),
+                kind=kind,
             )
         )
     for n in nodes:
@@ -432,6 +482,7 @@ def load_spec(text: str) -> Spec:
         nodes=nodes,
         zones=zones,
         edges=edges,
+        profile=profile,
     )
 
 
@@ -1275,8 +1326,169 @@ def _zone_ancestors(spec: Spec, zone_id: str) -> set[str]:
     out = set()
     cur = by_id[zone_id].parent
     while cur is not None:
+        if cur in out:
+            break
         out.add(cur)
         cur = by_id[cur].parent
+    return out
+
+
+def _zone_membership(spec: Spec, node: Node) -> set[str]:
+    if node.zone is None:
+        return set()
+    return {node.zone, *_zone_ancestors(spec, node.zone)}
+
+
+def _profile_diagnostic(
+    code: str,
+    message: str,
+    subject: dict[str, object],
+    evidence: dict[str, object],
+    supported_fixes: tuple[str, ...],
+) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        severity=SEVERITY_ERROR,
+        message=message,
+        subject=subject,
+        evidence=evidence,
+        supported_fixes=supported_fixes,
+    )
+
+
+def check_deployment_profile(spec: Spec) -> list[Diagnostic]:
+    """Validate authored deployment facts without assigning missing facts."""
+    if spec.profile != "deployment-ownership":
+        return []
+
+    memberships = {node.id: _zone_membership(spec, node) for node in spec.nodes}
+    region_ids = {zone.id for zone in spec.zones if zone.kind == "region"}
+    security_ids = {zone.id for zone in spec.zones if zone.kind == "security"}
+    out: list[Diagnostic] = []
+
+    missing_kinds = [
+        kind
+        for kind, present in (
+            ("region", region_ids),
+            ("security", security_ids),
+        )
+        if not present
+    ]
+    if missing_kinds:
+        out.append(
+            _profile_diagnostic(
+                "profile/missing-required-zone-kinds",
+                f"deployment profile requires zone kinds: {', '.join(missing_kinds)}",
+                {"profile": spec.profile},
+                {
+                    "missing_kinds": missing_kinds,
+                    "declared_zones": [
+                        {"id": zone.id, "kind": zone.kind} for zone in spec.zones
+                    ],
+                },
+                (
+                    "add at least one `kind: region` zone",
+                    "add at least one `kind: security` zone",
+                ),
+            )
+        )
+
+    for node in spec.nodes:
+        if not node.external and (
+            not isinstance(node.owner, str) or not node.owner.strip()
+        ):
+            out.append(
+                _profile_diagnostic(
+                    "profile/missing-owner",
+                    f"node {node.id!r} has no non-blank owner",
+                    {"node": node.id},
+                    {"external": node.external, "owner": node.owner},
+                    (
+                        "set the node's `owner` to the accountable team or service",
+                        "set `external: true` only for an externally owned node",
+                    ),
+                )
+            )
+
+        node_regions = sorted(memberships[node.id] & region_ids)
+        if not node_regions:
+            out.append(
+                _profile_diagnostic(
+                    "profile/missing-region-scope",
+                    f"node {node.id!r} is not contained by a region zone",
+                    {"node": node.id},
+                    {
+                        "zone": node.zone,
+                        "zone_membership": sorted(memberships[node.id]),
+                    },
+                    ("assign the node to a zone nested under one `kind: region` zone",),
+                )
+            )
+        elif len(node_regions) > 1:
+            out.append(
+                _profile_diagnostic(
+                    "profile/ambiguous-region",
+                    f"node {node.id!r} is contained by multiple region zones",
+                    {"node": node.id},
+                    {"regions": node_regions},
+                    ("nest the node under exactly one `kind: region` zone",),
+                )
+            )
+
+        if node.storage and not (memberships[node.id] & security_ids):
+            out.append(
+                _profile_diagnostic(
+                    "profile/storage-outside-security-zone",
+                    f"storage node {node.id!r} is outside a security zone",
+                    {"node": node.id},
+                    {
+                        "zone": node.zone,
+                        "zone_membership": sorted(memberships[node.id]),
+                    },
+                    (
+                        "assign the storage node to a zone nested under `kind: security`",
+                    ),
+                )
+            )
+
+    for security_id in sorted(security_ids):
+        security_regions = sorted(_zone_ancestors(spec, security_id) & region_ids)
+        if len(security_regions) != 1:
+            out.append(
+                _profile_diagnostic(
+                    "profile/inconsistent-security-zone-region",
+                    f"security zone {security_id!r} does not resolve to one region",
+                    {"zone": security_id},
+                    {
+                        "regions": security_regions,
+                        "parent": next(
+                            zone.parent for zone in spec.zones if zone.id == security_id
+                        ),
+                    },
+                    ("nest the security zone under exactly one `kind: region` zone",),
+                )
+            )
+
+    for edge in spec.edges:
+        src_security = memberships[edge.src] & security_ids
+        dst_security = memberships[edge.dst] & security_ids
+        if src_security != dst_security and not edge.label.strip():
+            out.append(
+                _profile_diagnostic(
+                    "profile/missing-boundary-crossing-mechanism",
+                    f"edge {edge.src!r}->{edge.dst!r} crosses a security boundary without a mechanism",
+                    {"edge": {"from": edge.src, "to": edge.dst}},
+                    {
+                        "from_security_zones": sorted(src_security),
+                        "to_security_zones": sorted(dst_security),
+                        "from_node": edge.src,
+                        "to_node": edge.dst,
+                    },
+                    (
+                        "set a non-blank edge `label` naming the boundary-crossing mechanism",
+                    ),
+                )
+            )
     return out
 
 
@@ -1737,6 +1949,7 @@ def render(
     spec: Spec, icon_lookup: IconLookup, quality: str = QUALITY_STANDARD
 ) -> RenderResult:
     diagnostics: list[Diagnostic] = []
+    diagnostics += check_deployment_profile(spec)
     rank = assign_ranks(spec)
     order = order_within_ranks(spec, rank)
     node_boxes = compute_positions(spec, rank, order)
@@ -1799,6 +2012,8 @@ def _check_name(diagnostic: Diagnostic) -> str:
     code = diagnostic.code
     if code.startswith("spec/"):
         return "spec"
+    if code.startswith("profile/"):
+        return "profile"
     if code in ("layout/node-overlap", "layout/zone-overlap"):
         return "layout"
     if code == "layout/label-overflow":
@@ -1821,8 +2036,9 @@ def _check_name(diagnostic: Diagnostic) -> str:
 
 
 def _validation_receipt(
-    diagnostics: list[Diagnostic], quality: str
+    diagnostics: list[Diagnostic], quality: str, profile_active: bool = False
 ) -> dict[str, object]:
+    checks = _VALIDATION_CHECKS + (("profile",) if profile_active else ())
     counts = count_by_severity(diagnostics)
     composition = [d for d in diagnostics if d.code.startswith("composition/")]
     if any(d.severity == SEVERITY_ERROR for d in composition):
@@ -1835,8 +2051,8 @@ def _validation_receipt(
         _check_name(d) for d in diagnostics if d.severity == SEVERITY_ERROR
     }
     return {
-        "checks_passed": len(_VALIDATION_CHECKS) - len(failed_checks),
-        "checks_total": len(_VALIDATION_CHECKS),
+        "checks_passed": len(checks) - len(failed_checks),
+        "checks_total": len(checks),
         "quality": quality,
         "composition_status": composition_status,
         "errors": counts["errors"],
@@ -1854,6 +2070,7 @@ def _receipt(
     output: Path | None = None,
     written: bool = False,
     delivery_stage: str | None = None,
+    profile_active: bool = False,
 ) -> dict[str, object]:
     receipt: dict[str, object] = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
@@ -1873,7 +2090,7 @@ def _receipt(
             "path": str(output) if output is not None else None,
             "written": written,
         },
-        "validation": _validation_receipt(diagnostics, quality),
+        "validation": _validation_receipt(diagnostics, quality, profile_active),
         "diagnostics": [d.to_dict() for d in diagnostics],
     }
     if delivery_stage is not None:
@@ -2030,6 +2247,7 @@ def _validate(
         diagnostics,
         quality,
         delivery_stage="check" if result is not None and not result.ok else None,
+        profile_active=spec is not None and spec.profile is not None,
     )
     if layout_json and spec is not None and result is not None:
         receipt["layout"] = _layout_report(spec, result)
@@ -2092,7 +2310,7 @@ def _deliver(
             if os.stat(stage_dir).st_dev != os.stat(output_parent).st_dev:
                 raise OSError("staging directory is not on the output filesystem")
             (stage_dir / "specification.yaml").write_bytes(spec_bytes)
-            _, result, artifact_bytes, diagnostics = _render_candidate(
+            spec, result, artifact_bytes, diagnostics = _render_candidate(
                 spec_text, _icon_lookup(cache_dir, sha), quality
             )
             if artifact_bytes is None:
@@ -2105,6 +2323,7 @@ def _deliver(
                     quality,
                     output=output,
                     delivery_stage="render",
+                    profile_active=spec is not None and spec.profile is not None,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
             candidate = stage_dir / "candidate.svg"
@@ -2121,6 +2340,7 @@ def _deliver(
                     quality,
                     output=output,
                     delivery_stage="check",
+                    profile_active=spec is not None and spec.profile is not None,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
             receipt = _receipt(
@@ -2133,6 +2353,7 @@ def _deliver(
                 output=output,
                 written=True,
                 delivery_stage="commit",
+                profile_active=spec is not None and spec.profile is not None,
             )
             try:
                 (stage_dir / "receipt.json").write_text(

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-ambiguous-region.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-ambiguous-region.yaml
@@ -1,0 +1,22 @@
+profile: deployment-ownership
+zones:
+  - id: global
+    kind: region
+  - id: us-east-1
+    parent: global
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-inconsistent-security-region.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-inconsistent-security-region.yaml
@@ -1,0 +1,18 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    kind: security
+nodes:
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-boundary-mechanism.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-boundary-mechanism.yaml
@@ -1,0 +1,25 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: internet
+    external: true
+    zone: us-east-1
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: internet
+    to: api
+    label: " "
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-owner.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-owner.yaml
@@ -1,0 +1,24 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: internet
+    external: true
+    zone: us-east-1
+  - id: api
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: internet
+    to: api
+    label: HTTPS
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-region.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-region.yaml
@@ -1,0 +1,27 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: internet
+    external: true
+    zone: us-east-1
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+  - id: orphan
+    owner: platform
+edges:
+  - from: internet
+    to: api
+    label: HTTPS
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-required-zone-kinds.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-missing-required-zone-kinds.yaml
@@ -1,0 +1,17 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+  - id: private
+    parent: us-east-1
+nodes:
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-storage-outside-security.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-storage-outside-security.yaml
@@ -1,0 +1,25 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: internet
+    external: true
+    zone: us-east-1
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: us-east-1
+edges:
+  - from: internet
+    to: api
+    label: HTTPS
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/fixtures/deployment-profile-valid.yaml
+++ b/skills/architecture-diagram/tests/fixtures/deployment-profile-valid.yaml
@@ -1,0 +1,25 @@
+profile: deployment-ownership
+zones:
+  - id: us-east-1
+    kind: region
+  - id: private
+    parent: us-east-1
+    kind: security
+nodes:
+  - id: internet
+    external: true
+    zone: us-east-1
+  - id: api
+    owner: platform
+    zone: private
+  - id: database
+    owner: data
+    storage: true
+    zone: private
+edges:
+  - from: internet
+    to: api
+    label: HTTPS
+  - from: api
+    to: database
+    label: PostgreSQL

--- a/skills/architecture-diagram/tests/test_deployment_profile.py
+++ b/skills/architecture-diagram/tests/test_deployment_profile.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import render
+from render import check_deployment_profile, load_spec
+
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _findings(name: str) -> list[render.Diagnostic]:
+    spec = load_spec((_FIXTURES / name).read_text())
+    return check_deployment_profile(spec)
+
+
+def _codes(name: str) -> list[str]:
+    return [finding.code for finding in _findings(name)]
+
+
+@pytest.mark.parametrize(
+    ("fixture", "code"),
+    [
+        ("deployment-profile-missing-owner.yaml", "profile/missing-owner"),
+        ("deployment-profile-missing-region.yaml", "profile/missing-region-scope"),
+        ("deployment-profile-ambiguous-region.yaml", "profile/ambiguous-region"),
+        (
+            "deployment-profile-storage-outside-security.yaml",
+            "profile/storage-outside-security-zone",
+        ),
+        (
+            "deployment-profile-inconsistent-security-region.yaml",
+            "profile/inconsistent-security-zone-region",
+        ),
+        (
+            "deployment-profile-missing-boundary-mechanism.yaml",
+            "profile/missing-boundary-crossing-mechanism",
+        ),
+        (
+            "deployment-profile-missing-required-zone-kinds.yaml",
+            "profile/missing-required-zone-kinds",
+        ),
+    ],
+)
+def test_deployment_profile_rejects_each_required_fact(fixture: str, code: str) -> None:
+    finding = next(finding for finding in _findings(fixture) if finding.code == code)
+    assert finding.severity == "error"
+    assert finding.supported_fixes
+
+
+def test_deployment_profile_accepts_complete_authored_facts() -> None:
+    assert _codes("deployment-profile-valid.yaml") == []
+
+
+def test_profile_is_inert_when_omitted() -> None:
+    spec_text = (_FIXTURES / "deployment-profile-valid.yaml").read_text()
+    without_profile = spec_text.replace("profile: deployment-ownership\n", "")
+
+    result = render.render(load_spec(without_profile), lambda _provider, _service: None)
+
+    assert result.ok
+    assert not [
+        finding for finding in result.diagnostics if finding.code.startswith("profile/")
+    ]
+
+
+def test_existing_serverless_spec_remains_outside_profile_validation() -> None:
+    existing = (
+        Path(__file__).parent.parent / "assets" / "example-serverless.yaml"
+    ).read_text()
+    spec = load_spec(existing)
+
+    assert spec.profile is None
+    assert check_deployment_profile(spec) == []
+
+
+def test_profile_failure_has_a_distinct_receipt_check(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    assert (
+        render._check_name(_findings("deployment-profile-missing-owner.yaml")[0])
+        == "profile"
+    )
+    code = render.main(
+        [
+            "validate",
+            str(_FIXTURES / "deployment-profile-missing-owner.yaml"),
+            "--cache-dir",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+    receipt = json.loads(capsys.readouterr().out)
+
+    assert code == render.EXIT_FAILURE
+    assert receipt["validation"] == {
+        "checks_passed": 10,
+        "checks_total": 11,
+        "quality": "standard",
+        "composition_status": "passed",
+        "errors": 1,
+        "warnings": 0,
+    }


### PR DESCRIPTION
## Summary
- Add the opt-in deployment-ownership profile with fail-closed ownership, region, boundary, and required-zone checks.
- Keep existing specifications unchanged when no profile is selected.
- Document the new specification fields and profile semantics.

## Verification
- uv run pytest skills/architecture-diagram/engine/tests -q
- just check
