### PR TITLE
feat(architecture-diagram): verify authored source evidence

### DIFF
--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -54,6 +54,7 @@ Run the following commands from this skill directory (`skills/architecture-diagr
    python3 -m engine validate spec.yaml --quality showcase --json
    ```
    The receipt contains exact spec and candidate-artifact SHA-256 digests, validation counts, quality profile, composition status, and coded diagnostics. `validate` never touches an output path.
+   For declared `sources`, add `--verify-sources`; it fail-closes against local Git commits, blobs, and inclusive line ranges from the spec's checkout. It requires an `origin` remote and never copies source content or contacts a remote service.
    Use `--layout-json` instead of `--json` when an agent needs the exact emitted node boxes, zone membership and boxes, routed edge waypoints, and edge-label rectangles for review. It also never writes SVG output.
 6. **Deliver only a clean candidate:**
    ```bash

--- a/skills/architecture-diagram/engine/commands.py
+++ b/skills/architecture-diagram/engine/commands.py
@@ -18,6 +18,8 @@ from .diagnostics import (
     SEVERITY_ERROR,
     Diagnostic,
 )
+from .evidence import summary as evidence_summary
+from .evidence import verify_sources
 from .geometry_checks import edge_label_box
 from .icons import (
     BundledGenericIconLookup,
@@ -224,6 +226,7 @@ def _validate(
     sha: str | None,
     quality: str,
     layout_json: bool,
+    verify_sources_enabled: bool,
 ) -> tuple[int, dict[str, object], list[Diagnostic]]:
     loaded = _read_spec("validate", spec_path, None, quality)
     if len(loaded) == 3:
@@ -232,6 +235,11 @@ def _validate(
     spec, result, artifact_bytes, diagnostics = _render_candidate(
         spec_text, _icon_lookup(cache_dir, sha), quality
     )
+    evidence = None
+    if verify_sources_enabled and spec is not None:
+        verified_sources, evidence_diagnostics = verify_sources(spec, spec_path)
+        diagnostics = [*diagnostics, *evidence_diagnostics]
+        evidence = evidence_summary(spec, verified_sources)
     if artifact_bytes is not None:
         with tempfile.TemporaryDirectory(
             prefix=".architecture-diagram-validate-"
@@ -248,6 +256,7 @@ def _validate(
         quality,
         delivery_stage="check" if result is not None and not result.ok else None,
         profile_active=spec is not None and spec.profile is not None,
+        evidence=evidence,
     )
     if layout_json and spec is not None and result is not None:
         receipt["layout"] = _layout_report(spec, result)
@@ -294,6 +303,7 @@ def _deliver(
     cache_dir: Path | None,
     sha: str | None,
     quality: str,
+    verify_sources_enabled: bool,
 ) -> tuple[int, dict[str, object], list[Diagnostic]]:
     loaded = _read_spec("deliver", spec_path, output, quality)
     if len(loaded) == 3:
@@ -313,6 +323,11 @@ def _deliver(
             spec, result, artifact_bytes, diagnostics = _render_candidate(
                 spec_text, _icon_lookup(cache_dir, sha), quality
             )
+            evidence = None
+            if verify_sources_enabled and spec is not None:
+                verified_sources, evidence_diagnostics = verify_sources(spec, spec_path)
+                diagnostics = [*diagnostics, *evidence_diagnostics]
+                evidence = evidence_summary(spec, verified_sources)
             if artifact_bytes is None:
                 receipt = build_receipt(
                     "deliver",
@@ -324,13 +339,20 @@ def _deliver(
                     output=output,
                     delivery_stage="render",
                     profile_active=spec is not None and spec.profile is not None,
+                    evidence=evidence,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
             candidate = stage_dir / "candidate.svg"
             candidate.write_bytes(artifact_bytes)
             if os.stat(candidate).st_dev != os.stat(output_parent).st_dev:
                 raise OSError("candidate artifact is not on the output filesystem")
-            if result is None or not result.ok:
+            if (
+                result is None
+                or not result.ok
+                or any(
+                    diagnostic.severity == SEVERITY_ERROR for diagnostic in diagnostics
+                )
+            ):
                 receipt = build_receipt(
                     "deliver",
                     spec_path,
@@ -341,6 +363,7 @@ def _deliver(
                     output=output,
                     delivery_stage="check",
                     profile_active=spec is not None and spec.profile is not None,
+                    evidence=evidence,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
             receipt = build_receipt(
@@ -354,6 +377,7 @@ def _deliver(
                 written=True,
                 delivery_stage="commit",
                 profile_active=spec is not None and spec.profile is not None,
+                evidence=evidence,
             )
             try:
                 (stage_dir / "receipt.json").write_text(
@@ -404,6 +428,11 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="print the machine-readable receipt to stdout and nothing else",
     )
+    parser.add_argument(
+        "--verify-sources",
+        action="store_true",
+        help="verify declared source references against the local Git checkout",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -439,11 +468,21 @@ def main(argv: list[str] | None = None) -> int:
         return code
     if args.command == "validate":
         code, receipt, diagnostics = _validate(
-            args.spec, args.cache_dir, args.sha, args.quality, args.layout_json
+            args.spec,
+            args.cache_dir,
+            args.sha,
+            args.quality,
+            args.layout_json,
+            args.verify_sources,
         )
     else:
         code, receipt, diagnostics = _deliver(
-            args.spec, args.output, args.cache_dir, args.sha, args.quality
+            args.spec,
+            args.output,
+            args.cache_dir,
+            args.sha,
+            args.quality,
+            args.verify_sources,
         )
     _report(receipt, args.as_json or getattr(args, "layout_json", False), diagnostics)
     return code

--- a/skills/architecture-diagram/engine/evidence.py
+++ b/skills/architecture-diagram/engine/evidence.py
@@ -1,0 +1,178 @@
+"""Fail-closed local verification of authored Git source references."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+from .diagnostics import SEVERITY_ERROR, Diagnostic
+from .model import SourceReference, Spec
+
+
+@dataclass(frozen=True)
+class VerifiedSource:
+    """A source reference proven against one local Git repository."""
+
+    id: str
+    revision: str
+    path: str
+    lines: tuple[int, int]
+    line_count: int
+
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    """Verified references and the repository origin needed by a later receipt."""
+
+    origin: str
+    sources: tuple[VerifiedSource, ...]
+
+
+def _error(
+    code: str,
+    message: str,
+    source: SourceReference | None = None,
+    evidence: dict[str, object] | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        severity=SEVERITY_ERROR,
+        message=message,
+        subject={"source": source.id} if source is not None else {},
+        evidence=evidence or {},
+        supported_fixes=(
+            "run from a local checkout with an `origin` remote and correct source references",
+        ),
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _line_count(blob: bytes) -> int:
+    if not blob:
+        return 0
+    return blob.count(b"\n") + (0 if blob.endswith(b"\n") else 1)
+
+
+def _verify_source(
+    repository: Path, source: SourceReference
+) -> tuple[VerifiedSource | None, Diagnostic | None]:
+    commit = _git(repository, "cat-file", "-e", f"{source.revision}^{{commit}}")
+    if commit.returncode:
+        return None, _error(
+            "source/missing-commit",
+            f"source {source.id!r} does not name an available commit",
+            source,
+            {"revision": source.revision},
+        )
+
+    canonical = _git(repository, "rev-parse", f"{source.revision}^{{commit}}")
+    if canonical.returncode:
+        return None, _error(
+            "source/missing-commit",
+            f"source {source.id!r} does not name an available commit",
+            source,
+            {"revision": source.revision},
+        )
+    revision = canonical.stdout.decode("ascii").strip().lower()
+    object_name = f"{revision}:{source.path}"
+    object_type = _git(repository, "cat-file", "-t", object_name)
+    if object_type.returncode:
+        return None, _error(
+            "source/missing-path",
+            f"source {source.id!r} path is absent at its declared revision",
+            source,
+            {"revision": revision, "path": source.path},
+        )
+    if object_type.stdout.strip() != b"blob":
+        return None, _error(
+            "source/non-blob-path",
+            f"source {source.id!r} path does not name a blob",
+            source,
+            {"revision": revision, "path": source.path},
+        )
+
+    blob = _git(repository, "cat-file", "blob", object_name)
+    if blob.returncode:
+        return None, _error(
+            "source/missing-path",
+            f"source {source.id!r} path cannot be read at its declared revision",
+            source,
+            {"revision": revision, "path": source.path},
+        )
+    if b"\0" in blob.stdout:
+        return None, _error(
+            "source/binary-blob",
+            f"source {source.id!r} names a binary blob without line semantics",
+            source,
+            {"revision": revision, "path": source.path},
+        )
+
+    line_count = _line_count(blob.stdout)
+    if source.lines[1] > line_count:
+        return None, _error(
+            "source/line-range-out-of-bounds",
+            f"source {source.id!r} line range is outside its blob",
+            source,
+            {"lines": list(source.lines), "line_count": line_count},
+        )
+    return (
+        VerifiedSource(
+            id=source.id,
+            revision=revision,
+            path=source.path,
+            lines=source.lines,
+            line_count=line_count,
+        ),
+        None,
+    )
+
+
+def verify_sources(
+    spec: Spec, spec_path: Path
+) -> tuple[SourceEvidence | None, list[Diagnostic]]:
+    """Verify every declared source against the local checkout containing the spec."""
+    repository = _git(spec_path.parent, "rev-parse", "--show-toplevel")
+    if repository.returncode:
+        return None, [
+            _error(
+                "source/no-repository",
+                "source verification requires a local Git repository",
+            )
+        ]
+    repository_path = Path(repository.stdout.decode("utf-8").strip())
+
+    origin = _git(repository_path, "remote", "get-url", "origin")
+    if origin.returncode:
+        return None, [
+            _error(
+                "source/no-origin", "source verification requires an `origin` remote"
+            )
+        ]
+
+    verified: list[VerifiedSource] = []
+    for source in spec.sources:
+        verified_source, diagnostic = _verify_source(repository_path, source)
+        if diagnostic is not None:
+            return None, [diagnostic]
+        assert verified_source is not None
+        verified.append(verified_source)
+    return SourceEvidence(origin.stdout.decode("utf-8").strip(), tuple(verified)), []
+
+
+def summary(spec: Spec, evidence: SourceEvidence | None) -> dict[str, object]:
+    """Build the compact verification-mode receipt field."""
+    return {
+        "mode": "verified",
+        "verified_sources": len(evidence.sources) if evidence is not None else 0,
+        "sourced_nodes": sum(bool(node.sources) for node in spec.nodes),
+        "sourced_edges": sum(bool(edge.sources) for edge in spec.edges),
+    }

--- a/skills/architecture-diagram/engine/receipts.py
+++ b/skills/architecture-diagram/engine/receipts.py
@@ -99,6 +99,7 @@ def receipt(
     written: bool = False,
     delivery_stage: str | None = None,
     profile_active: bool = False,
+    evidence: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Build the stable validate or deliver JSON receipt."""
     result: dict[str, object] = {
@@ -122,6 +123,8 @@ def receipt(
         "validation": validation_receipt(diagnostics, quality, profile_active),
         "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
     }
+    if evidence is not None:
+        result["evidence"] = evidence
     if delivery_stage is not None:
         result["delivery_stage"] = delivery_stage
     return result

--- a/skills/architecture-diagram/engine/tests/test_evidence.py
+++ b/skills/architecture-diagram/engine/tests/test_evidence.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from engine.commands import main
+from engine.evidence import verify_sources
+from engine.spec import load_spec
+
+
+def _git(repository: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _write_spec(repository: Path, revision: str, path: str, lines: str) -> Path:
+    spec = repository / "diagram.yaml"
+    spec.write_text(
+        f"""sources:
+  - id: api
+    revision: {revision}
+    path: {path}
+    lines: {lines}
+nodes:
+  - id: service
+    sources: [api]
+"""
+    )
+    return spec
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "tests@example.invalid")
+    _git(repo, "config", "user.name", "Source Evidence Tests")
+    (repo / "src").mkdir()
+    (repo / "src" / "api.py").write_text("one\ntwo\nthree")
+    _git(repo, "add", "src/api.py")
+    _git(repo, "commit", "-qm", "fixture")
+    _git(repo, "remote", "add", "origin", "https://example.invalid/diagram.git")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_verifies_uppercase_commit_and_no_final_newline(
+    repository: tuple[Path, str],
+) -> None:
+    repo, revision = repository
+    spec_path = _write_spec(repo, revision.upper(), "src/api.py", "[1, 3]")
+
+    evidence, diagnostics = verify_sources(load_spec(spec_path.read_text()), spec_path)
+
+    assert diagnostics == []
+    assert evidence is not None
+    assert evidence.sources[0].revision == revision
+    assert evidence.sources[0].line_count == 3
+
+
+@pytest.mark.parametrize(
+    ("revision", "path", "lines", "expected"),
+    [
+        ("a" * 40, "src/api.py", "[1, 3]", "source/missing-commit"),
+        ("HEAD", "missing.py", "[1, 3]", "source/missing-path"),
+        ("HEAD", "src", "[1, 3]", "source/non-blob-path"),
+        ("HEAD", "src/api.py", "[1, 4]", "source/line-range-out-of-bounds"),
+    ],
+)
+def test_rejects_unverifiable_source_references(
+    repository: tuple[Path, str], revision: str, path: str, lines: str, expected: str
+) -> None:
+    repo, head = repository
+    actual_revision = head if revision == "HEAD" else revision
+    spec_path = _write_spec(repo, actual_revision, path, lines)
+
+    evidence, diagnostics = verify_sources(load_spec(spec_path.read_text()), spec_path)
+
+    assert evidence is None
+    assert [diagnostic.code for diagnostic in diagnostics] == [expected]
+
+
+def test_rejects_binary_blob(repository: tuple[Path, str]) -> None:
+    repo, _ = repository
+    (repo / "src" / "binary.bin").write_bytes(b"\0binary")
+    _git(repo, "add", "src/binary.bin")
+    _git(repo, "commit", "-qm", "binary fixture")
+    spec_path = _write_spec(
+        repo, _git(repo, "rev-parse", "HEAD"), "src/binary.bin", "[1, 1]"
+    )
+
+    evidence, diagnostics = verify_sources(load_spec(spec_path.read_text()), spec_path)
+
+    assert evidence is None
+    assert [diagnostic.code for diagnostic in diagnostics] == ["source/binary-blob"]
+
+
+def test_rejects_source_outside_a_git_repository(tmp_path: Path) -> None:
+    spec_path = _write_spec(tmp_path, "a" * 40, "src/api.py", "[1, 1]")
+
+    evidence, diagnostics = verify_sources(load_spec(spec_path.read_text()), spec_path)
+
+    assert evidence is None
+    assert [diagnostic.code for diagnostic in diagnostics] == ["source/no-repository"]
+
+
+def test_rejects_repository_without_origin(tmp_path: Path) -> None:
+    repo = tmp_path / "no-origin"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    spec_path = _write_spec(repo, "a" * 40, "src/api.py", "[1, 1]")
+
+    evidence, diagnostics = verify_sources(load_spec(spec_path.read_text()), spec_path)
+
+    assert evidence is None
+    assert [diagnostic.code for diagnostic in diagnostics] == ["source/no-origin"]
+
+
+def test_validate_receipt_reports_verified_evidence(
+    repository: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo, revision = repository
+    spec_path = _write_spec(repo, revision, "src/api.py", "[1, 3]")
+
+    assert main(["validate", str(spec_path), "--verify-sources", "--json"]) == 0
+
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["evidence"] == {
+        "mode": "verified",
+        "sourced_edges": 0,
+        "sourced_nodes": 1,
+        "verified_sources": 1,
+    }
+
+
+def test_deliver_verifies_before_writing(
+    repository: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo, revision = repository
+    spec_path = _write_spec(repo, revision, "src/api.py", "[1, 3]")
+    output = repo / "diagram.svg"
+
+    assert (
+        main(
+            [
+                "deliver",
+                str(spec_path),
+                "--verify-sources",
+                "--json",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    receipt = json.loads(capsys.readouterr().out)
+    assert output.is_file()
+    assert receipt["evidence"]["verified_sources"] == 1
+    assert receipt["evidence"] == {
+        "mode": "verified",
+        "sourced_edges": 0,
+        "sourced_nodes": 1,
+        "verified_sources": 1,
+    }

--- a/skills/architecture-diagram/references/spec-format.md
+++ b/skills/architecture-diagram/references/spec-format.md
@@ -95,10 +95,15 @@ Under `profile: deployment-ownership`, a labeled cross-security-zone edge names 
 ## Compare two specifications
 
 Run `python3 -m engine compare base.yaml head.yaml` to emit a deterministic JSON receipt. It matches nodes by their authored `id` and edges by their authored `id`; rendering hashes, generated geometry, labels-as-identifiers, and endpoint-pair matching never participate.
-
 Each node or edge is `added`, `removed`, `unchanged`, or has one or more statuses from disjoint authored field groups: node semantic fields produce `changed`, node `zone` produces `moved`, edge semantic fields (`label`, `type`) produce `changed`, and edge endpoints (`from`, `to`) produce `rerouted`. `changed_fields` records the exact JSON-pointer paths and before/after authored values.
 
 Every receipt includes this limitation: `Authored specification only; no runtime impact, causality, risk, or merge safety is inferred.`
+
+## Verify authored source references
+
+Run `python3 -m engine validate --verify-sources spec.yaml --json` to fail closed unless every declared source names a local Git commit, a blob at the declared path, and an in-bounds inclusive line range. Verification starts from the spec file's directory and requires that checkout to have an `origin` remote; detached HEAD is valid because declarations name immutable commits.
+
+Verification uses only direct local Git object reads. It neither copies source bytes into command output nor performs remote lookups. The verifier accepts uppercase Git object ids and records canonical lowercase ids internally. A tree path, binary blob, absent commit/path, or range beyond the blob's line count is a coded error.
 
 ## What the renderer computes for you (don't set these)
 


### PR DESCRIPTION
## Summary

Adds fail-closed local Git verification for authored source declarations through `--verify-sources` on `validate` and `deliver`. Verification validates repository/origin, commit, blob path/type, binary content, and inclusive source-line spans.

## Stack

Stack-Id: `architecture-diagram-source-evidence-9b6c4d`
Base: `feat/architecture-diagram-source-schema`
Position: 3/4

1. `refactor/architecture-diagram-receipts` → ancestor
2. `feat/architecture-diagram-source-schema` → parent
3. `feat/architecture-diagram-verify-sources` → this PR
4. `feat/architecture-diagram-source-sidecars` → dependent

Depends on: parent PR

## Validation

- `uv run python -m pytest skills/architecture-diagram/engine/tests -q` — 218 passed
- `uv run ruff check skills/architecture-diagram/engine`
- `uv run ruff format --check skills/architecture-diagram/engine`
- Real temporary-Git fixtures cover commits, blobs, trees, missing paths, binary blobs, ranges, detached-compatible commits, no repository, and no origin

No SVG badge or sidecar artifact is included.