### PR TITLE
refactor(architecture-diagram): extract icons and svg modules

### DIFF
--- a/skills/architecture-diagram/engine/icons.py
+++ b/skills/architecture-diagram/engine/icons.py
@@ -1,0 +1,168 @@
+"""Verified local and bundled icon lookup implementations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from . import fetch_icons
+from .data import data_path
+from .diagnostics import Diagnostic, SEVERITY_ERROR
+
+
+@dataclass
+class IconRef:
+    view_box: str
+    body: str
+
+
+class IconLookup(Protocol):
+    def __call__(self, provider: str, service_slug: str) -> IconRef | None: ...
+
+
+class IconCacheError(RuntimeError):
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        super().__init__(diagnostic.message)
+        self.diagnostic = diagnostic
+
+
+@dataclass
+class CacheIconLookup:
+    """Resolve cache entries only after validating their manifest digest."""
+
+    cache_dir: Path
+    sha: str
+
+    def _error(
+        self,
+        code: str,
+        message: str,
+        provider: str,
+        service_slug: str,
+        evidence: dict[str, object],
+    ) -> IconCacheError:
+        return IconCacheError(
+            Diagnostic(
+                code=code,
+                severity=SEVERITY_ERROR,
+                message=message,
+                subject={"provider": provider, "service": service_slug},
+                evidence=evidence,
+                supported_fixes=(
+                    f"rebuild the {provider} icon cache: "
+                    f"fetch_icons.py --provider {provider} --force",
+                ),
+                suppresses=("icon/not-found",),
+            )
+        )
+
+    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
+        cache_root = self.cache_dir / self.sha
+        path = cache_root / provider / f"{service_slug}.json"
+        if not path.exists():
+            return None
+        manifest_path = cache_root / "manifest.json"
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            payload = path.read_bytes()
+        except (OSError, json.JSONDecodeError) as exc:
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has no readable integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path), "error": str(exc)},
+            ) from exc
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("format_version") != fetch_icons.CACHE_MANIFEST_VERSION
+            or manifest.get("sha") != self.sha
+            or not isinstance(manifest.get("providers"), dict)
+        ):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has an unsupported integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        provider_stats = manifest["providers"].get(provider)
+        if not isinstance(provider_stats, dict) or not isinstance(
+            provider_stats.get("icons"), dict
+        ):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} is absent from its integrity manifest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        record = provider_stats["icons"].get(path.name)
+        expected_digest = record.get("sha256") if isinstance(record, dict) else None
+        actual_digest = hashlib.sha256(payload).hexdigest()
+        if not isinstance(expected_digest, str):
+            raise self._error(
+                "icon/cache-unverified",
+                f"icon cache entry {path} has no recorded content digest",
+                provider,
+                service_slug,
+                {"path": str(path)},
+            )
+        if actual_digest != expected_digest:
+            raise self._error(
+                "icon/digest-mismatch",
+                f"icon cache entry {path} does not match its recorded digest",
+                provider,
+                service_slug,
+                {
+                    "path": str(path),
+                    "expected_sha256": expected_digest,
+                    "actual_sha256": actual_digest,
+                },
+            )
+        try:
+            data = json.loads(payload)
+            return IconRef(view_box=data["viewBox"], body=data["body"])
+        except (KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise self._error(
+                "icon/cache-unverified",
+                f"verified icon cache entry {path} is not a usable icon",
+                provider,
+                service_slug,
+                {"path": str(path), "error": str(exc)},
+            ) from exc
+
+
+@dataclass
+class BundledGenericIconLookup:
+    """Resolve the always-available generic icon catalog without a network cache."""
+
+    path: Path = field(
+        default_factory=lambda: data_path("assets", "generic-icons.json")
+    )
+
+    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
+        if provider != "generic" or not self.path.exists():
+            return None
+        data = json.loads(self.path.read_text())
+        entry = data.get(service_slug)
+        if entry is None:
+            return None
+        return IconRef(view_box=entry["viewBox"], body=entry["body"])
+
+
+@dataclass
+class CompositeIconLookup:
+    """Return the first result from the configured lookup sequence."""
+
+    lookups: list[IconLookup]
+
+    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
+        for lookup in self.lookups:
+            reference = lookup(provider, service_slug)
+            if reference is not None:
+                return reference
+        return None

--- a/skills/architecture-diagram/engine/render.py
+++ b/skills/architecture-diagram/engine/render.py
@@ -29,12 +29,8 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
-
 
 from . import fetch_icons
-from .data import data_path
-
 from .compare import compare_specs
 from .diagnostics import (
     QUALITY_PROFILES,
@@ -45,8 +41,6 @@ from .diagnostics import (
     count_by_severity,
     suppress_derived,
 )
-from .model import Node, Spec, Zone
-from .spec import SpecError, load_spec
 from .geometry_checks import (
     check_ambiguous_corridors,
     check_edge_through_node,
@@ -56,523 +50,27 @@ from .geometry_checks import (
     check_route_rhythm,
     edge_label_box,
 )
+from .icons import (
+    BundledGenericIconLookup,
+    CacheIconLookup,
+    CompositeIconLookup,
+    IconCacheError,
+    IconLookup,
+    IconRef,
+)
 from .layout import (
-    EDGE_LABEL_FONT_SIZE,
-    ICON,
-    MARGIN,
-    MIN_NODE_TEXT_FONT_SIZE,
-    NODE_H,
-    NODE_LABEL_FONT_SIZE,
-    NODE_SUBLABEL_FONT_SIZE,
-    NODE_TEXT_PADDING,
-    NODE_W,
     Box,
     assign_ranks,
     box_evidence,
     compute_positions,
     compute_zone_boxes,
-    icon_box,
     order_within_ranks,
-    text_width,
-    zone_ancestors,
 )
+from .model import Spec
 from .profile import check_deployment_profile
 from .routing import RoutedEdge, route_edges
-
-# --- layout constants -------------------------------------------------------
-
-# Shared-side ports must stay away from the icon corners and remain legible as
-# fan-out grows. A 64px icon leaves a 32px usable span after 16px gutters:
-# five ports therefore land 8px apart without one endpoint covering another.
-# Rejoin a lone source/destination pair when their spread ports are nearly
-# aligned. This keeps short hops straight without collapsing a shared side.
-# Orthogonal detours leave a real 24px endpoint stub. Centered channel offsets
-# span at most +/-16px, so even their nearest first segment is at least 8px.
-# Route rhythm failures are composition findings: every segment needs 8px and
-# a segment between two turns needs 16px to remain visually distinguishable.
-# A route passing within two pixels of an unrelated node visually reads as
-# entering it. Expand every unrelated node by this clearance before testing.
-# Cross-product signs closer than this are endpoint touches or collinear runs,
-# not an interior X that makes two unrelated relationships ambiguous.
-# Unrelated collinear paths sharing eight pixels or more read as one ambiguous
-# corridor rather than distinct connections.
-# Edge labels use the same glyph estimator as nodes. A route closer than four
-# pixels to the label mask makes the connection annotation unreadable.
-# Node labels stay readable at no smaller than 6px. Their estimated width at
-# that floor must remain within the node plus 8px tolerance, while normal
-# fitted text remains inside the 8px-padded node box.
-
-
-EDGE_COLORS = {
-    "realtime": "#2563EB",
-    "batch": "#DC2626",
-    "event": "#16A34A",
-    "control": "#D97706",
-    "default": "#5A6C86",
-}
-
-# Average glyph-width factor (fraction of font-size) for a system-ui-style
-# sans stack, bucketed by character class. Good enough for label-fit and
-# zone-label-width decisions; not a substitute for real font metrics.
-
-
-def _escape(text: str) -> str:
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
-# --- diagnostics -------------------------------------------------------------
-
-
-# Codes in this namespace describe how the drawing reads rather than whether
-# the spec is answerable: two routes crossing, a label sitting on a route.
-# They are warnings under the standard profile and errors under showcase, so
-# stricter geometry rules can ship without breaking specs that already render.
-
-
-# --- spec -------------------------------------------------------------------
-
-
-# --- ranking + ordering ------------------------------------------------------
-
-
-# --- geometry ----------------------------------------------------------------
-
-
-# --- routing -----------------------------------------------------------------
-
-
-# --- icon resolution ----------------------------------------------------------
-
-
-@dataclass
-class IconRef:
-    view_box: str
-    body: str
-
-
-class IconLookup(Protocol):
-    def __call__(self, provider: str, service_slug: str) -> IconRef | None: ...
-
-
-class IconCacheError(RuntimeError):
-    def __init__(self, diagnostic: Diagnostic) -> None:
-        super().__init__(diagnostic.message)
-        self.diagnostic = diagnostic
-
-
-@dataclass
-class CacheIconLookup:
-    """Verified local cloud-provider icon cache — see fetch_icons.py."""
-
-    cache_dir: Path
-    sha: str
-
-    def _error(
-        self,
-        code: str,
-        message: str,
-        provider: str,
-        service_slug: str,
-        evidence: dict[str, object],
-    ) -> IconCacheError:
-        return IconCacheError(
-            Diagnostic(
-                code=code,
-                severity=SEVERITY_ERROR,
-                message=message,
-                subject={"provider": provider, "service": service_slug},
-                evidence=evidence,
-                supported_fixes=(
-                    f"rebuild the {provider} icon cache: "
-                    f"fetch_icons.py --provider {provider} --force",
-                ),
-                suppresses=("icon/not-found",),
-            )
-        )
-
-    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
-        cache_root = self.cache_dir / self.sha
-        path = cache_root / provider / f"{service_slug}.json"
-        if not path.exists():
-            return None
-        manifest_path = cache_root / "manifest.json"
-        try:
-            manifest = json.loads(manifest_path.read_text())
-            payload = path.read_bytes()
-        except (OSError, json.JSONDecodeError) as exc:
-            raise self._error(
-                "icon/cache-unverified",
-                f"icon cache entry {path} has no readable integrity manifest",
-                provider,
-                service_slug,
-                {"path": str(path), "error": str(exc)},
-            ) from exc
-        if (
-            not isinstance(manifest, dict)
-            or manifest.get("format_version") != fetch_icons.CACHE_MANIFEST_VERSION
-            or manifest.get("sha") != self.sha
-            or not isinstance(manifest.get("providers"), dict)
-        ):
-            raise self._error(
-                "icon/cache-unverified",
-                f"icon cache entry {path} has an unsupported integrity manifest",
-                provider,
-                service_slug,
-                {"path": str(path)},
-            )
-        provider_stats = manifest["providers"].get(provider)
-        if not isinstance(provider_stats, dict) or not isinstance(
-            provider_stats.get("icons"), dict
-        ):
-            raise self._error(
-                "icon/cache-unverified",
-                f"icon cache entry {path} is absent from its integrity manifest",
-                provider,
-                service_slug,
-                {"path": str(path)},
-            )
-        record = provider_stats["icons"].get(path.name)
-        expected_digest = record.get("sha256") if isinstance(record, dict) else None
-        actual_digest = hashlib.sha256(payload).hexdigest()
-        if not isinstance(expected_digest, str):
-            raise self._error(
-                "icon/cache-unverified",
-                f"icon cache entry {path} has no recorded content digest",
-                provider,
-                service_slug,
-                {"path": str(path)},
-            )
-        if actual_digest != expected_digest:
-            raise self._error(
-                "icon/digest-mismatch",
-                f"icon cache entry {path} does not match its recorded digest",
-                provider,
-                service_slug,
-                {
-                    "path": str(path),
-                    "expected_sha256": expected_digest,
-                    "actual_sha256": actual_digest,
-                },
-            )
-        try:
-            data = json.loads(payload)
-            return IconRef(view_box=data["viewBox"], body=data["body"])
-        except (KeyError, TypeError, json.JSONDecodeError) as exc:
-            raise self._error(
-                "icon/cache-unverified",
-                f"verified icon cache entry {path} is not a usable icon",
-                provider,
-                service_slug,
-                {"path": str(path), "error": str(exc)},
-            ) from exc
-
-
-@dataclass
-class BundledGenericIconLookup:
-    """Hand-drawn, non-cloud icon catalog shipped inside this skill package
-    (assets/generic-icons.json, generated from references/icons-generic.md).
-    No network, no cache directory — always available. Only answers for
-    provider == "generic"; every cloud provider is CacheIconLookup's job."""
-
-    path: Path = field(
-        default_factory=lambda: data_path("assets", "generic-icons.json")
-    )
-
-    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
-        if provider != "generic" or not self.path.exists():
-            return None
-        data = json.loads(self.path.read_text())
-        entry = data.get(service_slug)
-        if entry is None:
-            return None
-        return IconRef(view_box=entry["viewBox"], body=entry["body"])
-
-
-@dataclass
-class CompositeIconLookup:
-    """Tries each lookup in order, returning the first hit. The default
-    render.py CLI wiring is [CacheIconLookup, BundledGenericIconLookup] so a
-    single spec can freely mix cloud-provider nodes and provider: generic
-    nodes without the caller needing to know which backend serves which."""
-
-    lookups: list[IconLookup]
-
-    def __call__(self, provider: str, service_slug: str) -> IconRef | None:
-        for lookup in self.lookups:
-            ref = lookup(provider, service_slug)
-            if ref is not None:
-                return ref
-        return None
-
-
-# --- emit ----------------------------------------------------------------------
-
-
-def _fitted_node_font_size(text: str, preferred_size: float, box: Box) -> float | None:
-    """Return a readable fitted size, or None when the label cannot fit safely."""
-    available = box.w - NODE_TEXT_PADDING
-    projected_minimum_width = text_width(text, MIN_NODE_TEXT_FONT_SIZE)
-    if projected_minimum_width > box.w + NODE_TEXT_PADDING:
-        return None
-    unit_width = text_width(text, 1.0)
-    if unit_width == 0:
-        return preferred_size
-    fitted_size = min(preferred_size, available / unit_width)
-    return fitted_size if fitted_size >= MIN_NODE_TEXT_FONT_SIZE else None
-
-
-def _label_overflow(
-    node_id: str, field_name: str, text: str, preferred_size: float, box: Box
-) -> Diagnostic:
-    return Diagnostic(
-        code="layout/label-overflow",
-        severity=SEVERITY_ERROR,
-        message=f"{field_name} cannot fit inside its node box: {text!r} on {node_id!r}",
-        subject={"node": node_id, "field": field_name},
-        evidence={
-            "text": text,
-            "estimated_width": round(text_width(text, preferred_size), 2),
-            "available_width": box.w - NODE_TEXT_PADDING,
-            "projected_minimum_width": round(
-                text_width(text, MIN_NODE_TEXT_FONT_SIZE), 2
-            ),
-            "minimum_font_size": MIN_NODE_TEXT_FONT_SIZE,
-            "maximum_projected_width": box.w + NODE_TEXT_PADDING,
-        },
-        supported_fixes=(
-            "shorten the text",
-            "move the detail into `sublabel`",
-        ),
-    )
-
-
-def _icon_not_found(node: Node) -> Diagnostic:
-    fixes = ["use the exact slug from that provider's reference service map"]
-    # The generic set is bundled in the package, so telling the author to
-    # fetch a cache for it would send them after a cache that never exists.
-    if node.provider != "generic":
-        fixes.insert(
-            0, f"warm the icon cache: fetch_icons.py --provider {node.provider}"
-        )
-    fixes.append(
-        "drop the node's `service` field to render the labeled placeholder deliberately"
-    )
-    return Diagnostic(
-        code="icon/not-found",
-        severity=SEVERITY_ERROR,
-        message=(
-            f"no icon for node {node.id!r} "
-            f"(service={node.service!r}, provider={node.provider!r})"
-        ),
-        subject={"node": node.id},
-        evidence={"service": node.service, "provider": node.provider},
-        supported_fixes=tuple(fixes),
-    )
-
-
-def _node_svg(
-    node: Node, box: Box, icon: IconRef | None, diagnostics: list[Diagnostic]
-) -> str:
-    parts = [f'<g id="node-{_escape(node.id)}">']
-    icon_pos = icon_box(box)
-    parts.append(
-        f'<rect x="{icon_pos.x:g}" y="{icon_pos.y:g}" width="{ICON:g}" height="{ICON:g}" rx="10" fill="{node.color}"/>'
-    )
-    if icon is not None:
-        inset = 9
-        parts.append(
-            f'<svg x="{icon_pos.x + inset:g}" y="{icon_pos.y + inset:g}" width="{ICON - inset * 2:g}" '
-            f'height="{ICON - inset * 2:g}" viewBox="{icon.view_box}" color="#FFFFFF">{icon.body}</svg>'
-        )
-    else:
-        if node.service:
-            diagnostics.append(_icon_not_found(node))
-        cx, cy = icon_pos.x + ICON / 2, icon_pos.y + ICON / 2
-        initial = _escape(node.label[:1].upper() or "?")
-        parts.append(
-            f'<text x="{cx:g}" y="{cy + 6:g}" font-size="22" font-weight="700" text-anchor="middle" fill="#FFFFFF">{initial}</text>'
-        )
-    label_y = box.y + ICON + 18
-    label_font_size = _fitted_node_font_size(node.label, NODE_LABEL_FONT_SIZE, box)
-    if label_font_size is None:
-        diagnostics.append(
-            _label_overflow(
-                node.id,
-                "label",
-                node.label,
-                NODE_LABEL_FONT_SIZE,
-                box,
-            )
-        )
-        label_font_size = MIN_NODE_TEXT_FONT_SIZE
-    parts.append(
-        f'<text x="{box.x + box.w / 2:g}" y="{label_y:g}" font-size="{label_font_size:g}" font-weight="600" '
-        f'text-anchor="middle" fill="#1F2937">{_escape(node.label)}</text>'
-    )
-    if node.sublabel:
-        sub_font_size = _fitted_node_font_size(
-            node.sublabel, NODE_SUBLABEL_FONT_SIZE, box
-        )
-        if sub_font_size is None:
-            diagnostics.append(
-                _label_overflow(
-                    node.id,
-                    "sublabel",
-                    node.sublabel,
-                    NODE_SUBLABEL_FONT_SIZE,
-                    box,
-                )
-            )
-            sub_font_size = MIN_NODE_TEXT_FONT_SIZE
-        parts.append(
-            f'<text x="{box.x + box.w / 2:g}" y="{label_y + 15:g}" font-size="{sub_font_size:g}" '
-            f'text-anchor="middle" fill="#6B7280">{_escape(node.sublabel)}</text>'
-        )
-    parts.append("</g>")
-    return "".join(parts)
-
-
-def _zone_svg(zone: Zone, box: Box) -> str:
-    return (
-        f'<g id="zone-{_escape(zone.id)}">'
-        f'<rect x="{box.x:g}" y="{box.y:g}" width="{box.w:g}" height="{box.h:g}" rx="8" '
-        f'fill="none" stroke="#8C4FFF" stroke-width="1.5" stroke-dasharray="6 4"/>'
-        f'<text x="{box.x + 12:g}" y="{box.y + 18:g}" font-size="11" font-weight="600" fill="#8C4FFF">{_escape(zone.label)}</text>'
-        f"</g>"
-    )
-
-
-def _edge_svg(routed: RoutedEdge) -> str:
-    e = routed.edge
-    color = EDGE_COLORS.get(e.type, EDGE_COLORS["default"])
-    dash = ' stroke-dasharray="6 4"' if e.type == "batch" else ""
-    marker = f'marker-end="url(#arrow-{e.type})"'
-    parts = [f'<g id="edge-{_escape(e.src)}-{_escape(e.dst)}">']
-    parts.append(
-        f'<path d="{routed.path_d}" fill="none" stroke="{color}" stroke-width="1.8"{dash} {marker}/>'
-    )
-    if e.label:
-        mx, my = routed.label_pos
-        parts.append(
-            f'<text x="{mx:g}" y="{my:g}" font-size="{EDGE_LABEL_FONT_SIZE:g}" fill="{color}">{_escape(e.label)}</text>'
-        )
-    parts.append("</g>")
-    return "".join(parts)
-
-
-def _legend_svg(edge_types: set[str], x: float, y: float) -> str:
-    parts = ['<g id="legend">']
-    for i, t in enumerate(sorted(edge_types)):
-        color = EDGE_COLORS.get(t, EDGE_COLORS["default"])
-        ly = y + i * 18
-        parts.append(
-            f'<line x1="{x:g}" y1="{ly:g}" x2="{x + 24:g}" y2="{ly:g}" stroke="{color}" stroke-width="2"/>'
-        )
-        parts.append(
-            f'<text x="{x + 30:g}" y="{ly + 4:g}" font-size="10" fill="#374151">{_escape(t)}</text>'
-        )
-    parts.append("</g>")
-    return "".join(parts)
-
-
-def emit_svg(
-    spec: Spec,
-    node_boxes: dict[str, Box],
-    zone_boxes: dict[str, Box],
-    routed_edges: list[RoutedEdge],
-    icons: dict[str, IconRef | None],
-    diagnostics: list[Diagnostic],
-) -> str:
-    zone_by_id = {z.id: z for z in spec.zones}
-    all_extents = [b for b in node_boxes.values()] + [b for b in zone_boxes.values()]
-    width = max((b.x2 for b in all_extents), default=NODE_W) + MARGIN
-    height = max((b.y2 for b in all_extents), default=NODE_H) + MARGIN
-
-    edge_types = {e.type for e in spec.edges}
-    show_legend = len(edge_types) > 1
-    legend_h = 12 + len(edge_types) * 18 if show_legend else 0
-    height += legend_h
-
-    svg_open = (
-        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width:g}" height="{height:g}" '
-        f'viewBox="0 0 {width:g} {height:g}" font-family="Segoe UI, system-ui, sans-serif">'
-    )
-    parts = [
-        svg_open,
-        f'<rect width="{width:g}" height="{height:g}" fill="#FAFAF8"/>',
-        "<defs>",
-    ]
-    for t, color in EDGE_COLORS.items():
-        parts.append(
-            f'<marker id="arrow-{t}" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" '
-            f'orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="{color}"/></marker>'
-        )
-    parts.append("</defs>")
-
-    if spec.title:
-        parts.append(
-            f'<text x="{MARGIN:g}" y="{MARGIN + 14:g}" font-size="17" font-weight="700" fill="#1F2937">{_escape(spec.title)}</text>'
-        )
-
-    # zones first (background layer), parents before children so children draw on top
-    for zid in sorted(zone_boxes, key=lambda z: len(zone_ancestors(spec, z))):
-        parts.append(_zone_svg(zone_by_id[zid], zone_boxes[zid]))
-
-    for routed in routed_edges:
-        parts.append(_edge_svg(routed))
-
-    for n in spec.nodes:
-        parts.append(_node_svg(n, node_boxes[n.id], icons.get(n.id), diagnostics))
-
-    if show_legend:
-        parts.append(_legend_svg(edge_types, MARGIN, height - legend_h + 6))
-
-    parts.append("</svg>")
-    return "".join(parts)
-
-
-# --- editability check --------------------------------------------------------
-
-_FORBIDDEN_MARKERS = ("<image", "base64,", "<use ", "<use>")
-
-
-def check_editability(svg_text: str) -> list[Diagnostic]:
-    """Enforce the output contract this rewrite exists to deliver: no raster
-    fallback, no `<use>` clones (Inkscape/MDN both document that clone nodes
-    aren't independently node-editable — see `references/editability.md`),
-    no external references. A regression here means a future change quietly
-    reintroduced one of the failure modes the whole design avoids."""
-    out: list[Diagnostic] = []
-    for marker in _FORBIDDEN_MARKERS:
-        if marker in svg_text:
-            out.append(
-                Diagnostic(
-                    code="editability/forbidden-markup",
-                    severity=SEVERITY_ERROR,
-                    message=f"editability violation: found {marker!r}",
-                    evidence={"marker": marker},
-                    supported_fixes=(
-                        "file this as a renderer bug: the spec cannot introduce this markup",
-                    ),
-                )
-            )
-    for marker in ('href="http', 'xlink:href="http'):
-        if marker in svg_text:
-            out.append(
-                Diagnostic(
-                    code="editability/external-reference",
-                    severity=SEVERITY_ERROR,
-                    message=f"editability violation: external reference ({marker!r})",
-                    evidence={"marker": marker},
-                    supported_fixes=(
-                        "file this as a renderer bug: the output must stay self-contained",
-                    ),
-                )
-            )
-    return out
-
-
-# --- top-level render ----------------------------------------------------------
+from .spec import SpecError, load_spec
+from .svg import check_editability, emit_svg
 
 
 @dataclass
@@ -610,15 +108,15 @@ def render(
     diagnostics += check_label_route_clearance(routed_edges)
 
     icons: dict[str, IconRef | None] = {}
-    for n in spec.nodes:
-        if not n.service:
-            icons[n.id] = None
+    for node in spec.nodes:
+        if not node.service:
+            icons[node.id] = None
             continue
         try:
-            icons[n.id] = icon_lookup(n.provider, n.service)
+            icons[node.id] = icon_lookup(node.provider, node.service)
         except IconCacheError as exc:
             diagnostics.append(exc.diagnostic)
-            icons[n.id] = None
+            icons[node.id] = None
 
     svg = emit_svg(spec, node_boxes, zone_boxes, routed_edges, icons, diagnostics)
     diagnostics += check_editability(svg)

--- a/skills/architecture-diagram/engine/svg.py
+++ b/skills/architecture-diagram/engine/svg.py
@@ -1,0 +1,285 @@
+"""Editable SVG emission and output editability validation."""
+
+from __future__ import annotations
+
+from .diagnostics import Diagnostic, SEVERITY_ERROR
+from .icons import IconRef
+from .layout import (
+    EDGE_LABEL_FONT_SIZE,
+    ICON,
+    MARGIN,
+    MIN_NODE_TEXT_FONT_SIZE,
+    NODE_H,
+    NODE_LABEL_FONT_SIZE,
+    NODE_SUBLABEL_FONT_SIZE,
+    NODE_TEXT_PADDING,
+    NODE_W,
+    Box,
+    icon_box,
+    text_width,
+    zone_ancestors,
+)
+from .model import Node, Spec, Zone
+from .routing import RoutedEdge
+
+EDGE_COLORS = {
+    "realtime": "#2563EB",
+    "batch": "#DC2626",
+    "event": "#16A34A",
+    "control": "#D97706",
+    "default": "#5A6C86",
+}
+
+_FORBIDDEN_MARKERS = ("<image", "base64,", "<use ", "<use>")
+
+
+def _escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _fitted_node_font_size(text: str, preferred_size: float, box: Box) -> float | None:
+    """Return a readable fitted size, or None when the label cannot fit safely."""
+    available = box.w - NODE_TEXT_PADDING
+    projected_minimum_width = text_width(text, MIN_NODE_TEXT_FONT_SIZE)
+    if projected_minimum_width > box.w + NODE_TEXT_PADDING:
+        return None
+    unit_width = text_width(text, 1.0)
+    if unit_width == 0:
+        return preferred_size
+    fitted_size = min(preferred_size, available / unit_width)
+    return fitted_size if fitted_size >= MIN_NODE_TEXT_FONT_SIZE else None
+
+
+def _label_overflow(
+    node_id: str, field_name: str, text: str, preferred_size: float, box: Box
+) -> Diagnostic:
+    return Diagnostic(
+        code="layout/label-overflow",
+        severity=SEVERITY_ERROR,
+        message=f"{field_name} cannot fit inside its node box: {text!r} on {node_id!r}",
+        subject={"node": node_id, "field": field_name},
+        evidence={
+            "text": text,
+            "estimated_width": round(text_width(text, preferred_size), 2),
+            "available_width": box.w - NODE_TEXT_PADDING,
+            "projected_minimum_width": round(
+                text_width(text, MIN_NODE_TEXT_FONT_SIZE), 2
+            ),
+            "minimum_font_size": MIN_NODE_TEXT_FONT_SIZE,
+            "maximum_projected_width": box.w + NODE_TEXT_PADDING,
+        },
+        supported_fixes=("shorten the text", "move the detail into `sublabel`"),
+    )
+
+
+def _icon_not_found(node: Node) -> Diagnostic:
+    fixes = ["use the exact slug from that provider's reference service map"]
+    if node.provider != "generic":
+        fixes.insert(
+            0, f"warm the icon cache: fetch_icons.py --provider {node.provider}"
+        )
+    fixes.append(
+        "drop the node's `service` field to render the labeled placeholder deliberately"
+    )
+    return Diagnostic(
+        code="icon/not-found",
+        severity=SEVERITY_ERROR,
+        message=(
+            f"no icon for node {node.id!r} "
+            f"(service={node.service!r}, provider={node.provider!r})"
+        ),
+        subject={"node": node.id},
+        evidence={"service": node.service, "provider": node.provider},
+        supported_fixes=tuple(fixes),
+    )
+
+
+def _node_svg(
+    node: Node, box: Box, icon: IconRef | None, diagnostics: list[Diagnostic]
+) -> str:
+    parts = [f'<g id="node-{_escape(node.id)}">']
+    icon_position = icon_box(box)
+    parts.append(
+        f'<rect x="{icon_position.x:g}" y="{icon_position.y:g}" width="{ICON:g}" height="{ICON:g}" rx="10" fill="{node.color}"/>'
+    )
+    if icon is not None:
+        inset = 9
+        parts.append(
+            f'<svg x="{icon_position.x + inset:g}" y="{icon_position.y + inset:g}" width="{ICON - inset * 2:g}" '
+            f'height="{ICON - inset * 2:g}" viewBox="{icon.view_box}" color="#FFFFFF">{icon.body}</svg>'
+        )
+    else:
+        if node.service:
+            diagnostics.append(_icon_not_found(node))
+        center_x, center_y = (
+            icon_position.x + ICON / 2,
+            icon_position.y + ICON / 2,
+        )
+        initial = _escape(node.label[:1].upper() or "?")
+        parts.append(
+            f'<text x="{center_x:g}" y="{center_y + 6:g}" font-size="22" font-weight="700" text-anchor="middle" fill="#FFFFFF">{initial}</text>'
+        )
+    label_y = box.y + ICON + 18
+    label_font_size = _fitted_node_font_size(node.label, NODE_LABEL_FONT_SIZE, box)
+    if label_font_size is None:
+        diagnostics.append(
+            _label_overflow(node.id, "label", node.label, NODE_LABEL_FONT_SIZE, box)
+        )
+        label_font_size = MIN_NODE_TEXT_FONT_SIZE
+    parts.append(
+        f'<text x="{box.x + box.w / 2:g}" y="{label_y:g}" font-size="{label_font_size:g}" font-weight="600" '
+        f'text-anchor="middle" fill="#1F2937">{_escape(node.label)}</text>'
+    )
+    if node.sublabel:
+        sublabel_font_size = _fitted_node_font_size(
+            node.sublabel, NODE_SUBLABEL_FONT_SIZE, box
+        )
+        if sublabel_font_size is None:
+            diagnostics.append(
+                _label_overflow(
+                    node.id,
+                    "sublabel",
+                    node.sublabel,
+                    NODE_SUBLABEL_FONT_SIZE,
+                    box,
+                )
+            )
+            sublabel_font_size = MIN_NODE_TEXT_FONT_SIZE
+        parts.append(
+            f'<text x="{box.x + box.w / 2:g}" y="{label_y + 15:g}" font-size="{sublabel_font_size:g}" '
+            f'text-anchor="middle" fill="#6B7280">{_escape(node.sublabel)}</text>'
+        )
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def _zone_svg(zone: Zone, box: Box) -> str:
+    return (
+        f'<g id="zone-{_escape(zone.id)}">'
+        f'<rect x="{box.x:g}" y="{box.y:g}" width="{box.w:g}" height="{box.h:g}" rx="8" '
+        f'fill="none" stroke="#8C4FFF" stroke-width="1.5" stroke-dasharray="6 4"/>'
+        f'<text x="{box.x + 12:g}" y="{box.y + 18:g}" font-size="11" font-weight="600" fill="#8C4FFF">{_escape(zone.label)}</text>'
+        "</g>"
+    )
+
+
+def _edge_svg(routed: RoutedEdge) -> str:
+    edge = routed.edge
+    color = EDGE_COLORS.get(edge.type, EDGE_COLORS["default"])
+    dash = ' stroke-dasharray="6 4"' if edge.type == "batch" else ""
+    marker = f'marker-end="url(#arrow-{edge.type})"'
+    parts = [f'<g id="edge-{_escape(edge.src)}-{_escape(edge.dst)}">']
+    parts.append(
+        f'<path d="{routed.path_d}" fill="none" stroke="{color}" stroke-width="1.8"{dash} {marker}/>'
+    )
+    if edge.label:
+        x, y = routed.label_pos
+        parts.append(
+            f'<text x="{x:g}" y="{y:g}" font-size="{EDGE_LABEL_FONT_SIZE:g}" fill="{color}">{_escape(edge.label)}</text>'
+        )
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def _legend_svg(edge_types: set[str], x: float, y: float) -> str:
+    parts = ['<g id="legend">']
+    for index, edge_type in enumerate(sorted(edge_types)):
+        color = EDGE_COLORS.get(edge_type, EDGE_COLORS["default"])
+        label_y = y + index * 18
+        parts.append(
+            f'<line x1="{x:g}" y1="{label_y:g}" x2="{x + 24:g}" y2="{label_y:g}" stroke="{color}" stroke-width="2"/>'
+        )
+        parts.append(
+            f'<text x="{x + 30:g}" y="{label_y + 4:g}" font-size="10" fill="#374151">{_escape(edge_type)}</text>'
+        )
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def emit_svg(
+    spec: Spec,
+    node_boxes: dict[str, Box],
+    zone_boxes: dict[str, Box],
+    routed_edges: list[RoutedEdge],
+    icons: dict[str, IconRef | None],
+    diagnostics: list[Diagnostic],
+) -> str:
+    """Emit standalone editable SVG markup from computed layout and icons."""
+    zone_by_id = {zone.id: zone for zone in spec.zones}
+    all_extents = [*node_boxes.values(), *zone_boxes.values()]
+    width = max((box.x2 for box in all_extents), default=NODE_W) + MARGIN
+    height = max((box.y2 for box in all_extents), default=NODE_H) + MARGIN
+
+    edge_types = {edge.type for edge in spec.edges}
+    show_legend = len(edge_types) > 1
+    legend_height = 12 + len(edge_types) * 18 if show_legend else 0
+    height += legend_height
+
+    svg_open = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width:g}" height="{height:g}" '
+        f'viewBox="0 0 {width:g} {height:g}" font-family="Segoe UI, system-ui, sans-serif">'
+    )
+    parts = [
+        svg_open,
+        f'<rect width="{width:g}" height="{height:g}" fill="#FAFAF8"/>',
+        "<defs>",
+    ]
+    for edge_type, color in EDGE_COLORS.items():
+        parts.append(
+            f'<marker id="arrow-{edge_type}" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" '
+            f'orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="{color}"/></marker>'
+        )
+    parts.append("</defs>")
+
+    if spec.title:
+        parts.append(
+            f'<text x="{MARGIN:g}" y="{MARGIN + 14:g}" font-size="17" font-weight="700" fill="#1F2937">{_escape(spec.title)}</text>'
+        )
+
+    for zone_id in sorted(
+        zone_boxes, key=lambda value: len(zone_ancestors(spec, value))
+    ):
+        parts.append(_zone_svg(zone_by_id[zone_id], zone_boxes[zone_id]))
+    for routed in routed_edges:
+        parts.append(_edge_svg(routed))
+    for node in spec.nodes:
+        parts.append(
+            _node_svg(node, node_boxes[node.id], icons.get(node.id), diagnostics)
+        )
+    if show_legend:
+        parts.append(_legend_svg(edge_types, MARGIN, height - legend_height + 6))
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def check_editability(svg_text: str) -> list[Diagnostic]:
+    """Reject raster, clone, and remote-reference output markup."""
+    findings: list[Diagnostic] = []
+    for marker in _FORBIDDEN_MARKERS:
+        if marker in svg_text:
+            findings.append(
+                Diagnostic(
+                    code="editability/forbidden-markup",
+                    severity=SEVERITY_ERROR,
+                    message=f"editability violation: found {marker!r}",
+                    evidence={"marker": marker},
+                    supported_fixes=(
+                        "file this as a renderer bug: the spec cannot introduce this markup",
+                    ),
+                )
+            )
+    for marker in ('href="http', 'xlink:href="http'):
+        if marker in svg_text:
+            findings.append(
+                Diagnostic(
+                    code="editability/external-reference",
+                    severity=SEVERITY_ERROR,
+                    message=f"editability violation: external reference ({marker!r})",
+                    evidence={"marker": marker},
+                    supported_fixes=(
+                        "file this as a renderer bug: the output must stay self-contained",
+                    ),
+                )
+            )
+    return findings

--- a/skills/architecture-diagram/engine/tests/test_render.py
+++ b/skills/architecture-diagram/engine/tests/test_render.py
@@ -22,6 +22,7 @@ from engine.geometry_checks import (
 from engine.layout import (
     COL_GAP,
     ICON,
+    NODE_W,
     ROW_GAP,
     Box,
     assign_ranks,
@@ -29,6 +30,7 @@ from engine.layout import (
     compute_zone_boxes,
     icon_box,
     order_within_ranks,
+    text_width,
 )
 from engine.model import Edge, Node, Spec
 from engine.render import IconRef, check_editability, render as do_render
@@ -795,7 +797,7 @@ class TestEndToEndRender:
         assert font_match
         fitted_size = float(font_match.group(1))
         assert 6 <= fitted_size < 12
-        assert render.text_width(label, fitted_size) <= render.NODE_W - 8 + 1e-6
+        assert text_width(label, fitted_size) <= NODE_W - 8 + 1e-6
         assert result.ok
 
     def test_svg_has_valid_viewbox_matching_dimensions(self) -> None:


### PR DESCRIPTION
## Summary

Extracts icon resolution and editable SVG emission from the renderer.

- Adds cache and bundled icon lookup ownership.
- Adds SVG emission, text fitting, and editability validation ownership.
- Preserves SVG bytes and command receipts.

## Stack

Stack-Id: `architecture-diagram-m1-3d8ce7`
Base: `main`
Position: 3/4

1. `refactor/architecture-diagram-model-spec` -> #133
2. `refactor/architecture-diagram-layout-checks` -> #134
3. `refactor/architecture-diagram-icons-svg` -> this PR
4. `refactor/architecture-diagram-command-cutover` -> #136

Depends on: #134
Upstack: #136

## Validation

- `uv run ruff check engine && uv run ruff format --check engine`: passed
- `uv run pytest engine/tests`: 195 passed
- `python3 -m engine validate ... --json`: SVG SHA-256 preserved
- `python3 -m engine compare ...`: receipt preserved
