### PR TITLE
feat(architecture-diagram): add editable drawio delivery

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -51,11 +51,12 @@ packages:
   - name: architecture-diagram
     version: 2.4.0
     description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams,
-      or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead
-      of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram",
-      "topology diagram", "draw architecture", "AWS diagram", "Azure diagram", "GCP diagram", "cloud infrastructure diagram",
-      "VPC diagram", "draw my AWS setup". Use when a user wants a static architecture diagram they can still edit afterward
-      in Figma, Illustrator, or Inkscape. NOT for architecture reviews, use architecture-reviewer.'
+      or hand-drawn generic icons for everything else. Optionally deliver a self-contained editable draw.io mxGraph companion.
+      Deterministic layout computes zone nesting and orthogonal routing instead of hand-placed coordinates. Triggers on: "architecture
+      diagram", "infra diagram", "system diagram", "deployment diagram", "topology diagram", "draw architecture", "AWS diagram",
+      "Azure diagram", "GCP diagram", "cloud infrastructure diagram", "VPC diagram", "draw my AWS setup". Use when a user
+      wants a static architecture diagram they can still edit afterward in Figma, Illustrator, Inkscape, or draw.io. NOT for
+      architecture reviews, use architecture-reviewer.'
     path: skills/architecture-diagram
     source: https://github.com/Mathews-Tom/armory/blob/main/skills/architecture-diagram/SKILL.md
     tags:

--- a/skills/architecture-diagram/SKILL.md
+++ b/skills/architecture-diagram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-diagram
-description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams, or hand-drawn generic icons for everything else. Deterministic layout computes zone nesting and orthogonal routing instead of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram", "topology diagram", "draw architecture", "AWS diagram", "Azure diagram", "GCP diagram", "cloud infrastructure diagram", "VPC diagram", "draw my AWS setup". Use when a user wants a static architecture diagram they can still edit afterward in Figma, Illustrator, or Inkscape. NOT for architecture reviews, use architecture-reviewer.'
+description: 'Generate architecture diagrams as fully editable SVG with native AWS, Azure, and GCP icons for cloud diagrams, or hand-drawn generic icons for everything else. Optionally deliver a self-contained editable draw.io mxGraph companion. Deterministic layout computes zone nesting and orthogonal routing instead of hand-placed coordinates. Triggers on: "architecture diagram", "infra diagram", "system diagram", "deployment diagram", "topology diagram", "draw architecture", "AWS diagram", "Azure diagram", "GCP diagram", "cloud infrastructure diagram", "VPC diagram", "draw my AWS setup". Use when a user wants a static architecture diagram they can still edit afterward in Figma, Illustrator, Inkscape, or draw.io. NOT for architecture reviews, use architecture-reviewer.'
 metadata:
   version: 2.4.0
   category: visualization
@@ -11,7 +11,7 @@ metadata:
 
 # Architecture Diagram Generator
 
-Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS/Azure/GCP official architecture icons, or a hand-drawn generic set for anything else), deterministic zone-aware layout, orthogonal connection routing, real `<text>` labels. Zero raster images, zero `<use>` clones — every icon is inlined per node so the output opens cleanly as an editable layer tree in Figma, Illustrator, Inkscape, or draw.io.
+Produces standalone, fully editable `.svg` files: real inlined vector icons (AWS/Azure/GCP official architecture icons, or a hand-drawn generic set for everything else), deterministic zone-aware layout, orthogonal connection routing, and real `<text>` labels. `deliver --emit drawio` additionally produces a self-contained editable `.drawio` mxGraph companion. SVG output uses zero raster images and zero `<use>` clones; draw.io output uses independently editable cells with local vector icon data and no remote image, external URL, or provider stencil dependency.
 
 ## When to use this
 
@@ -58,15 +58,19 @@ Run the following commands from this skill directory (`skills/architecture-diagr
    Use `--layout-json` instead of `--json` when an agent needs the exact emitted node boxes, zone membership and boxes, routed edge waypoints, and edge-label rectangles for review. It also never writes SVG output.
 6. **Deliver only a clean candidate:**
    ```bash
-   python3 -m engine deliver spec.yaml -o diagram.svg --quality showcase --json
+   python3 -m engine deliver spec.yaml -o diagram.svg --quality showcase --emit drawio --json
    ```
-   `deliver` stages the exact spec and candidate SVG beside the target, then atomically replaces the target only after every check passes. With `--verify-sources`, it delivers `diagram.svg` and `diagram.sources.json`; the SVG carries local `VERIFIED SRC n` badges and source-id metadata, while the sidecar binds verified references to the delivered SVG digest. Caught write or replacement failures restore the prior pair; process termination between replacements is outside that rollback contract.
-7. **Compare authored revisions when needed:**
+   `deliver` stages the exact spec and candidate SVG beside the target, then atomically replaces every requested output only after every check passes. `--emit drawio` also delivers `diagram.drawio`; the JSON receipt's top-level `artifacts` list records the path, SHA-256, and byte count for each committed file. With `--verify-sources`, it atomically delivers `diagram.svg`, `diagram.drawio`, and `diagram.sources.json`; the SVG and draw.io output carry local `VERIFIED SRC n` badges, while the sidecar binds verified references to the delivered SVG digest. Caught write or replacement failures restore the prior bundle; process termination between replacements is outside that rollback contract.
+7. **Review a draw.io companion before handoff:**
+   1. Open `diagram.drawio` in draw.io.
+   2. Confirm that a zone, node container, icon, node label, edge, and edge label select independently.
+   3. Move a node label and save. The output preserves authored structure and initial computed placement; it does not promise round-trip SVG bytes or manual-route preservation.
+8. **Compare authored revisions when needed:**
    ```bash
    python3 -m engine compare base.yaml head.yaml
    ```
    `compare` emits a JSON receipt keyed only by authored node and edge ids. It reports added, removed, changed, moved, and rerouted entities with exact field paths. Its mandatory limitation is: `Authored specification only; no runtime impact, causality, risk, or merge safety is inferred.`
-8. **Output** the final `.svg` to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
+9. **Output** the final `.svg` and requested `.drawio` companion to the working directory or user-specified path. Mention the icon-cache prerequisite only if this was the first render for a given provider.
 
 ## Spec fields at a glance
 
@@ -232,11 +236,11 @@ Every finding is a coded diagnostic carrying `code`, `severity`, `message`, `sub
 
 | Exit | Meaning | Action |
 |---|---|---|
-| 0 | `validate` completed with no error findings, or `deliver` atomically committed a validated SVG | Hand off the receipt or SVG; any warnings are deliberate, explainable tradeoffs |
+| 0 | `validate` completed with no error findings, or `deliver` atomically committed a validated SVG bundle | Hand off the receipt and requested artifacts; any warnings are deliberate, explainable tradeoffs |
 | 1 | A blocking finding or operational delivery failure | Apply a diagnostic's `supported_fixes`, or correct the output path or filesystem permissions |
 | 2 | Usage error — missing subcommand, unreadable spec path, unknown flag or profile value | Correct the command |
 
-`--json` prints the receipt and nothing else on stdout. It contains `input` and `artifact` SHA-256/byte records, `output.written`, `validation.checks_passed`/`checks_total`, quality, composition status, severity counts, and diagnostics. `--quality showcase` raises `composition/*` route-geometry findings to errors; the default `standard` keeps them as warnings.
+`--json` prints the receipt and nothing else on stdout. It contains `input` and primary-SVG `artifact` SHA-256/byte records, `output.written`, `validation.checks_passed`/`checks_total`, quality, composition status, severity counts, and diagnostics. When `--emit drawio` is present, `artifacts` lists every committed output with its path, SHA-256, and byte count. `--quality showcase` raises `composition/*` route-geometry findings to errors; the default `standard` keeps them as warnings.
 
 | Code | Meaning | Fix |
 |---|---|---|
@@ -252,7 +256,7 @@ A fetch failure (`could not fetch <provider> icons`) is a network problem, not a
 
 ## Output
 
-Report the output path, any warning-severity findings left unresolved and why, and — only on the first render for a given provider — the icon-cache fetch cost.
+Report the SVG path, requested draw.io companion path, and any warning-severity findings left unresolved and why. Mention the icon-cache fetch cost only on the first render for a given provider.
 
 ## Reference table
 

--- a/skills/architecture-diagram/engine/commands.py
+++ b/skills/architecture-diagram/engine/commands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from . import fetch_icons
 from .compare import compare_specs
 from .delivery import BundleCommitError, commit_bundle
+from .drawio import emit_drawio as emit_drawio_xml
 from .diagnostics import (
     QUALITY_PROFILES,
     QUALITY_STANDARD,
@@ -306,6 +307,7 @@ def _deliver(
     sha: str | None,
     quality: str,
     verify_sources_enabled: bool,
+    emit_drawio_enabled: bool,
 ) -> tuple[int, dict[str, object], list[Diagnostic]]:
     loaded = _read_spec("deliver", spec_path, output, quality)
     if len(loaded) == 3:
@@ -347,13 +349,26 @@ def _deliver(
                 return EXIT_FAILURE, receipt, diagnostics
             candidate = stage_dir / "candidate.svg"
             candidate.write_bytes(artifact_bytes)
-            sidecar_candidate = None
-            sidecar_path = None
+            replacements: list[tuple[Path, Path]] = [(candidate, output)]
+            if emit_drawio_enabled:
+                assert spec is not None
+                assert result is not None
+                drawio_path = output.with_name(f"{output.stem}.drawio")
+                drawio_candidate = stage_dir / "candidate.drawio"
+                drawio_candidate.write_text(
+                    emit_drawio_xml(
+                        spec,
+                        result,
+                        source_badges=verify_sources_enabled,
+                    )
+                )
+                replacements.append((drawio_candidate, drawio_path))
             if verified_sources is not None:
                 sidecar_path = output.with_name(f"{output.stem}.sources.json")
                 sidecar_candidate = stage_dir / "candidate.sources.json"
                 sidecar = sidecar_bytes(verified_sources, output, artifact_bytes)
                 sidecar_candidate.write_bytes(sidecar)
+                replacements.append((sidecar_candidate, sidecar_path))
                 evidence["sidecar"] = {
                     "path": str(sidecar_path),
                     "sha256": sha256(sidecar),
@@ -380,6 +395,16 @@ def _deliver(
                     evidence=evidence,
                 )
                 return EXIT_FAILURE, receipt, diagnostics
+            artifacts = None
+            if emit_drawio_enabled:
+                artifacts = [
+                    {
+                        "path": str(target),
+                        "sha256": sha256(candidate.read_bytes()),
+                        "bytes": candidate.stat().st_size,
+                    }
+                    for candidate, target in replacements
+                ]
             receipt = build_receipt(
                 "deliver",
                 spec_path,
@@ -392,6 +417,7 @@ def _deliver(
                 delivery_stage="commit",
                 profile_active=spec is not None and spec.profile is not None,
                 evidence=evidence,
+                artifacts=artifacts,
             )
             try:
                 (stage_dir / "receipt.json").write_text(
@@ -408,9 +434,6 @@ def _deliver(
                     exc,
                 )
             try:
-                replacements = [(candidate, output)]
-                if sidecar_candidate is not None and sidecar_path is not None:
-                    replacements.append((sidecar_candidate, sidecar_path))
                 commit_bundle(stage_dir, replacements)
             except BundleCommitError as exc:
                 return _delivery_failure(
@@ -471,6 +494,12 @@ def main(argv: list[str] | None = None) -> int:
     deliver_parser.add_argument(
         "-o", "--output", type=Path, required=True, help="target SVG path"
     )
+    deliver_parser.add_argument(
+        "--emit",
+        choices=("drawio",),
+        default=None,
+        help="stage and atomically deliver the requested companion artifact",
+    )
     compare_parser = commands.add_parser(
         "compare", help="compare two authored specifications into a JSON receipt"
     )
@@ -500,6 +529,7 @@ def main(argv: list[str] | None = None) -> int:
             args.sha,
             args.quality,
             args.verify_sources,
+            args.emit == "drawio",
         )
     _report(receipt, args.as_json or getattr(args, "layout_json", False), diagnostics)
     return code

--- a/skills/architecture-diagram/engine/drawio.py
+++ b/skills/architecture-diagram/engine/drawio.py
@@ -1,0 +1,307 @@
+"""Deterministic, self-contained mxGraph projection for architecture diagrams."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+import xml.etree.ElementTree as ElementTree
+
+from .layout import Box, ICON, icon_box, zone_ancestors
+from .model import Node, Spec, Zone
+from .pipeline import RenderResult
+from .svg import EDGE_COLORS
+
+_MXFILE_ID = "architecture-diagram"
+_ROOT_ID = "0"
+_DEFAULT_PARENT_ID = "1"
+
+
+def _number(value: float) -> str:
+    """Serialize one computed coordinate without representation drift."""
+    return f"{value:g}"
+
+
+def _cell_id(kind: str, authored_id: str) -> str:
+    """Keep every cell addressable through its authored identity."""
+    return f"{kind}-{authored_id}"
+
+
+def _cell(
+    cell_id: str,
+    value: str,
+    style: str,
+    parent: str,
+    *,
+    vertex: bool = False,
+    edge: bool = False,
+    source: str | None = None,
+    target: str | None = None,
+) -> ElementTree.Element:
+    attributes = {"id": cell_id, "value": value, "style": style, "parent": parent}
+    if vertex:
+        attributes["vertex"] = "1"
+    if edge:
+        attributes["edge"] = "1"
+    if source is not None:
+        attributes["source"] = source
+    if target is not None:
+        attributes["target"] = target
+    return ElementTree.Element("mxCell", attributes)
+
+
+def _geometry(
+    cell: ElementTree.Element,
+    box: Box,
+    *,
+    relative: bool = False,
+) -> None:
+    attributes = {
+        "x": _number(box.x),
+        "y": _number(box.y),
+        "width": _number(box.w),
+        "height": _number(box.h),
+        "as": "geometry",
+    }
+    if relative:
+        attributes["relative"] = "1"
+    ElementTree.SubElement(cell, "mxGeometry", attributes)
+
+
+def _relative_box(box: Box, parent: Box | None) -> Box:
+    """Translate absolute engine geometry into an mxGraph parent coordinate space."""
+    if parent is None:
+        return box
+    return Box(box.x - parent.x, box.y - parent.y, box.w, box.h)
+
+
+def _inline_icon_uri(view_box: str, body: str) -> str:
+    """Embed a resolved vector icon without a remote image or stencil dependency."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="{view_box}" color="#FFFFFF">{body}</svg>'
+    )
+    return f"data:image/svg+xml,{quote(svg, safe='')}"
+
+
+def _zone_style(zone: Zone) -> str:
+    colors = {
+        "generic": ("#F5F3FF", "#7C3AED"),
+        "region": ("#EFF6FF", "#2563EB"),
+        "security": ("#ECFDF5", "#059669"),
+    }
+    fill, stroke = colors[zone.kind]
+    return (
+        "swimlane;horizontal=0;startSize=28;rounded=1;arcSize=8;html=1;"
+        f"fillColor={fill};strokeColor={stroke};fontColor={stroke};"
+    )
+
+
+def _node_style(node: Node) -> str:
+    return f"rounded=1;arcSize=8;html=1;fillColor=#FFFFFF;strokeColor={node.color};"
+
+
+def _icon_style(node: Node, icon_uri: str | None) -> str:
+    if icon_uri is None:
+        return f"shape=ellipse;html=1;fillColor={node.color};strokeColor={node.color};"
+    return f"shape=image;imageAspect=0;html=1;image={icon_uri};"
+
+
+def _text_style(color: str, *, bold: bool = False) -> str:
+    weight = "fontStyle=1;" if bold else ""
+    return f"text;html=1;align=center;verticalAlign=middle;{weight}fontColor={color};"
+
+
+def _append_node(
+    root: ElementTree.Element,
+    node: Node,
+    result: RenderResult,
+    *,
+    source_badges: bool,
+) -> None:
+    node_box = result.node_boxes[node.id]
+    parent_box = result.zone_boxes.get(node.zone) if node.zone is not None else None
+    parent_id = (
+        _cell_id("zone", node.zone) if node.zone is not None else _DEFAULT_PARENT_ID
+    )
+    node_id = _cell_id("node", node.id)
+    node_cell = _cell(node_id, "", _node_style(node), parent_id, vertex=True)
+    _geometry(node_cell, _relative_box(node_box, parent_box))
+    root.append(node_cell)
+
+    visible_icon = icon_box(node_box)
+    icon = result.icons[node.id]
+    icon_uri = None if icon is None else _inline_icon_uri(icon.view_box, icon.body)
+    icon_cell = _cell(
+        _cell_id("icon", node.id),
+        "",
+        _icon_style(node, icon_uri),
+        node_id,
+        vertex=True,
+    )
+    _geometry(
+        icon_cell,
+        Box(
+            visible_icon.x - node_box.x,
+            visible_icon.y - node_box.y,
+            visible_icon.w,
+            visible_icon.h,
+        ),
+    )
+    root.append(icon_cell)
+
+    label_cell = _cell(
+        _cell_id("label", node.id),
+        node.label,
+        _text_style("#1F2937", bold=True),
+        node_id,
+        vertex=True,
+    )
+    _geometry(label_cell, Box(0, ICON + 6, node_box.w, 20))
+    root.append(label_cell)
+
+    if node.sublabel:
+        sublabel_cell = _cell(
+            _cell_id("sublabel", node.id),
+            node.sublabel,
+            _text_style("#6B7280"),
+            node_id,
+            vertex=True,
+        )
+        _geometry(sublabel_cell, Box(0, ICON + 26, node_box.w, 18))
+        root.append(sublabel_cell)
+
+    if source_badges and node.sources:
+        badge_cell = _cell(
+            _cell_id("source-badge-node", node.id),
+            f"VERIFIED SRC {len(node.sources)}",
+            _text_style("#047857", bold=True),
+            node_id,
+            vertex=True,
+        )
+        _geometry(badge_cell, Box(0, node_box.h - 18, node_box.w, 14))
+        root.append(badge_cell)
+
+
+def _append_edge(
+    root: ElementTree.Element,
+    edge_index: int,
+    result: RenderResult,
+    *,
+    source_badges: bool,
+) -> None:
+    routed = result.routed_edges[edge_index]
+    edge = routed.edge
+    semantic_id = edge.id or f"{edge.src}-to-{edge.dst}"
+    edge_id = f"{_cell_id('edge', semantic_id)}-{edge_index}"
+    color = EDGE_COLORS.get(edge.type, EDGE_COLORS["default"])
+    dash = "dashed=1;" if edge.type == "batch" else ""
+    edge_cell = _cell(
+        edge_id,
+        "",
+        f"edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor={color};{dash}",
+        _DEFAULT_PARENT_ID,
+        edge=True,
+        source=_cell_id("node", edge.src),
+        target=_cell_id("node", edge.dst),
+    )
+    geometry = ElementTree.SubElement(
+        edge_cell, "mxGeometry", {"relative": "1", "as": "geometry"}
+    )
+    intermediate = routed.points[1:-1]
+    if intermediate:
+        points = ElementTree.SubElement(geometry, "Array", {"as": "points"})
+        for x, y in intermediate:
+            ElementTree.SubElement(
+                points, "mxPoint", {"x": _number(x), "y": _number(y)}
+            )
+    root.append(edge_cell)
+
+    if edge.label:
+        label_cell = _cell(
+            f"{_cell_id('edge-label', semantic_id)}-{edge_index}",
+            edge.label,
+            _text_style(color),
+            edge_id,
+            vertex=True,
+        )
+        _geometry(label_cell, Box(0, -16, 90, 18), relative=True)
+        root.append(label_cell)
+
+    if source_badges and edge.sources:
+        badge_cell = _cell(
+            f"{_cell_id('source-badge-edge', semantic_id)}-{edge_index}",
+            f"VERIFIED SRC {len(edge.sources)}",
+            _text_style("#047857", bold=True),
+            edge_id,
+            vertex=True,
+        )
+        _geometry(badge_cell, Box(0, 4, 100, 14), relative=True)
+        root.append(badge_cell)
+
+
+def emit_drawio(
+    spec: Spec, result: RenderResult, *, source_badges: bool = False
+) -> str:
+    """Project authored and computed IR into stable, self-contained mxGraph XML."""
+    mxfile = ElementTree.Element(
+        "mxfile", {"host": "app.diagrams.net", "type": "device"}
+    )
+    diagram = ElementTree.SubElement(
+        mxfile, "diagram", {"id": _MXFILE_ID, "name": "Architecture Diagram"}
+    )
+    model = ElementTree.SubElement(
+        diagram,
+        "mxGraphModel",
+        {
+            "grid": "1",
+            "gridSize": "10",
+            "guides": "1",
+            "tooltips": "1",
+            "connect": "1",
+            "arrows": "1",
+            "fold": "1",
+            "page": "1",
+            "pageScale": "1",
+            "pageWidth": "850",
+            "pageHeight": "1100",
+            "math": "0",
+            "shadow": "0",
+        },
+    )
+    root = ElementTree.SubElement(model, "root")
+    root.append(ElementTree.Element("mxCell", {"id": _ROOT_ID}))
+    root.append(
+        ElementTree.Element("mxCell", {"id": _DEFAULT_PARENT_ID, "parent": _ROOT_ID})
+    )
+
+    zone_by_id = {zone.id: zone for zone in spec.zones}
+    for zone_id in sorted(
+        result.zone_boxes,
+        key=lambda value: (len(zone_ancestors(spec, value)), value),
+    ):
+        zone = zone_by_id[zone_id]
+        parent_box = (
+            result.zone_boxes.get(zone.parent) if zone.parent is not None else None
+        )
+        parent_id = (
+            _cell_id("zone", zone.parent)
+            if zone.parent is not None
+            else _DEFAULT_PARENT_ID
+        )
+        zone_cell = _cell(
+            _cell_id("zone", zone.id),
+            zone.label,
+            _zone_style(zone),
+            parent_id,
+            vertex=True,
+        )
+        _geometry(zone_cell, _relative_box(result.zone_boxes[zone.id], parent_box))
+        root.append(zone_cell)
+
+    for node in spec.nodes:
+        _append_node(root, node, result, source_badges=source_badges)
+    for edge_index in range(len(result.routed_edges)):
+        _append_edge(root, edge_index, result, source_badges=source_badges)
+
+    ElementTree.indent(mxfile, space="  ")
+    xml = ElementTree.tostring(mxfile, encoding="unicode", short_empty_elements=True)
+    return f'<?xml version="1.0" encoding="UTF-8"?>\n{xml}\n'

--- a/skills/architecture-diagram/engine/layout.py
+++ b/skills/architecture-diagram/engine/layout.py
@@ -131,9 +131,11 @@ def compute_positions(
     spec: Spec, rank: dict[str, int], order: dict[str, int]
 ) -> dict[str, Box]:
     """Place node boxes from authored direction and computed rank/order."""
-    top_offset = MARGIN + TITLE_H
-    if spec.zones:
-        top_offset += ZONE_PAD + ZONE_LABEL_H
+    deepest_zone = max(
+        (len(zone_ancestors(spec, zone.id)) + 1 for zone in spec.zones),
+        default=0,
+    )
+    top_offset = MARGIN + TITLE_H + deepest_zone * (ZONE_PAD + ZONE_LABEL_H)
     boxes: dict[str, Box] = {}
     for node in spec.nodes:
         rank_id, order_id = rank[node.id], order[node.id]

--- a/skills/architecture-diagram/engine/pipeline.py
+++ b/skills/architecture-diagram/engine/pipeline.py
@@ -40,6 +40,7 @@ class RenderResult:
     node_boxes: dict[str, Box] = field(default_factory=dict)
     zone_boxes: dict[str, Box] = field(default_factory=dict)
     routed_edges: list[RoutedEdge] = field(default_factory=list)
+    icons: dict[str, IconRef | None] = field(default_factory=dict)
 
     @property
     def errors(self) -> list[Diagnostic]:
@@ -98,4 +99,5 @@ def render(
         node_boxes=node_boxes,
         zone_boxes=zone_boxes,
         routed_edges=routed_edges,
+        icons=icons,
     )

--- a/skills/architecture-diagram/engine/receipts.py
+++ b/skills/architecture-diagram/engine/receipts.py
@@ -100,6 +100,7 @@ def receipt(
     delivery_stage: str | None = None,
     profile_active: bool = False,
     evidence: dict[str, object] | None = None,
+    artifacts: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     """Build the stable validate or deliver JSON receipt."""
     result: dict[str, object] = {
@@ -125,6 +126,8 @@ def receipt(
     }
     if evidence is not None:
         result["evidence"] = evidence
+    if artifacts is not None:
+        result["artifacts"] = artifacts
     if delivery_stage is not None:
         result["delivery_stage"] = delivery_stage
     return result

--- a/skills/architecture-diagram/engine/tests/fixtures/drawio-review.drawio
+++ b/skills/architecture-diagram/engine/tests/fixtures/drawio-review.drawio
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" type="device">
+  <diagram id="architecture-diagram" name="Architecture Diagram">
+    <mxGraphModel grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="zone-vpc" value="VPC" style="swimlane;horizontal=0;startSize=28;rounded=1;arcSize=8;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;fontColor=#7C3AED;" parent="1" vertex="1">
+          <mxGeometry x="220" y="76" width="164" height="188" as="geometry" />
+        </mxCell>
+        <mxCell id="node-public" value="" style="rounded=1;arcSize=8;html=1;fillColor=#FFFFFF;strokeColor=#3A3A3A;" parent="1" vertex="1">
+          <mxGeometry x="32" y="124" width="120" height="118" as="geometry" />
+        </mxCell>
+        <mxCell id="icon-public" value="" style="shape=ellipse;html=1;fillColor=#3A3A3A;strokeColor=#3A3A3A;" parent="node-public" vertex="1">
+          <mxGeometry x="28" y="0" width="64" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="label-public" value="Public endpoint" style="text;html=1;align=center;verticalAlign=middle;fontStyle=1;fontColor=#1F2937;" parent="node-public" vertex="1">
+          <mxGeometry x="0" y="70" width="120" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="node-service" value="" style="rounded=1;arcSize=8;html=1;fillColor=#FFFFFF;strokeColor=#3A3A3A;" parent="zone-vpc" vertex="1">
+          <mxGeometry x="22" y="48" width="120" height="118" as="geometry" />
+        </mxCell>
+        <mxCell id="icon-service" value="" style="shape=ellipse;html=1;fillColor=#3A3A3A;strokeColor=#3A3A3A;" parent="node-service" vertex="1">
+          <mxGeometry x="28" y="0" width="64" height="64" as="geometry" />
+        </mxCell>
+        <mxCell id="label-service" value="Service" style="text;html=1;align=center;verticalAlign=middle;fontStyle=1;fontColor=#1F2937;" parent="node-service" vertex="1">
+          <mxGeometry x="0" y="70" width="120" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="sublabel-service" value="Private tier" style="text;html=1;align=center;verticalAlign=middle;fontColor=#6B7280;" parent="node-service" vertex="1">
+          <mxGeometry x="0" y="90" width="120" height="18" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-ingress-0" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;endFill=1;strokeColor=#2563EB;" parent="1" edge="1" source="node-public" target="node-service">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-label-ingress-0" value="HTTPS" style="text;html=1;align=center;verticalAlign=middle;fontColor=#2563EB;" parent="edge-ingress-0" vertex="1">
+          <mxGeometry x="0" y="-16" width="90" height="18" as="geometry" relative="1" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/skills/architecture-diagram/engine/tests/fixtures/drawio-review.yaml
+++ b/skills/architecture-diagram/engine/tests/fixtures/drawio-review.yaml
@@ -1,0 +1,17 @@
+title: Editable review fixture
+zones:
+  - id: vpc
+    label: VPC
+nodes:
+  - id: public
+    label: Public endpoint
+  - id: service
+    label: Service
+    sublabel: Private tier
+    zone: vpc
+edges:
+  - id: ingress
+    from: public
+    to: service
+    label: HTTPS
+    type: realtime

--- a/skills/architecture-diagram/engine/tests/test_drawio.py
+++ b/skills/architecture-diagram/engine/tests/test_drawio.py
@@ -1,0 +1,160 @@
+"""Structural tests for the deterministic draw.io projection."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+from engine.drawio import emit_drawio
+from engine.icons import IconRef
+from engine.pipeline import render
+from engine.spec import load_spec
+
+
+def _icon_lookup(provider: str, service_slug: str) -> IconRef | None:
+    del provider
+    return IconRef(
+        view_box="0 0 100 100",
+        body=(
+            '<path d="M0,0 L100,100" fill="currentColor"/>'
+            f"<title>{service_slug}</title>"
+        ),
+    )
+
+
+DRAWIO_SPEC = """
+title: Editable projection
+provider: generic
+sources:
+  - id: src-service
+    revision: 0123456789abcdef0123456789abcdef01234567
+    path: src/service.py
+    lines: [1, 2]
+zones:
+  - id: outer
+    label: Outer
+    kind: region
+  - id: inner
+    label: Inner
+    parent: outer
+    kind: security
+nodes:
+  - id: public
+    label: Public
+    service: gateway
+  - id: service
+    label: Service & API
+    sublabel: Private <tier>
+    service: database
+    zone: inner
+    sources: [src-service]
+edges:
+  - id: egress
+    from: public
+    to: service
+    label: HTTPS & TLS
+    type: batch
+    sources: [src-service]
+"""
+
+
+def _cells(xml: str) -> dict[str, ElementTree.Element]:
+    document = ElementTree.fromstring(xml)
+    assert document.tag == "mxfile"
+    assert document.attrib == {"host": "app.diagrams.net", "type": "device"}
+    diagram = document.find("./diagram")
+    assert diagram is not None
+    assert diagram.attrib == {
+        "id": "architecture-diagram",
+        "name": "Architecture Diagram",
+    }
+    root = document.find("./diagram/mxGraphModel/root")
+    assert root is not None
+    cells = {cell.attrib["id"]: cell for cell in root.findall("mxCell")}
+    assert len(cells) == len(root.findall("mxCell"))
+    return cells
+
+
+def test_projects_every_editable_category_into_independent_cells() -> None:
+    spec = load_spec(DRAWIO_SPEC)
+    result = render(spec, _icon_lookup)
+
+    cells = _cells(emit_drawio(spec, result))
+
+    assert cells["zone-outer"].attrib["parent"] == "1"
+    assert cells["zone-inner"].attrib["parent"] == "zone-outer"
+    assert cells["node-service"].attrib["parent"] == "zone-inner"
+    assert cells["icon-service"].attrib["parent"] == "node-service"
+    assert cells["label-service"].attrib == {
+        "id": "label-service",
+        "value": "Service & API",
+        "style": "text;html=1;align=center;verticalAlign=middle;fontStyle=1;fontColor=#1F2937;",
+        "parent": "node-service",
+        "vertex": "1",
+    }
+    assert cells["sublabel-service"].attrib["value"] == "Private <tier>"
+    assert cells["edge-egress-0"].attrib["parent"] == "1"
+    assert cells["edge-egress-0"].attrib["source"] == "node-public"
+    assert cells["edge-egress-0"].attrib["target"] == "node-service"
+    assert cells["edge-label-egress-0"].attrib["parent"] == "edge-egress-0"
+    assert cells["edge-label-egress-0"].attrib["value"] == "HTTPS & TLS"
+
+
+def test_projected_references_are_resolvable_and_routes_are_retained() -> None:
+    spec = load_spec(DRAWIO_SPEC)
+    result = render(spec, _icon_lookup)
+    cells = _cells(emit_drawio(spec, result))
+
+    for cell in cells.values():
+        parent = cell.attrib.get("parent")
+        if parent is not None:
+            assert parent in cells
+        if cell.attrib.get("edge") == "1":
+            assert cell.attrib["source"] in cells
+            assert cell.attrib["target"] in cells
+
+    edge_geometry = cells["edge-egress-0"].find("mxGeometry")
+    assert edge_geometry is not None
+    points = edge_geometry.findall("./Array[@as='points']/mxPoint")
+    expected = result.routed_edges[0].points[1:-1]
+    assert [
+        (float(point.attrib["x"]), float(point.attrib["y"])) for point in points
+    ] == list(expected)
+
+
+def test_projection_is_deterministic_and_self_contained() -> None:
+    spec = load_spec(DRAWIO_SPEC)
+    first = render(spec, _icon_lookup)
+    second = render(spec, _icon_lookup)
+
+    first_xml = emit_drawio(spec, first)
+    assert first_xml == emit_drawio(spec, second)
+    assert "image=data:image/svg+xml," in first_xml
+    assert "http://" not in first_xml
+    assert "https://" not in first_xml
+    assert "mxgraph." not in first_xml
+    assert "<image" not in first_xml
+    ElementTree.fromstring(first_xml)
+
+
+def test_source_badges_are_local_cells_when_requested() -> None:
+    spec = load_spec(DRAWIO_SPEC)
+    result = render(spec, _icon_lookup, source_badges=True)
+
+    cells = _cells(emit_drawio(spec, result, source_badges=True))
+
+    assert cells["source-badge-node-service"].attrib["parent"] == "node-service"
+    assert cells["source-badge-node-service"].attrib["value"] == "VERIFIED SRC 1"
+    assert cells["source-badge-edge-egress-0"].attrib["parent"] == "edge-egress-0"
+    assert cells["source-badge-edge-egress-0"].attrib["value"] == "VERIFIED SRC 1"
+
+
+def test_review_fixture_is_the_current_importable_projection() -> None:
+    spec_path = Path(__file__).parent / "fixtures" / "drawio-review.yaml"
+    expected_path = spec_path.with_suffix(".drawio")
+    spec = load_spec(spec_path.read_text())
+
+    projected = emit_drawio(spec, render(spec, _icon_lookup))
+
+    assert projected == expected_path.read_text()
+    assert ElementTree.parse(expected_path).getroot().tag == "mxfile"

--- a/skills/architecture-diagram/engine/tests/test_drawio_delivery.py
+++ b/skills/architecture-diagram/engine/tests/test_drawio_delivery.py
@@ -1,0 +1,110 @@
+"""Delivery integration tests for opt-in draw.io exports."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import xml.etree.ElementTree as ElementTree
+
+import pytest
+
+from engine import commands
+from engine.receipts import sha256
+
+
+def _deliver(
+    capsys: pytest.CaptureFixture[str], spec: Path, output: Path, *extra: str
+) -> tuple[int, dict[str, object]]:
+    code = commands.main(
+        [
+            "deliver",
+            str(spec),
+            "--output",
+            str(output),
+            "--cache-dir",
+            str(output.parent),
+            "--json",
+            *extra,
+        ]
+    )
+    return code, json.loads(capsys.readouterr().out)
+
+
+def test_deliver_emit_drawio_commits_a_digest_bound_pair(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec = tmp_path / "diagram.yaml"
+    spec.write_text(
+        "nodes:\n"
+        "  - id: public\n"
+        "  - id: service\n"
+        "edges:\n"
+        "  - from: public\n"
+        "    to: service\n"
+        "    label: HTTPS\n"
+    )
+    output = tmp_path / "diagram.svg"
+
+    code, receipt = _deliver(capsys, spec, output, "--emit", "drawio")
+
+    drawio = tmp_path / "diagram.drawio"
+    assert code == commands.EXIT_OK
+    assert output.is_file()
+    assert drawio.is_file()
+    assert ElementTree.parse(drawio).getroot().tag == "mxfile"
+    assert receipt["artifacts"] == [
+        {
+            "path": str(output),
+            "sha256": sha256(output.read_bytes()),
+            "bytes": output.stat().st_size,
+        },
+        {
+            "path": str(drawio),
+            "sha256": sha256(drawio.read_bytes()),
+            "bytes": drawio.stat().st_size,
+        },
+    ]
+
+
+def test_default_delivery_keeps_drawio_and_artifact_list_opt_in(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spec = tmp_path / "diagram.yaml"
+    spec.write_text("nodes:\n  - id: service\n")
+    output = tmp_path / "diagram.svg"
+
+    code, receipt = _deliver(capsys, spec, output)
+
+    assert code == commands.EXIT_OK
+    assert output.is_file()
+    assert not (tmp_path / "diagram.drawio").exists()
+    assert "artifacts" not in receipt
+
+
+def test_drawio_commit_failure_restores_existing_outputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = tmp_path / "diagram.yaml"
+    spec.write_text("nodes:\n  - id: service\n")
+    output = tmp_path / "diagram.svg"
+    drawio = tmp_path / "diagram.drawio"
+    output.write_text("prior svg")
+    drawio.write_text("prior drawio")
+    replace = os.replace
+
+    def fail_drawio_candidate(source: Path | str, target: Path | str) -> None:
+        if Path(source).name == "candidate.drawio":
+            raise OSError("injected drawio replacement failure")
+        replace(source, target)
+
+    monkeypatch.setattr("engine.delivery.os.replace", fail_drawio_candidate)
+
+    code, receipt = _deliver(capsys, spec, output, "--emit", "drawio")
+
+    assert code == commands.EXIT_FAILURE
+    assert receipt["delivery_stage"] == "commit"
+    assert output.read_text() == "prior svg"
+    assert drawio.read_text() == "prior drawio"

--- a/skills/architecture-diagram/engine/tests/test_evidence.py
+++ b/skills/architecture-diagram/engine/tests/test_evidence.py
@@ -8,6 +8,7 @@ import pytest
 
 from engine.commands import main
 from engine.evidence import verify_sources
+from engine.receipts import sha256
 from engine.spec import load_spec
 
 
@@ -182,3 +183,45 @@ def test_deliver_verifies_before_writing(
     assert sidecar["repository"]["origin"] == "https://example.invalid/diagram.git"
     assert 'data-source-ids="api"' in output.read_text()
     assert "VERIFIED SRC 1" in output.read_text()
+
+
+def test_combined_delivery_commits_a_coherent_source_evidence_bundle(
+    repository: tuple[Path, str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo, revision = repository
+    spec_path = _write_spec(repo, revision, "src/api.py", "[1, 3]")
+    output = repo / "diagram.svg"
+    drawio_path = repo / "diagram.drawio"
+    sidecar_path = repo / "diagram.sources.json"
+
+    assert (
+        main(
+            [
+                "deliver",
+                str(spec_path),
+                "--verify-sources",
+                "--emit",
+                "drawio",
+                "--json",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    receipt = json.loads(capsys.readouterr().out)
+    assert [artifact["path"] for artifact in receipt["artifacts"]] == [
+        str(output),
+        str(drawio_path),
+        str(sidecar_path),
+    ]
+    for artifact, path in zip(
+        receipt["artifacts"], (output, drawio_path, sidecar_path), strict=True
+    ):
+        assert artifact == {
+            "path": str(path),
+            "sha256": sha256(path.read_bytes()),
+            "bytes": path.stat().st_size,
+        }
+    assert "source-badge-node-service" in drawio_path.read_text()

--- a/skills/architecture-diagram/engine/tests/test_render.py
+++ b/skills/architecture-diagram/engine/tests/test_render.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+import xml.etree.ElementTree as ElementTree
 
 import pytest
 
@@ -762,6 +763,38 @@ class TestEndToEndRender:
         result = do_render(spec, _icon_lookup)
         assert 'id="zone-vpc"' in result.svg
         assert "VPC" in result.svg
+
+    def test_title_clears_outermost_zone_label(self) -> None:
+        spec = load_spec(
+            """
+title: Cross-Cloud Analytics Mesh
+zones:
+  - id: region
+    label: AWS · us-east-1
+  - id: boundary
+    label: Ingestion Boundary
+    parent: region
+nodes:
+  - id: source
+  - id: destination
+    zone: boundary
+edges:
+  - from: source
+    to: destination
+"""
+        )
+        result = do_render(spec, _icon_lookup)
+        document = ElementTree.fromstring(result.svg)
+        namespace = {"svg": "http://www.w3.org/2000/svg"}
+        labels = {
+            text.text: text for text in document.findall(".//svg:text", namespace)
+        }
+
+        assert (
+            float(labels["AWS · us-east-1"].attrib["y"])
+            - float(labels["Cross-Cloud Analytics Mesh"].attrib["y"])
+            >= 17
+        )
 
     def test_legend_appears_only_with_multiple_edge_types(self) -> None:
         spec_text = "nodes:\n  - id: a\n  - id: b\n  - id: c\nedges:\n  - from: a\n    to: b\n    type: realtime\n  - from: b\n    to: c\n    type: batch\n"


### PR DESCRIPTION
## Summary

Adds an opt-in editable draw.io companion to `architecture-diagram` delivery and hardens titled nested-zone layout.

### Editable draw.io delivery

- Adds `deliver --emit drawio`, which emits a deterministic, uncompressed, self-contained `.drawio` mxGraph artifact beside the SVG.
- Projects authored zones, node containers, icon cells, labels, routed edges, edge labels, and verified-source badges into independent local cells.
- Reuses the resolved icon map from the render pipeline instead of performing a second lookup.
- Extends atomic staged delivery so SVG, draw.io, and the optional verified-source sidecar commit as one bundle or restore the previous bundle on a caught replacement failure.
- Adds top-level receipt `artifacts` entries with path, SHA-256, and byte count for every committed artifact.
- Keeps default SVG-only delivery and existing receipts unchanged when `--emit drawio` is absent.
- Documents the combined `--emit drawio --verify-sources` workflow and regenerates the package manifest.

### Quality regression fix

- Reserves a zone-header band for every nested zone depth before computing node positions.
- Prevents an SVG title from overlapping the outermost zone label while retaining aligned SVG, layout-receipt, and draw.io geometry.

## Coverage

- Deterministic draw.io XML and self-containment checks.
- Independent-cell, source-badge, route-reference, and generated-review-fixture coverage.
- Atomic multi-artifact delivery and rollback coverage.
- Combined verified-source SVG/draw.io/sidecar receipt coverage.
- Regression coverage for a title with nested zones.
- Manual review confirmed generated draw.io files open, expose editable components, and save after a label move.

## Validation

- `uv run pytest engine/tests -q` — 229 passed
- `uv run ruff check engine/layout.py engine/tests/test_render.py`
- `uv run ruff format --check engine/layout.py engine/tests/test_render.py`
- `python -m engine validate ... --quality showcase --json` — 10/10 checks, zero diagnostics
- `python -m engine deliver ... --quality showcase --emit drawio --json` — SVG and draw.io bundle committed atomically
