### PR TITLE
feat(architecture-diagram): declare source evidence references

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -76,6 +76,11 @@ title: string
 direction: LR | TB        # default LR
 provider: aws | azure | gcp | generic   # default provider for nodes that omit it
 profile: deployment-ownership             # opt-in blocking deployment checks
+sources:
+  - id: string               # unique authored reference id
+    revision: 40-char hex    # declared Git object id
+    path: relative POSIX path
+    lines: [start, end]      # positive inclusive range
 zones:
   - id: string
     label: string
@@ -92,12 +97,14 @@ nodes:
     owner: string          # required for non-external nodes under deployment-ownership
     external: boolean      # default false
     storage: boolean       # true requires a security zone under deployment-ownership
+    sources: [source-id]     # optional declared source ids
 edges:
   - id: string              # required and stable when using compare
     from: string            # node id
     to: string              # node id
     label: string           # required for security-boundary crossings under deployment-ownership
     type: realtime | batch | event | control | default
+    sources: [source-id]     # optional declared source ids
 ```
 
 ### Deployment ownership validation

--- a/skills/architecture-diagram/engine/model.py
+++ b/skills/architecture-diagram/engine/model.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class SourceReference:
+    """One immutable authored source location."""
+
+    id: str
+    revision: str
+    path: str
+    lines: tuple[int, int]
 
 
 @dataclass
@@ -17,6 +27,7 @@ class Node:
     owner: str | None = None
     external: bool = False
     storage: bool = False
+    sources: tuple[str, ...] = ()
 
 
 @dataclass
@@ -34,6 +45,7 @@ class Edge:
     label: str = ""
     type: str = "default"
     id: str | None = None
+    sources: tuple[str, ...] = ()
 
 
 @dataclass
@@ -45,3 +57,4 @@ class Spec:
     zones: list[Zone]
     edges: list[Edge]
     profile: str | None = None
+    sources: list[SourceReference] = field(default_factory=list)

--- a/skills/architecture-diagram/engine/spec.py
+++ b/skills/architecture-diagram/engine/spec.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 import yaml
 
 from .diagnostics import Diagnostic, SEVERITY_ERROR
-from .model import Edge, Node, Spec, Zone
+from .model import Edge, Node, SourceReference, Spec, Zone
 
 
 class SpecError(ValueError):
@@ -35,6 +37,182 @@ def _spec_error(
     )
 
 
+_SOURCE_REVISION = re.compile(r"[0-9a-fA-F]{40}\Z")
+
+
+def _source_error(
+    code: str,
+    message: str,
+    subject: dict[str, object],
+    evidence: dict[str, object],
+    supported_fixes: tuple[str, ...],
+) -> SpecError:
+    return _spec_error(code, message, subject, evidence, supported_fixes)
+
+
+def _parse_sources(data: dict[str, object]) -> list[SourceReference]:
+    raw_sources = data.get("sources", [])
+    if not isinstance(raw_sources, list):
+        raise _source_error(
+            "source/invalid-declarations",
+            "`sources` must be a YAML list",
+            {"sources": raw_sources},
+            {"type": type(raw_sources).__name__},
+            ("declare source references as a YAML list",),
+        )
+
+    sources: list[SourceReference] = []
+    source_ids: set[str] = set()
+    for raw in raw_sources:
+        if not isinstance(raw, dict):
+            raise _source_error(
+                "source/invalid-declaration",
+                "each source declaration must be a mapping",
+                {"source": raw},
+                {"type": type(raw).__name__},
+                ("declare `id`, `revision`, `path`, and `lines` for every source",),
+            )
+
+        source_id = raw.get("id")
+        if (
+            not isinstance(source_id, str)
+            or not source_id
+            or source_id.strip() != source_id
+        ):
+            raise _source_error(
+                "source/invalid-id",
+                "source declarations require a non-blank string `id`",
+                {"source": source_id},
+                {"id": source_id},
+                ("set `id` to a non-blank string without surrounding whitespace",),
+            )
+        if source_id in source_ids:
+            raise _source_error(
+                "source/duplicate-id",
+                f"duplicate source id: {source_id!r}",
+                {"source": source_id},
+                {"id": source_id},
+                ("give every source declaration a unique `id`",),
+            )
+
+        revision = raw.get("revision")
+        if (
+            not isinstance(revision, str)
+            or _SOURCE_REVISION.fullmatch(revision) is None
+        ):
+            raise _source_error(
+                "source/invalid-revision",
+                f"source {source_id!r} requires a 40-character hexadecimal `revision`",
+                {"source": source_id},
+                {"revision": revision},
+                ("set `revision` to a full 40-character Git object id",),
+            )
+
+        path = raw.get("path")
+        path_parts = path.split("/") if isinstance(path, str) else []
+        if (
+            not isinstance(path, str)
+            or not path
+            or path.strip() != path
+            or path.startswith("/")
+            or "\\" in path
+            or ":" in path
+            or any(part in ("", ".", "..") for part in path_parts)
+        ):
+            raise _source_error(
+                "source/invalid-path",
+                f"source {source_id!r} requires a relative POSIX `path`",
+                {"source": source_id},
+                {"path": path},
+                ("use a non-empty relative POSIX path without `.` or `..` segments",),
+            )
+
+        lines = raw.get("lines")
+        if (
+            not isinstance(lines, list)
+            or len(lines) != 2
+            or any(
+                not isinstance(line, int) or isinstance(line, bool) for line in lines
+            )
+        ):
+            raise _source_error(
+                "source/invalid-lines",
+                f"source {source_id!r} requires `lines: [start, end]` with integers",
+                {"source": source_id},
+                {"lines": lines},
+                ("set `lines` to two integer line numbers",),
+            )
+        start_line, end_line = lines
+        if start_line < 1 or end_line < start_line:
+            raise _source_error(
+                "source/invalid-line-range",
+                f"source {source_id!r} has an invalid inclusive line range",
+                {"source": source_id},
+                {"lines": lines},
+                ("use positive line numbers with start less than or equal to end",),
+            )
+
+        source_ids.add(source_id)
+        sources.append(
+            SourceReference(
+                id=source_id,
+                revision=revision,
+                path=path,
+                lines=(start_line, end_line),
+            )
+        )
+    return sources
+
+
+def _parse_source_attachments(
+    raw: dict[str, object],
+    subject: dict[str, object],
+    source_ids: set[str],
+) -> tuple[str, ...]:
+    attachments = raw.get("sources", [])
+    if not isinstance(attachments, list):
+        raise _source_error(
+            "source/invalid-attachments",
+            "`sources` attachments must be a YAML list",
+            subject,
+            {"sources": attachments, "type": type(attachments).__name__},
+            ("list zero or more declared source ids under `sources`",),
+        )
+
+    parsed: list[str] = []
+    for source_id in attachments:
+        if (
+            not isinstance(source_id, str)
+            or not source_id
+            or source_id.strip() != source_id
+        ):
+            raise _source_error(
+                "source/invalid-attachment",
+                "source attachments must be non-blank string ids",
+                subject,
+                {"source": source_id},
+                ("reference a declared source id",),
+            )
+        if source_id in parsed:
+            raise _source_error(
+                "source/duplicate-attachment",
+                f"source {source_id!r} is attached more than once",
+                subject,
+                {"source": source_id},
+                ("list each source id at most once per node or edge",),
+            )
+        if source_id not in source_ids:
+            raise _source_error(
+                "source/unknown-attachment",
+                f"source attachment {source_id!r} is not declared",
+                subject,
+                {"source": source_id, "known_sources": sorted(source_ids)},
+                ("declare the source under top-level `sources`",),
+            )
+        parsed.append(source_id)
+    return tuple(parsed)
+
+
 def load_spec(text: str) -> Spec:
     """Parse and validate one authored YAML specification."""
     data = yaml.safe_load(text) or {}
@@ -57,6 +235,9 @@ def load_spec(text: str) -> Spec:
                 "set `profile: deployment-ownership`",
             ),
         )
+
+    sources = _parse_sources(data)
+    source_ids = {source.id for source in sources}
 
     node_ids = set()
     nodes = []
@@ -104,6 +285,7 @@ def load_spec(text: str) -> Spec:
                 owner=raw.get("owner"),
                 external=raw.get("external", False),
                 storage=raw.get("storage", False),
+                sources=_parse_source_attachments(raw, {"node": raw["id"]}, source_ids),
             )
         )
 
@@ -198,6 +380,11 @@ def load_spec(text: str) -> Spec:
                 id=raw.get("id"),
                 label=raw.get("label", ""),
                 type=raw.get("type", "default"),
+                sources=_parse_source_attachments(
+                    raw,
+                    {"edge": raw.get("id", {"from": raw["from"], "to": raw["to"]})},
+                    source_ids,
+                ),
             )
         )
 
@@ -209,4 +396,5 @@ def load_spec(text: str) -> Spec:
         zones=zones,
         edges=edges,
         profile=profile,
+        sources=sources,
     )

--- a/skills/architecture-diagram/engine/tests/test_source_evidence_schema.py
+++ b/skills/architecture-diagram/engine/tests/test_source_evidence_schema.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from engine.compare import compare_specs
+from engine.spec import SpecError, load_spec
+
+_VALID_SOURCE = "a" * 40
+
+
+def _valid_spec(*, node_sources: str = "    sources: [src-api]\n") -> str:
+    return f"""sources:
+  - id: src-api
+    revision: {_VALID_SOURCE}
+    path: src/api.py
+    lines: [1, 3]
+nodes:
+  - id: api
+{node_sources}  - id: db
+edges:
+  - id: api-to-db
+    from: api
+    to: db
+    sources: [src-api]
+"""
+
+
+def _code(text: str) -> str:
+    with pytest.raises(SpecError) as raised:
+        load_spec(text)
+    return raised.value.diagnostic.code
+
+
+def test_parses_source_declarations_and_entity_attachments() -> None:
+    spec = load_spec(_valid_spec())
+
+    assert [
+        (source.id, source.revision, source.path, source.lines)
+        for source in spec.sources
+    ] == [("src-api", _VALID_SOURCE, "src/api.py", (1, 3))]
+    assert spec.nodes[0].sources == ("src-api",)
+    assert spec.edges[0].sources == ("src-api",)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            _valid_spec().replace(
+                "    lines: [1, 3]\n",
+                "    lines: [1, 3]\n  - id: src-api\n",
+                1,
+            ),
+            "source/duplicate-id",
+        ),
+        (_valid_spec().replace(_VALID_SOURCE, "a" * 39), "source/invalid-revision"),
+        (
+            _valid_spec().replace("path: src/api.py", "path: ../api.py"),
+            "source/invalid-path",
+        ),
+        (
+            _valid_spec().replace("lines: [1, 3]", "lines: [0, 3]"),
+            "source/invalid-line-range",
+        ),
+        (
+            _valid_spec().replace("lines: [1, 3]", "lines: [3, 1]"),
+            "source/invalid-line-range",
+        ),
+        (
+            _valid_spec(node_sources="    sources: [src-api, src-api]\n"),
+            "source/duplicate-attachment",
+        ),
+        (
+            _valid_spec(node_sources="    sources: [missing]\n"),
+            "source/unknown-attachment",
+        ),
+    ],
+)
+def test_rejects_invalid_source_evidence_schema(text: str, expected: str) -> None:
+    assert _code(text) == expected
+
+
+def test_specs_without_source_declarations_keep_empty_authored_evidence() -> None:
+    spec = load_spec("nodes:\n  - id: api\n")
+
+    assert spec.sources == []
+    assert spec.nodes[0].sources == ()
+
+
+def test_compare_ignores_source_only_authored_changes() -> None:
+    base = load_spec(_valid_spec())
+    head = load_spec(
+        _valid_spec(node_sources="    sources: []\n").replace(
+            "sources: [src-api]\n", "sources: []\n", 1
+        )
+    )
+
+    comparison = compare_specs(base, head)
+
+    assert all(change["status"] == ["unchanged"] for change in comparison["nodes"])
+    assert all(change["status"] == ["unchanged"] for change in comparison["edges"])

--- a/skills/architecture-diagram/references/spec-format.md
+++ b/skills/architecture-diagram/references/spec-format.md
@@ -9,6 +9,7 @@ title: string              # optional; omit for no title bar
 direction: LR | TB         # optional, default LR
 provider: aws | azure | gcp | generic   # optional, default generic — sets the default for nodes that omit their own provider
 profile: deployment-ownership            # optional; opt-in deployment validation
+sources: [...]              # optional authored source declarations
 zones: [...]                # optional
 nodes: [...]                 # required, at least one
 edges: [...]                 # optional
@@ -24,6 +25,20 @@ With the profile enabled, declare at least one `kind: region` zone and one `kind
 
 The zone-kind enum is `generic` (the default), `region`, and `security`. `generic` remains decorative; the profile only enforces the facts above when explicitly enabled.
 
+## `sources`
+
+Source declarations record authored evidence without changing rendering or `compare` results. Every attachment on a node or edge must name one declaration.
+
+```yaml
+sources:
+  - id: src-api             # required, unique non-blank string
+    revision: 0123...cdef   # required, full 40-character hexadecimal Git object id
+    path: src/api.py        # required, non-empty relative POSIX path
+    lines: [41, 73]         # required, positive inclusive start and end lines
+```
+
+`path` cannot be absolute or contain `.` or `..` segments. `lines` must contain exactly two integer values, with `start >= 1` and `end >= start`. This schema declares references only; it does not read a repository or verify that an object, path, or line range exists.
+
 ## `nodes`
 
 ```yaml
@@ -38,6 +53,7 @@ nodes:
     owner: string             # required for non-external nodes under deployment-ownership
     external: boolean         # optional, default false; external nodes do not require owner
     storage: boolean          # optional, default false; true requires a security zone under deployment-ownership
+    sources: [src-api]       # optional declared source ids, each at most once
 ```
 
 `service` is the exact cache slug from `references/services-aws.yaml`, `references/services-azure.yaml`, or `references/services-gcp.yaml` (cloud providers) or `references/icons-generic.md` (`provider: generic`) — not a free-text service name. A `service` slug with no matching cache entry produces a `warning: no icon for node` at render time and the node falls back to a labeled placeholder (a colored square with the label's first letter) rather than failing the render. A node with no `service` set at all renders the same placeholder silently — that's the correct default for a component with no natural icon, not an error.
@@ -67,6 +83,7 @@ edges:
     to: string            # required, a node id
     label: string           # optional
     type: realtime | batch | event | control | default   # optional, default "default"
+    sources: [src-api]       # optional declared source ids, each at most once
 ```
 
 An edge referencing a node id that doesn't exist in `nodes` is a spec error. Edges do not need to respect zone boundaries — a node inside a zone can connect to one outside it freely; the router treats zones as a purely visual grouping, not a routing constraint.


### PR DESCRIPTION
## Summary

Adds validated authored source declarations and node/edge source attachments. Source-only changes remain excluded from architecture comparison results.

## Stack

Stack-Id: `architecture-diagram-source-evidence-9b6c4d`
Base: `refactor/architecture-diagram-receipts`
Position: 2/4

1. `refactor/architecture-diagram-receipts` → parent
2. `feat/architecture-diagram-source-schema` → this PR
3. `feat/architecture-diagram-verify-sources` → dependent
4. `feat/architecture-diagram-source-sidecars` → dependent

Depends on: parent PR

## Validation

- `uv run python -m pytest skills/architecture-diagram/engine/tests -q` — 208 passed
- `uv run ruff check skills/architecture-diagram/engine`
- `uv run ruff format --check skills/architecture-diagram/engine`
- Existing compare CLI smoke test

No Git execution, source verification, badge emission, or sidecar delivery is included.