### PR TITLE
feat(architecture-diagram): compare two specs into a change receipt

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -46,7 +46,7 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
 1. **Parse** the user's request: components (with descriptions), containment hierarchy (zones — VPC/Region/Resource Group/Subnet), connections (with semantic types if specified), and cloud provider(s).
 2. **Resolve services to icons.** For each cloud component, read `references/services-aws.yaml`, `references/services-azure.yaml`, or `references/services-gcp.yaml` (whichever matches its provider) — or `references/icons-generic.md` for non-cloud — and note the exact slug to use as that node's `service` field. If a service genuinely has no icon in that provider's set (documented per-provider in each table), either pick the closest sibling category or leave `service` unset — the renderer falls back to a labeled placeholder rather than a wrong icon.
 3. **Ensure the icon cache is warm** for every provider used (see Prerequisites). Skip this for `provider: generic`.
-4. **Author the spec** — a small YAML file per `references/spec-format.md`: `title`, `direction` (`LR`/`TB`), `zones` (with `parent` for nesting), `nodes` (`id`, `label`, `service`, `zone`, `color`), `edges` (`from`, `to`, `label`, `type`).
+4. **Author the spec** — a small YAML file per `references/spec-format.md`: `title`, `direction` (`LR`/`TB`), `zones` (with `parent` for nesting), `nodes` (`id`, `label`, `service`, `zone`, `color`), `edges` (`id`, `from`, `to`, `label`, `type`).
 5. **Validate without writing an artifact:**
    ```bash
    python3 scripts/render.py validate spec.yaml --quality showcase --json
@@ -58,7 +58,12 @@ Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS
    python3 scripts/render.py deliver spec.yaml -o diagram.svg --quality showcase --json
    ```
    `deliver` stages the exact spec and candidate SVG beside the target, then atomically replaces the target only after every check passes. Every failure leaves a previous artifact unchanged.
-7. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
+7. **Compare authored revisions when needed:**
+   ```bash
+   python3 scripts/render.py compare base.yaml head.yaml
+   ```
+   `compare` emits a JSON receipt keyed only by authored node and edge ids. It reports added, removed, changed, moved, and rerouted entities with exact field paths. Its mandatory limitation is: `Authored specification only; no runtime impact, causality, risk, or merge safety is inferred.`
+8. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
 
 ## Spec fields at a glance
 
@@ -86,7 +91,8 @@ nodes:
     external: boolean      # default false
     storage: boolean       # true requires a security zone under deployment-ownership
 edges:
-  - from: string            # node id
+  - id: string              # required and stable when using compare
+    from: string            # node id
     to: string              # node id
     label: string           # required for security-boundary crossings under deployment-ownership
     type: realtime | batch | event | control | default

--- a/skills/architecture-diagram/references/spec-format.md
+++ b/skills/architecture-diagram/references/spec-format.md
@@ -62,7 +62,8 @@ Nesting is unlimited depth via `parent`. A zone's rendered box is the bounding b
 
 ```yaml
 edges:
-  - from: string        # required, a node id
+  - id: string          # optional for rendering; required, unique, and stable for `compare`
+    from: string        # required, a node id
     to: string            # required, a node id
     label: string           # optional
     type: realtime | batch | event | control | default   # optional, default "default"
@@ -73,6 +74,14 @@ An edge referencing a node id that doesn't exist in `nodes` is a spec error. Edg
 Under `profile: deployment-ownership`, a labeled cross-security-zone edge names the mechanism used at that boundary. The profile rejects an empty or whitespace-only label; it does not infer one from `type`, a service name, or endpoint labels.
 
 `type` drives both the connector's color/style and whether a legend renders — see the connection type table in `SKILL.md`. Cycles (a connects to b, b connects back to a) are fine; the rank-assignment algorithm terminates on them rather than looping, though a diagram with many cycles will look messier since rank order stops being a clean single flow direction.
+
+## Compare two specifications
+
+Run `python3 scripts/render.py compare base.yaml head.yaml` to emit a deterministic JSON receipt. It matches nodes by their authored `id` and edges by their authored `id`; rendering hashes, generated geometry, labels-as-identifiers, and endpoint-pair matching never participate.
+
+Each node or edge is `added`, `removed`, `unchanged`, or has one or more statuses from disjoint authored field groups: node semantic fields produce `changed`, node `zone` produces `moved`, edge semantic fields (`label`, `type`) produce `changed`, and edge endpoints (`from`, `to`) produce `rerouted`. `changed_fields` records the exact JSON-pointer paths and before/after authored values.
+
+Every receipt includes this limitation: `Authored specification only; no runtime impact, causality, risk, or merge safety is inferred.`
 
 ## What the renderer computes for you (don't set these)
 

--- a/skills/architecture-diagram/scripts/render.py
+++ b/skills/architecture-diagram/scripts/render.py
@@ -266,6 +266,7 @@ class Edge:
     dst: str
     label: str = ""
     type: str = "default"
+    id: str | None = None
 
 
 @dataclass
@@ -470,6 +471,7 @@ def load_spec(text: str) -> Spec:
             Edge(
                 src=raw["from"],
                 dst=raw["to"],
+                id=raw.get("id"),
                 label=raw.get("label", ""),
                 type=raw.get("type", "default"),
             )
@@ -484,6 +486,165 @@ def load_spec(text: str) -> Spec:
         edges=edges,
         profile=profile,
     )
+
+
+_NODE_SEMANTIC_FIELDS = (
+    "label",
+    "service",
+    "sublabel",
+    "color",
+    "provider",
+    "owner",
+    "external",
+    "storage",
+)
+_NODE_SCOPE_FIELDS = ("zone",)
+_EDGE_SEMANTIC_FIELDS = ("label", "type")
+_EDGE_ROUTE_FIELDS = ("from", "to")
+
+
+def _comparison_error(
+    code: str,
+    message: str,
+    subject: dict[str, object],
+    evidence: dict[str, object],
+    supported_fixes: tuple[str, ...],
+) -> SpecError:
+    return _spec_error(code, message, subject, evidence, supported_fixes)
+
+
+def _canonical_nodes(spec: Spec) -> dict[str, dict[str, object]]:
+    nodes: dict[str, dict[str, object]] = {}
+    for node in spec.nodes:
+        if not isinstance(node.id, str) or not node.id:
+            raise _comparison_error(
+                "compare/invalid-node-id",
+                "comparison requires every node to have a non-blank string id",
+                {"node": node.id},
+                {"id": node.id},
+                ("set each node `id` to a non-blank string",),
+            )
+        nodes[node.id] = {
+            "label": node.label,
+            "service": node.service,
+            "sublabel": node.sublabel,
+            "color": node.color,
+            "provider": node.provider,
+            "owner": node.owner,
+            "external": node.external,
+            "storage": node.storage,
+            "zone": node.zone,
+        }
+    return nodes
+
+
+def _canonical_edges(spec: Spec) -> dict[str, dict[str, object]]:
+    edges: dict[str, dict[str, object]] = {}
+    for edge in spec.edges:
+        if not isinstance(edge.id, str) or not edge.id:
+            raise _comparison_error(
+                "compare/missing-edge-id",
+                "comparison requires every edge to have a non-blank authored id",
+                {"edge": {"from": edge.src, "to": edge.dst}},
+                {"id": edge.id},
+                ("set a unique non-blank `id` on every edge",),
+            )
+        if edge.id in edges:
+            raise _comparison_error(
+                "compare/duplicate-edge-id",
+                f"comparison found duplicate edge id {edge.id!r}",
+                {"edge": edge.id},
+                {"id": edge.id},
+                ("make every edge `id` unique within its specification",),
+            )
+        edges[edge.id] = {
+            "from": edge.src,
+            "to": edge.dst,
+            "label": edge.label,
+            "type": edge.type,
+        }
+    return edges
+
+
+def _field_changes(
+    base: dict[str, object], head: dict[str, object], fields: tuple[str, ...]
+) -> list[dict[str, object]]:
+    return [
+        {"path": f"/{field}", "base": base[field], "head": head[field]}
+        for field in fields
+        if base[field] != head[field]
+    ]
+
+
+def _compare_entities(
+    base: dict[str, dict[str, object]],
+    head: dict[str, dict[str, object]],
+    semantic_fields: tuple[str, ...],
+    relocation_fields: tuple[str, ...],
+    relocation_status: str,
+) -> list[dict[str, object]]:
+    changes: list[dict[str, object]] = []
+    for entity_id in sorted(base.keys() | head.keys()):
+        before = base.get(entity_id)
+        after = head.get(entity_id)
+        if before is None:
+            changes.append(
+                {
+                    "id": entity_id,
+                    "status": ["added"],
+                    "changed_fields": [],
+                    "before": None,
+                    "after": after,
+                }
+            )
+            continue
+        if after is None:
+            changes.append(
+                {
+                    "id": entity_id,
+                    "status": ["removed"],
+                    "changed_fields": [],
+                    "before": before,
+                    "after": None,
+                }
+            )
+            continue
+
+        semantic_changes = _field_changes(before, after, semantic_fields)
+        relocation_changes = _field_changes(before, after, relocation_fields)
+        status = []
+        if semantic_changes:
+            status.append("changed")
+        if relocation_changes:
+            status.append(relocation_status)
+        changes.append(
+            {
+                "id": entity_id,
+                "status": status or ["unchanged"],
+                "changed_fields": semantic_changes + relocation_changes,
+            }
+        )
+    return changes
+
+
+def compare_specs(base: Spec, head: Spec) -> dict[str, list[dict[str, object]]]:
+    """Compare canonical authored IR only; no generated geometry participates."""
+    return {
+        "nodes": _compare_entities(
+            _canonical_nodes(base),
+            _canonical_nodes(head),
+            _NODE_SEMANTIC_FIELDS,
+            _NODE_SCOPE_FIELDS,
+            "moved",
+        ),
+        "edges": _compare_entities(
+            _canonical_edges(base),
+            _canonical_edges(head),
+            _EDGE_SEMANTIC_FIELDS,
+            _EDGE_ROUTE_FIELDS,
+            "rerouted",
+        ),
+    }
 
 
 # --- ranking + ordering ------------------------------------------------------
@@ -1990,6 +2151,38 @@ EXIT_FAILURE = 1
 EXIT_USAGE = 2
 
 RECEIPT_SCHEMA_VERSION = 1
+COMPARISON_LIMITATIONS = "Authored specification only; no runtime impact, causality, risk, or merge safety is inferred."
+
+
+def _comparison_receipt(
+    base_path: Path,
+    base_bytes: bytes | None,
+    head_path: Path,
+    head_bytes: bytes | None,
+    diagnostics: list[Diagnostic],
+    comparison: dict[str, list[dict[str, object]]] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
+        "command": "compare",
+        "type": "architecture-diagram",
+        "base": {
+            "path": str(base_path),
+            "sha256": _sha256(base_bytes) if base_bytes is not None else None,
+            "bytes": len(base_bytes) if base_bytes is not None else None,
+        },
+        "head": {
+            "path": str(head_path),
+            "sha256": _sha256(head_bytes) if head_bytes is not None else None,
+            "bytes": len(head_bytes) if head_bytes is not None else None,
+        },
+        "comparison": comparison or {"nodes": [], "edges": []},
+        "limitations": COMPARISON_LIMITATIONS,
+        "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
+    }
+
+
 _VALIDATION_CHECKS = (
     "spec",
     "layout",
@@ -2194,6 +2387,67 @@ def _read_spec(
         return source, source.decode("utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return _input_failure(command, spec_path, output, quality, exc)
+
+
+def _read_comparison_spec(
+    side: str, path: Path
+) -> tuple[bytes | None, Spec | None, Diagnostic | None]:
+    try:
+        source = path.read_bytes()
+        text = source.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return (
+            None,
+            None,
+            Diagnostic(
+                code=f"compare/{side}-unreadable",
+                severity=SEVERITY_ERROR,
+                message=f"cannot read {side} specification {str(path)!r}: {exc}",
+                subject={"path": str(path)},
+                supported_fixes=("pass an existing UTF-8 YAML specification",),
+            ),
+        )
+    try:
+        return source, load_spec(text), None
+    except SpecError as exc:
+        return source, None, exc.diagnostic
+
+
+def _compare(
+    base_path: Path, head_path: Path
+) -> tuple[int, dict[str, object], list[Diagnostic]]:
+    base_bytes, base_spec, base_error = _read_comparison_spec("base", base_path)
+    head_bytes, head_spec, head_error = _read_comparison_spec("head", head_path)
+    diagnostics = [error for error in (base_error, head_error) if error is not None]
+    if diagnostics:
+        return (
+            EXIT_FAILURE,
+            _comparison_receipt(
+                base_path, base_bytes, head_path, head_bytes, diagnostics
+            ),
+            diagnostics,
+        )
+
+    assert base_spec is not None
+    assert head_spec is not None
+    try:
+        comparison = compare_specs(base_spec, head_spec)
+    except SpecError as exc:
+        diagnostics = [exc.diagnostic]
+        return (
+            EXIT_FAILURE,
+            _comparison_receipt(
+                base_path, base_bytes, head_path, head_bytes, diagnostics
+            ),
+            diagnostics,
+        )
+    return (
+        EXIT_OK,
+        _comparison_receipt(
+            base_path, base_bytes, head_path, head_bytes, [], comparison
+        ),
+        [],
+    )
 
 
 def _icon_lookup(cache_dir: Path | None, sha: str | None) -> IconLookup:
@@ -2425,8 +2679,18 @@ def main(argv: list[str] | None = None) -> int:
     deliver_parser.add_argument(
         "-o", "--output", type=Path, required=True, help="target SVG path"
     )
+    compare_parser = commands.add_parser(
+        "compare", help="compare two authored specifications into a JSON receipt"
+    )
+    compare_parser.add_argument("base", type=Path, help="baseline UTF-8 YAML spec")
+    compare_parser.add_argument("head", type=Path, help="changed UTF-8 YAML spec")
+
     args = parser.parse_args(argv)
 
+    if args.command == "compare":
+        code, receipt, diagnostics = _compare(args.base, args.head)
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+        return code
     if args.command == "validate":
         code, receipt, diagnostics = _validate(
             args.spec, args.cache_dir, args.sha, args.quality, args.layout_json

--- a/skills/architecture-diagram/tests/fixtures/spec-compare-base.yaml
+++ b/skills/architecture-diagram/tests/fixtures/spec-compare-base.yaml
@@ -1,0 +1,29 @@
+zones:
+  - id: left
+  - id: right
+nodes:
+  - id: changed
+    label: Before
+    zone: left
+  - id: moved
+    label: Moved
+    zone: left
+  - id: unchanged
+    label: Unchanged
+    zone: left
+  - id: removed
+    label: Removed
+    zone: left
+edges:
+  - id: changed-edge
+    from: changed
+    to: unchanged
+    label: before
+  - id: rerouted-edge
+    from: changed
+    to: unchanged
+    label: fixed
+  - id: removed-edge
+    from: moved
+    to: unchanged
+    label: removed

--- a/skills/architecture-diagram/tests/fixtures/spec-compare-head.yaml
+++ b/skills/architecture-diagram/tests/fixtures/spec-compare-head.yaml
@@ -1,0 +1,29 @@
+zones:
+  - id: left
+  - id: right
+nodes:
+  - id: changed
+    label: After
+    zone: left
+  - id: moved
+    label: Moved
+    zone: right
+  - id: unchanged
+    label: Unchanged
+    zone: left
+  - id: added
+    label: Added
+    zone: left
+edges:
+  - id: changed-edge
+    from: changed
+    to: unchanged
+    label: after
+  - id: rerouted-edge
+    from: moved
+    to: unchanged
+    label: fixed
+  - id: added-edge
+    from: added
+    to: unchanged
+    label: added

--- a/skills/architecture-diagram/tests/fixtures/spec-compare-reordered.yaml
+++ b/skills/architecture-diagram/tests/fixtures/spec-compare-reordered.yaml
@@ -1,0 +1,29 @@
+zones:
+  - id: right
+  - id: left
+nodes:
+  - id: removed
+    label: Removed
+    zone: left
+  - id: unchanged
+    label: Unchanged
+    zone: left
+  - id: moved
+    label: Moved
+    zone: left
+  - id: changed
+    label: Before
+    zone: left
+edges:
+  - id: removed-edge
+    from: moved
+    to: unchanged
+    label: removed
+  - id: rerouted-edge
+    from: changed
+    to: unchanged
+    label: fixed
+  - id: changed-edge
+    from: changed
+    to: unchanged
+    label: before

--- a/skills/architecture-diagram/tests/test_spec_compare.py
+++ b/skills/architecture-diagram/tests/test_spec_compare.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import render
+from render import compare_specs, load_spec
+
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _statuses(
+    receipt: dict[str, list[dict[str, object]]], entity: str
+) -> dict[str, list[str]]:
+    statuses: dict[str, list[str]] = {}
+    for change in receipt[entity]:
+        status = change["status"]
+        assert isinstance(status, list)
+        assert all(isinstance(item, str) for item in status)
+        statuses[str(change["id"])] = status
+    return statuses
+
+
+def test_compare_specs_classifies_disjoint_change_groups() -> None:
+    receipt = compare_specs(
+        load_spec((_FIXTURES / "spec-compare-base.yaml").read_text()),
+        load_spec((_FIXTURES / "spec-compare-head.yaml").read_text()),
+    )
+
+    assert _statuses(receipt, "nodes") == {
+        "added": ["added"],
+        "changed": ["changed"],
+        "moved": ["moved"],
+        "removed": ["removed"],
+        "unchanged": ["unchanged"],
+    }
+    assert _statuses(receipt, "edges") == {
+        "added-edge": ["added"],
+        "changed-edge": ["changed"],
+        "removed-edge": ["removed"],
+        "rerouted-edge": ["rerouted"],
+    }
+    changed_node = next(
+        change for change in receipt["nodes"] if change["id"] == "changed"
+    )
+    moved_node = next(change for change in receipt["nodes"] if change["id"] == "moved")
+    rerouted_edge = next(
+        change for change in receipt["edges"] if change["id"] == "rerouted-edge"
+    )
+    assert changed_node["changed_fields"] == [
+        {"path": "/label", "base": "Before", "head": "After"}
+    ]
+    assert moved_node["changed_fields"] == [
+        {"path": "/zone", "base": "left", "head": "right"}
+    ]
+    assert rerouted_edge["changed_fields"] == [
+        {"path": "/from", "base": "changed", "head": "moved"}
+    ]
+
+
+def test_compare_specs_canonicalizes_entity_order() -> None:
+    receipt = compare_specs(
+        load_spec((_FIXTURES / "spec-compare-base.yaml").read_text()),
+        load_spec((_FIXTURES / "spec-compare-reordered.yaml").read_text()),
+    )
+
+    assert all(
+        status == ["unchanged"] for status in _statuses(receipt, "nodes").values()
+    )
+    assert all(
+        status == ["unchanged"] for status in _statuses(receipt, "edges").values()
+    )
+
+
+def test_compare_cli_always_includes_the_limitations_text(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = render.main(
+        [
+            "compare",
+            str(_FIXTURES / "spec-compare-base.yaml"),
+            str(_FIXTURES / "spec-compare-head.yaml"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == render.EXIT_OK
+    assert captured.err == ""
+    assert json.loads(captured.out)["limitations"] == render.COMPARISON_LIMITATIONS
+
+
+def test_compare_cli_rejects_an_edge_without_an_authored_id(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec = tmp_path / "missing-id.yaml"
+    spec.write_text("nodes:\n  - id: a\n  - id: b\nedges:\n  - from: a\n    to: b\n")
+
+    code = render.main(["compare", str(spec), str(spec)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == render.EXIT_FAILURE
+    assert [finding["code"] for finding in payload["diagnostics"]] == [
+        "compare/missing-edge-id"
+    ]
+    assert payload["limitations"] == render.COMPARISON_LIMITATIONS


### PR DESCRIPTION
## Summary
- Add deterministic comparison receipts for two authored diagram specifications.
- Classify node and edge additions, removals, semantic changes, moves, and reroutes by explicit IDs.
- Include exact changed paths and the explicit authored-specification limitation.

## Verification
- uv run pytest skills/architecture-diagram/engine/tests -q
- just check
