### PR TITLE
refactor(architecture-diagram): extract command receipts

### DIFF
--- a/skills/architecture-diagram/engine/commands.py
+++ b/skills/architecture-diagram/engine/commands.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import sys
@@ -18,7 +17,6 @@ from .diagnostics import (
     QUALITY_STANDARD,
     SEVERITY_ERROR,
     Diagnostic,
-    count_by_severity,
 )
 from .geometry_checks import edge_label_box
 from .icons import (
@@ -31,151 +29,12 @@ from .layout import box_evidence
 from .model import Spec
 from .pipeline import RenderResult, render
 from .spec import SpecError, load_spec
+from .receipts import comparison_receipt, receipt as build_receipt
 
 
 EXIT_OK = 0
 EXIT_FAILURE = 1
 EXIT_USAGE = 2
-
-RECEIPT_SCHEMA_VERSION = 1
-COMPARISON_LIMITATIONS = "Authored specification only; no runtime impact, causality, risk, or merge safety is inferred."
-
-
-def _comparison_receipt(
-    base_path: Path,
-    base_bytes: bytes | None,
-    head_path: Path,
-    head_bytes: bytes | None,
-    diagnostics: list[Diagnostic],
-    comparison: dict[str, list[dict[str, object]]] | None = None,
-) -> dict[str, object]:
-    return {
-        "schema_version": RECEIPT_SCHEMA_VERSION,
-        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
-        "command": "compare",
-        "type": "architecture-diagram",
-        "base": {
-            "path": str(base_path),
-            "sha256": _sha256(base_bytes) if base_bytes is not None else None,
-            "bytes": len(base_bytes) if base_bytes is not None else None,
-        },
-        "head": {
-            "path": str(head_path),
-            "sha256": _sha256(head_bytes) if head_bytes is not None else None,
-            "bytes": len(head_bytes) if head_bytes is not None else None,
-        },
-        "comparison": comparison or {"nodes": [], "edges": []},
-        "limitations": COMPARISON_LIMITATIONS,
-        "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
-    }
-
-
-_VALIDATION_CHECKS = (
-    "spec",
-    "layout",
-    "route-rhythm",
-    "edge-through-node",
-    "proper-crossing",
-    "ambiguous-corridor",
-    "label-route-clearance",
-    "icons",
-    "labels",
-    "editability",
-)
-
-
-def _sha256(payload: bytes) -> str:
-    return hashlib.sha256(payload).hexdigest()
-
-
-def _check_name(diagnostic: Diagnostic) -> str:
-    code = diagnostic.code
-    if code.startswith("spec/"):
-        return "spec"
-    if code.startswith("profile/"):
-        return "profile"
-    if code in ("layout/node-overlap", "layout/zone-overlap"):
-        return "layout"
-    if code == "layout/label-overflow":
-        return "labels"
-    if code.startswith("composition/micro-segment") or code.startswith(
-        "composition/short-interior-segment"
-    ):
-        return "route-rhythm"
-    if code == "composition/edge-through-node":
-        return "edge-through-node"
-    if code == "composition/proper-crossing":
-        return "proper-crossing"
-    if code == "composition/ambiguous-corridor":
-        return "ambiguous-corridor"
-    if code == "composition/label-route-clearance":
-        return "label-route-clearance"
-    if code.startswith("icon/"):
-        return "icons"
-    return "editability"
-
-
-def _validation_receipt(
-    diagnostics: list[Diagnostic], quality: str, profile_active: bool = False
-) -> dict[str, object]:
-    checks = _VALIDATION_CHECKS + (("profile",) if profile_active else ())
-    counts = count_by_severity(diagnostics)
-    composition = [d for d in diagnostics if d.code.startswith("composition/")]
-    if any(d.severity == SEVERITY_ERROR for d in composition):
-        composition_status = "failed"
-    elif composition:
-        composition_status = "warnings"
-    else:
-        composition_status = "passed"
-    failed_checks = {
-        _check_name(d) for d in diagnostics if d.severity == SEVERITY_ERROR
-    }
-    return {
-        "checks_passed": len(checks) - len(failed_checks),
-        "checks_total": len(checks),
-        "quality": quality,
-        "composition_status": composition_status,
-        "errors": counts["errors"],
-        "warnings": counts["warnings"],
-    }
-
-
-def _receipt(
-    command: str,
-    input_path: Path,
-    input_bytes: bytes | None,
-    artifact_bytes: bytes | None,
-    diagnostics: list[Diagnostic],
-    quality: str,
-    output: Path | None = None,
-    written: bool = False,
-    delivery_stage: str | None = None,
-    profile_active: bool = False,
-) -> dict[str, object]:
-    receipt: dict[str, object] = {
-        "schema_version": RECEIPT_SCHEMA_VERSION,
-        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
-        "command": command,
-        "type": "architecture-diagram",
-        "input": {
-            "path": str(input_path),
-            "sha256": _sha256(input_bytes) if input_bytes is not None else None,
-            "bytes": len(input_bytes) if input_bytes is not None else None,
-        },
-        "artifact": {
-            "sha256": _sha256(artifact_bytes) if artifact_bytes is not None else None,
-            "bytes": len(artifact_bytes) if artifact_bytes is not None else None,
-        },
-        "output": {
-            "path": str(output) if output is not None else None,
-            "written": written,
-        },
-        "validation": _validation_receipt(diagnostics, quality, profile_active),
-        "diagnostics": [d.to_dict() for d in diagnostics],
-    }
-    if delivery_stage is not None:
-        receipt["delivery_stage"] = delivery_stage
-    return receipt
 
 
 def _layout_report(spec: Spec, result: RenderResult) -> dict[str, object]:
@@ -252,7 +111,7 @@ def _input_failure(
     )
     return (
         EXIT_USAGE,
-        _receipt(
+        build_receipt(
             command,
             spec_path,
             None,
@@ -309,7 +168,7 @@ def _compare(
     if diagnostics:
         return (
             EXIT_FAILURE,
-            _comparison_receipt(
+            comparison_receipt(
                 base_path, base_bytes, head_path, head_bytes, diagnostics
             ),
             diagnostics,
@@ -323,14 +182,14 @@ def _compare(
         diagnostics = [exc.diagnostic]
         return (
             EXIT_FAILURE,
-            _comparison_receipt(
+            comparison_receipt(
                 base_path, base_bytes, head_path, head_bytes, diagnostics
             ),
             diagnostics,
         )
     return (
         EXIT_OK,
-        _comparison_receipt(
+        comparison_receipt(
             base_path, base_bytes, head_path, head_bytes, [], comparison
         ),
         [],
@@ -380,7 +239,7 @@ def _validate(
             candidate = Path(path) / "candidate.svg"
             candidate.write_bytes(artifact_bytes)
             artifact_bytes = candidate.read_bytes()
-    receipt = _receipt(
+    receipt = build_receipt(
         "validate",
         spec_path,
         spec_bytes,
@@ -415,7 +274,7 @@ def _delivery_failure(
     )
     return (
         EXIT_FAILURE,
-        _receipt(
+        build_receipt(
             "deliver",
             spec_path,
             spec_bytes,
@@ -455,7 +314,7 @@ def _deliver(
                 spec_text, _icon_lookup(cache_dir, sha), quality
             )
             if artifact_bytes is None:
-                receipt = _receipt(
+                receipt = build_receipt(
                     "deliver",
                     spec_path,
                     spec_bytes,
@@ -472,7 +331,7 @@ def _deliver(
             if os.stat(candidate).st_dev != os.stat(output_parent).st_dev:
                 raise OSError("candidate artifact is not on the output filesystem")
             if result is None or not result.ok:
-                receipt = _receipt(
+                receipt = build_receipt(
                     "deliver",
                     spec_path,
                     spec_bytes,
@@ -484,7 +343,7 @@ def _deliver(
                     profile_active=spec is not None and spec.profile is not None,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
-            receipt = _receipt(
+            receipt = build_receipt(
                 "deliver",
                 spec_path,
                 spec_bytes,

--- a/skills/architecture-diagram/engine/receipts.py
+++ b/skills/architecture-diagram/engine/receipts.py
@@ -1,0 +1,157 @@
+"""Machine-readable command receipt construction."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from .diagnostics import SEVERITY_ERROR, Diagnostic, count_by_severity
+
+RECEIPT_SCHEMA_VERSION = 1
+COMPARISON_LIMITATIONS = (
+    "Authored specification only; no runtime impact, causality, risk, or merge "
+    "safety is inferred."
+)
+
+_VALIDATION_CHECKS = (
+    "spec",
+    "layout",
+    "route-rhythm",
+    "edge-through-node",
+    "proper-crossing",
+    "ambiguous-corridor",
+    "label-route-clearance",
+    "icons",
+    "labels",
+    "editability",
+)
+
+
+def sha256(payload: bytes) -> str:
+    """Return the stable digest recorded in command receipts."""
+    return hashlib.sha256(payload).hexdigest()
+
+
+def check_name(diagnostic: Diagnostic) -> str:
+    """Map one diagnostic to its validation receipt check."""
+    code = diagnostic.code
+    if code.startswith("spec/"):
+        return "spec"
+    if code.startswith("profile/"):
+        return "profile"
+    if code in ("layout/node-overlap", "layout/zone-overlap"):
+        return "layout"
+    if code == "layout/label-overflow":
+        return "labels"
+    if code.startswith("composition/micro-segment") or code.startswith(
+        "composition/short-interior-segment"
+    ):
+        return "route-rhythm"
+    if code == "composition/edge-through-node":
+        return "edge-through-node"
+    if code == "composition/proper-crossing":
+        return "proper-crossing"
+    if code == "composition/ambiguous-corridor":
+        return "ambiguous-corridor"
+    if code == "composition/label-route-clearance":
+        return "label-route-clearance"
+    if code.startswith("icon/"):
+        return "icons"
+    return "editability"
+
+
+def validation_receipt(
+    diagnostics: list[Diagnostic], quality: str, profile_active: bool = False
+) -> dict[str, object]:
+    """Summarize validation checks without changing diagnostic detail."""
+    checks = _VALIDATION_CHECKS + (("profile",) if profile_active else ())
+    counts = count_by_severity(diagnostics)
+    composition = [d for d in diagnostics if d.code.startswith("composition/")]
+    if any(d.severity == SEVERITY_ERROR for d in composition):
+        composition_status = "failed"
+    elif composition:
+        composition_status = "warnings"
+    else:
+        composition_status = "passed"
+    failed_checks = {
+        check_name(diagnostic)
+        for diagnostic in diagnostics
+        if diagnostic.severity == SEVERITY_ERROR
+    }
+    return {
+        "checks_passed": len(checks) - len(failed_checks),
+        "checks_total": len(checks),
+        "quality": quality,
+        "composition_status": composition_status,
+        "errors": counts["errors"],
+        "warnings": counts["warnings"],
+    }
+
+
+def receipt(
+    command: str,
+    input_path: Path,
+    input_bytes: bytes | None,
+    artifact_bytes: bytes | None,
+    diagnostics: list[Diagnostic],
+    quality: str,
+    output: Path | None = None,
+    written: bool = False,
+    delivery_stage: str | None = None,
+    profile_active: bool = False,
+) -> dict[str, object]:
+    """Build the stable validate or deliver JSON receipt."""
+    result: dict[str, object] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
+        "command": command,
+        "type": "architecture-diagram",
+        "input": {
+            "path": str(input_path),
+            "sha256": sha256(input_bytes) if input_bytes is not None else None,
+            "bytes": len(input_bytes) if input_bytes is not None else None,
+        },
+        "artifact": {
+            "sha256": sha256(artifact_bytes) if artifact_bytes is not None else None,
+            "bytes": len(artifact_bytes) if artifact_bytes is not None else None,
+        },
+        "output": {
+            "path": str(output) if output is not None else None,
+            "written": written,
+        },
+        "validation": validation_receipt(diagnostics, quality, profile_active),
+        "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
+    }
+    if delivery_stage is not None:
+        result["delivery_stage"] = delivery_stage
+    return result
+
+
+def comparison_receipt(
+    base_path: Path,
+    base_bytes: bytes | None,
+    head_path: Path,
+    head_bytes: bytes | None,
+    diagnostics: list[Diagnostic],
+    comparison: dict[str, list[dict[str, object]]] | None = None,
+) -> dict[str, object]:
+    """Build the stable authored-spec comparison JSON receipt."""
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "ok": not any(d.severity == SEVERITY_ERROR for d in diagnostics),
+        "command": "compare",
+        "type": "architecture-diagram",
+        "base": {
+            "path": str(base_path),
+            "sha256": sha256(base_bytes) if base_bytes is not None else None,
+            "bytes": len(base_bytes) if base_bytes is not None else None,
+        },
+        "head": {
+            "path": str(head_path),
+            "sha256": sha256(head_bytes) if head_bytes is not None else None,
+            "bytes": len(head_bytes) if head_bytes is not None else None,
+        },
+        "comparison": comparison or {"nodes": [], "edges": []},
+        "limitations": COMPARISON_LIMITATIONS,
+        "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
+    }

--- a/skills/architecture-diagram/engine/tests/test_deployment_profile.py
+++ b/skills/architecture-diagram/engine/tests/test_deployment_profile.py
@@ -7,6 +7,7 @@ import pytest
 
 from engine import commands, pipeline
 from engine.diagnostics import Diagnostic
+from engine.receipts import check_name
 from engine.profile import check_deployment_profile
 from engine.spec import load_spec
 
@@ -85,8 +86,7 @@ def test_profile_failure_has_a_distinct_receipt_check(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
     assert (
-        commands._check_name(_findings("deployment-profile-missing-owner.yaml")[0])
-        == "profile"
+        check_name(_findings("deployment-profile-missing-owner.yaml")[0]) == "profile"
     )
     code = commands.main(
         [

--- a/skills/architecture-diagram/engine/tests/test_receipts.py
+++ b/skills/architecture-diagram/engine/tests/test_receipts.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.diagnostics import Diagnostic, SEVERITY_ERROR
+from engine.receipts import comparison_receipt, receipt, sha256
+
+
+def test_receipt_binds_artifact_digest_and_delivery_stage() -> None:
+    artifact = b"<svg/>"
+    finding = Diagnostic(
+        code="spec/no-nodes",
+        severity=SEVERITY_ERROR,
+        message="spec has no nodes",
+    )
+
+    payload = receipt(
+        "deliver",
+        Path("diagram.yaml"),
+        b"nodes: []\n",
+        artifact,
+        [finding],
+        "standard",
+        output=Path("diagram.svg"),
+        delivery_stage="check",
+    )
+
+    assert payload["ok"] is False
+    assert payload["artifact"] == {"sha256": sha256(artifact), "bytes": len(artifact)}
+    assert payload["output"] == {"path": "diagram.svg", "written": False}
+    assert payload["delivery_stage"] == "check"
+    validation = payload["validation"]
+    assert isinstance(validation, dict)
+    assert validation["checks_passed"] == 9
+
+
+def test_comparison_receipt_keeps_authored_only_limitation() -> None:
+    payload = comparison_receipt(
+        Path("base.yaml"),
+        b"nodes: []\n",
+        Path("head.yaml"),
+        b"nodes: []\n",
+        [],
+    )
+
+    assert payload["ok"] is True
+    assert payload["comparison"] == {"nodes": [], "edges": []}
+    assert payload["limitations"] == (
+        "Authored specification only; no runtime impact, causality, risk, or "
+        "merge safety is inferred."
+    )

--- a/skills/architecture-diagram/engine/tests/test_render.py
+++ b/skills/architecture-diagram/engine/tests/test_render.py
@@ -48,6 +48,7 @@ from engine.icons import (
     IconRef,
 )
 from engine.model import Edge, Node, Spec
+from engine.receipts import RECEIPT_SCHEMA_VERSION, sha256
 from engine.routing import RoutedEdge, route_edges
 from engine.spec import SpecError, load_spec
 from engine.svg import check_editability
@@ -1179,7 +1180,7 @@ class TestCliContract:
             "warnings": 0,
         }
         assert payload["diagnostics"] == []
-        assert payload["schema_version"] == commands.RECEIPT_SCHEMA_VERSION
+        assert payload["schema_version"] == RECEIPT_SCHEMA_VERSION
 
     def test_deliver_commits_the_validated_candidate(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1203,7 +1204,7 @@ class TestCliContract:
         assert payload["command"] == "deliver"
         assert payload["output"] == {"path": str(out), "written": True}
         assert payload["artifact"]["bytes"] == len(out.read_bytes())
-        assert payload["artifact"]["sha256"] == commands._sha256(out.read_bytes())
+        assert payload["artifact"]["sha256"] == sha256(out.read_bytes())
 
     def test_json_mode_puts_nothing_but_json_on_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/skills/architecture-diagram/engine/tests/test_spec_compare.py
+++ b/skills/architecture-diagram/engine/tests/test_spec_compare.py
@@ -7,6 +7,7 @@ import pytest
 
 from engine import commands
 from engine.compare import compare_specs
+from engine.receipts import COMPARISON_LIMITATIONS
 from engine.spec import load_spec
 
 
@@ -90,7 +91,7 @@ def test_compare_cli_always_includes_the_limitations_text(
 
     assert code == commands.EXIT_OK
     assert captured.err == ""
-    assert json.loads(captured.out)["limitations"] == commands.COMPARISON_LIMITATIONS
+    assert json.loads(captured.out)["limitations"] == COMPARISON_LIMITATIONS
 
 
 def test_compare_cli_rejects_an_edge_without_an_authored_id(
@@ -106,4 +107,4 @@ def test_compare_cli_rejects_an_edge_without_an_authored_id(
     assert [finding["code"] for finding in payload["diagnostics"]] == [
         "compare/missing-edge-id"
     ]
-    assert payload["limitations"] == commands.COMPARISON_LIMITATIONS
+    assert payload["limitations"] == COMPARISON_LIMITATIONS


### PR DESCRIPTION
## Summary

Extracts machine-readable command receipt construction from `engine/commands.py` into `engine/receipts.py`. The CLI orchestration stays in `commands.py`; receipt bytes, diagnostics, exit codes, and SVG output remain unchanged.

## Stack

Stack-Id: `architecture-diagram-source-evidence-9b6c4d`
Base: `main`
Position: 1/4

1. `refactor/architecture-diagram-receipts` → this PR
2. `feat/architecture-diagram-source-schema` → dependent
3. `feat/architecture-diagram-verify-sources` → dependent
4. `feat/architecture-diagram-source-sidecars` → dependent

Depends on: none — root

## Validation

- `uv run python -m pytest skills/architecture-diagram/engine/tests -q` — 198 passed
- `uv run ruff check skills/architecture-diagram/engine`
- `uv run ruff format --check skills/architecture-diagram/engine`
- Exact validate, compare, and deliver stdout/SVG comparisons against `main`

No release, version, changelog, tag, or publication change.